### PR TITLE
Add PAC CLI installation script if not installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ curl -fsSL https://raw.githubusercontent.com/microsoft/power-platform-skills/mai
 
 The installer automatically:
 
+- Installs `pac` CLI if not already installed
 - Detects available tools (Claude Code, GitHub Copilot CLI)
 - Registers the plugin marketplace and installs all listed plugins
 - Enables auto-update so plugins stay current

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -270,6 +270,26 @@ async function main() {
     const ver = run("pac help");
     const versionMatch = ver.ok && ver.output.match(/Version:\s*(.+)/i);
     ok(`PAC CLI ${versionMatch ? versionMatch[1].trim() : "(installed)"}`);
+
+    // Try to update to the latest version
+    if (hasCommand("dotnet")) {
+      info("Checking for updates...");
+      const updateResult = run(
+        "dotnet tool update --global Microsoft.PowerApps.CLI.Tool"
+      );
+      if (updateResult.ok) {
+        const updatedMatch = updateResult.output.match(/version '([^']+)'/);
+        if (updateResult.output.includes("was reinstalled")) {
+          ok(`Already on latest version`);
+        } else if (updatedMatch) {
+          ok(`Updated to ${updatedMatch[1]}`);
+        } else {
+          ok("Update check complete");
+        }
+      } else {
+        warn(`Could not check for updates: ${updateResult.output}`);
+      }
+    }
   } else {
     warn("PAC CLI not found in PATH");
 

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -263,6 +263,40 @@ async function main() {
     process.exit(1);
   }
 
+  // ── PAC CLI ──────────────────────────────────────────────────
+  header("Power Platform CLI (pac)");
+
+  if (hasCommand("pac")) {
+    const ver = run("pac help");
+    const versionMatch = ver.ok && ver.output.match(/Version:\s*(.+)/i);
+    ok(`PAC CLI ${versionMatch ? versionMatch[1].trim() : "(installed)"}`);
+  } else {
+    warn("PAC CLI not found in PATH");
+
+    if (hasCommand("dotnet")) {
+      info("Installing PAC CLI via dotnet tool...");
+      const installResult = run(
+        "dotnet tool install --global Microsoft.PowerApps.CLI.Tool"
+      );
+      if (installResult.ok) {
+        ok("PAC CLI installed");
+        info("You may need to restart your terminal for the 'pac' command to be available.");
+      } else if (installResult.output.includes("already installed")) {
+        ok("PAC CLI already installed (not on PATH — restart your terminal)");
+      } else {
+        fail(`Failed to install PAC CLI: ${installResult.output}`);
+        info("Install manually: https://aka.ms/PowerPlatformCLI");
+      }
+    } else {
+      fail("dotnet SDK not found — cannot auto-install PAC CLI");
+      console.log("");
+      console.log("  Install the PAC CLI manually using one of these methods:");
+      console.log("    .NET Tool (cross-platform)  https://aka.ms/PowerPlatformCLI");
+      console.log("    VS Code Extension           https://aka.ms/PowerPlatformCLI");
+      console.log("    Windows MSI                 https://aka.ms/PowerPlatformCLI");
+    }
+  }
+
   // ── Marketplace ────────────────────────────────────────────
   header("Reading marketplace");
 

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -271,23 +271,33 @@ async function main() {
     const versionMatch = ver.ok && ver.output.match(/Version:\s*(.+)/i);
     ok(`PAC CLI ${versionMatch ? versionMatch[1].trim() : "(installed)"}`);
 
-    // Try to update to the latest version
+    // Check NuGet for a newer version and update if available
     if (hasCommand("dotnet")) {
-      info("Checking for updates...");
-      const updateResult = run(
-        "dotnet tool update --global Microsoft.PowerApps.CLI.Tool"
-      );
-      if (updateResult.ok) {
-        const updatedMatch = updateResult.output.match(/version '([^']+)'/);
-        if (updateResult.output.includes("was reinstalled")) {
-          ok(`Already on latest version`);
-        } else if (updatedMatch) {
-          ok(`Updated to ${updatedMatch[1]}`);
+      const localVersion = versionMatch ? versionMatch[1].trim().split("+")[0] : null;
+      let latestVersion = null;
+      try {
+        const nugetJson = await httpsGet(
+          "https://api.nuget.org/v3-flatcontainer/microsoft.powerapps.cli.tool/index.json"
+        );
+        const versions = JSON.parse(nugetJson).versions;
+        latestVersion = versions[versions.length - 1];
+      } catch {
+        warn("Could not check NuGet for latest version");
+      }
+
+      if (latestVersion && localVersion && latestVersion === localVersion) {
+        ok("Already on latest version");
+      } else if (latestVersion) {
+        info(`Newer version available: ${latestVersion} (installed: ${localVersion || "unknown"})`);
+        info("Updating PAC CLI...");
+        const updateResult = run(
+          "dotnet tool update --global Microsoft.PowerApps.CLI.Tool"
+        );
+        if (updateResult.ok) {
+          ok(`Updated to ${latestVersion}`);
         } else {
-          ok("Update check complete");
+          warn(`Could not update: ${updateResult.output}`);
         }
-      } else {
-        warn(`Could not check for updates: ${updateResult.output}`);
       }
     }
   } else {


### PR DESCRIPTION
This pull request adds automated detection, installation, and update support for the Power Platform CLI (`pac`) in the `scripts/install.js` installation script. The script now checks if `pac` is available, verifies its version, and installs or updates it via the .NET toolchain if necessary, providing user guidance throughout the process.

**Power Platform CLI (`pac`) support:**

* Added logic to detect if the `pac` command is available and display its installed version.
* If `pac` is installed and the `dotnet` command is available, the script checks NuGet for the latest version and updates `pac` if a newer version exists.
* If `pac` is not installed but `dotnet` is available, the script attempts to install `pac` globally using the .NET tool installer, handling errors and providing user instructions as needed.
* If neither `pac` nor `dotnet` are found, the script instructs the user on how to manually install the Power Platform CLI using alternative methods.