### PR TITLE
Add GitHub repo stats workflow

### DIFF
--- a/.github/workflows/github-repo-stats.yml
+++ b/.github/workflows/github-repo-stats.yml
@@ -1,0 +1,19 @@
+name: github-repo-stats
+
+on:
+    schedule:
+        # Run this once per day, towards the end of the day for keeping the most
+        # recent data point most meaningful (hours are interpreted in UTC).
+        - cron: "0 23 * * *"
+    workflow_dispatch: # Allow for running this manually.
+
+jobs:
+    j1:
+        name: github-repo-stats
+        runs-on: ubuntu-latest
+        steps:
+            - name: run-ghrs
+              # Use latest release.
+              uses: jgehrcke/github-repo-stats@RELEASE
+              with:
+                  ghtoken: ${{ secrets.ghrs_github_api_token }}


### PR DESCRIPTION
- Add daily scheduled workflow using jgehrcke/github-repo-stats action
- Runs at 23:00 UTC daily with manual dispatch option
- Uses ghrs_github_api_token secret for API access