### PR TITLE
Add stable and latest release channels

### DIFF
--- a/.claude/examples/settings-latest.jsonc
+++ b/.claude/examples/settings-latest.jsonc
@@ -1,0 +1,11 @@
+// Use the LATEST channel — tracks main, updates on every merged PR
+{
+  "extraKnownMarketplaces": {
+    "power-platform-skills": {
+      "source": {
+        "source": "github",
+        "repo": "microsoft/power-platform-skills"
+      }
+    }
+  }
+}

--- a/.claude/examples/settings-stable.jsonc
+++ b/.claude/examples/settings-stable.jsonc
@@ -1,0 +1,12 @@
+// Use the STABLE channel — updates only on version tag (e.g., v1.1.0)
+{
+  "extraKnownMarketplaces": {
+    "power-platform-skills": {
+      "source": {
+        "source": "github",
+        "repo": "microsoft/power-platform-skills",
+        "ref": "stable"
+      }
+    }
+  }
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,70 @@
+name: Release to Stable Channel
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g., 1.1.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Validate version format
+        run: |
+          VERSION="${{ inputs.version }}"
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid version format '$VERSION'. Use semver (e.g., 1.1.0)"
+            exit 1
+          fi
+          if git rev-parse "v$VERSION" >/dev/null 2>&1; then
+            echo "::error::Tag v$VERSION already exists."
+            exit 1
+          fi
+
+      - name: Validate JSON manifests
+        run: |
+          echo "Validating marketplace manifest..."
+          node -e "JSON.parse(require('fs').readFileSync('.claude-plugin/marketplace.json', 'utf8'))"
+          echo "Validating plugin manifests..."
+          for manifest in plugins/*/.claude-plugin/plugin.json; do
+            echo "  Checking $manifest"
+            node -e "JSON.parse(require('fs').readFileSync('$manifest', 'utf8'))"
+          done
+          echo "All manifests valid."
+
+      - name: Check version in plugin manifests
+        run: |
+          VERSION="${{ inputs.version }}"
+          echo "Expected version: $VERSION"
+          MATCH=false
+          for manifest in plugins/*/.claude-plugin/plugin.json; do
+            PLUGIN_VERSION=$(node -e "console.log(JSON.parse(require('fs').readFileSync('$manifest','utf8')).version)")
+            PLUGIN_NAME=$(node -e "console.log(JSON.parse(require('fs').readFileSync('$manifest','utf8')).name)")
+            echo "  $PLUGIN_NAME: v$PLUGIN_VERSION"
+            if [ "$PLUGIN_VERSION" = "$VERSION" ]; then MATCH=true; fi
+          done
+          if [ "$MATCH" = "false" ]; then
+            echo "::warning::No plugin.json has version $VERSION. Bump the version before releasing."
+          fi
+
+      - name: Create tag
+        run: |
+          git tag "v${{ inputs.version }}"
+          git push origin "v${{ inputs.version }}"
+          echo "Created tag v${{ inputs.version }}"
+
+      - name: Promote to stable branch
+        run: |
+          git push origin HEAD:refs/heads/stable
+          echo "Updated stable branch to v${{ inputs.version }}"

--- a/README.md
+++ b/README.md
@@ -83,6 +83,42 @@ To use a plugin from this marketplace:
     /plugin install power-apps@power-platform-skills
     ```
 
+## Release Channels
+
+| Channel | Branch | Updates when | Best for |
+|---------|--------|-------------|----------|
+| **Latest** | `main` | Every merged PR | Early access, development |
+| **Stable** | `stable` | Version tag pushed (e.g., `v1.1.0`) | Production, reliability |
+
+Add the marketplace to your project's `.claude/settings.json` with the desired channel:
+
+**Stable channel (recommended for teams):**
+```json
+"extraKnownMarketplaces": {
+  "power-platform-skills": {
+    "source": {
+      "source": "github",
+      "repo": "microsoft/power-platform-skills",
+      "ref": "stable"
+    }
+  }
+}
+```
+
+**Latest channel:**
+```json
+"extraKnownMarketplaces": {
+  "power-platform-skills": {
+    "source": {
+      "source": "github",
+      "repo": "microsoft/power-platform-skills"
+    }
+  }
+}
+```
+
+See `.claude/examples/` for complete example settings files.
+
 ## Local Development
 
 To develop and test plugins locally, follow these steps:


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow (`.github/workflows/release.yml`) for releasing to the stable channel via `workflow_dispatch` — validates manifests, creates version tags, and fast-forwards the `stable` branch
- Add example settings files (`.claude/examples/settings-stable.jsonc` and `settings-latest.jsonc`) for consuming projects to configure either channel
- Update `README.md` with a Release Channels section documenting stable vs latest usage

## How it works
1. **Latest channel** (`main`) — users get updates on every merged PR
2. **Stable channel** (`stable` branch) — updated only when a release workflow is run with a version tag (e.g., `v1.1.0`)

The release workflow:
- Validates semver format and checks for duplicate tags
- Validates all JSON manifests (marketplace + plugin)
- Warns if no `plugin.json` matches the release version
- Creates a `v<version>` tag on `main`
- Fast-forwards the `stable` branch to `main`

## Test plan
- [ ] Verify the workflow file appears in GitHub Actions tab after merge
- [ ] Run the workflow with version `1.0.0` — confirm it creates the tag and updates `stable`
- [ ] Test consuming from both channels: `ref: "stable"` vs default (main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)