### PR TITLE
feat(code-apps): add list-flows and add-flow plugin skills

### DIFF
--- a/plugins/code-apps/AGENTS.md
+++ b/plugins/code-apps/AGENTS.md
@@ -61,6 +61,10 @@ skills/
     SKILL.md                      <- Add Office 365 Outlook connector
   add-mcscopilot/
     SKILL.md                      <- Add Copilot Studio agent connector
+  list-flows/
+    SKILL.md                      <- List solution-aware Power Automate flows to get flow IDs
+  add-flow/
+    SKILL.md                      <- Add a Power Automate cloud flow with generated TypeScript service
 ```
 
 ## Skills
@@ -80,6 +84,8 @@ skills/
 | `/add-office365` | Add Office 365 Outlook connector |
 | `/add-mcscopilot` | Add Copilot Studio agent connector |
 | `/add-connector` | Add any other Power Platform connector |
+| `/list-flows` | List solution-aware Power Automate flows to find flow IDs |
+| `/add-flow` | Add a Power Automate cloud flow with generated TypeScript service |
 
 ## Key Concepts
 

--- a/plugins/code-apps/agents/code-app-architect.md
+++ b/plugins/code-apps/agents/code-app-architect.md
@@ -62,6 +62,7 @@ pwsh -NoProfile -Command "pac"         # Windows executable — must use pwsh
 | Read lists or manage documents in SharePoint         | SharePoint (`/add-sharepoint`)        |
 | Send emails, read inbox, manage calendar             | Office 365 Outlook (`/add-office365`) |
 | Invoke a Copilot Studio agent                        | MCS Copilot (`/add-mcscopilot`)       |
+| Trigger or integrate a Power Automate cloud flow     | Logic Flows (`/add-flow`)             |
 | Connect to any other service                         | Generic connector (`/add-connector`)  |
 
 **If none of the specific skills match**, invoke `/add-connector` — it handles any connector not covered above. Browse available connectors at https://learn.microsoft.com/en-us/connectors/connector-reference/ to find the correct API name. **If no connector exists for the required functionality, tell the user clearly and do not implement a direct API call as a workaround — it will not work in production.**

--- a/plugins/code-apps/skills/add-datasource/SKILL.md
+++ b/plugins/code-apps/skills/add-datasource/SKILL.md
@@ -40,6 +40,7 @@ Map the user's goal to the appropriate skill:
 | Work with SharePoint lists or document libraries | SharePoint Online connector | `/add-sharepoint` |
 | Send emails, read inbox, manage calendar events | Office 365 Outlook connector | `/add-office365` |
 | Invoke an AI agent or copilot built in Copilot Studio | Copilot Studio connector | `/add-mcscopilot` |
+| Trigger or integrate a Power Automate cloud flow | Logic Flows connector | `/add-flow` |
 | Something else or not sure | Generic connector (we'll figure it out) | `/add-connector` |
 
 **Important routing rules:**

--- a/plugins/code-apps/skills/add-flow/SKILL.md
+++ b/plugins/code-apps/skills/add-flow/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: add-flow
+description: Adds a Power Automate cloud flow to a Power Apps code app, fetching its metadata and swagger and generating a typed TypeScript service file. Use when integrating a cloud flow into a code app via the `npx power-apps add-flow` command.
+user-invocable: true
+allowed-tools: Read, Edit, Write, Grep, Glob, Bash, LSP, TaskCreate, TaskUpdate, TaskList, TaskGet, AskUserQuestion, Skill
+model: sonnet
+---
+
+**📋 Shared Instructions: [shared-instructions.md](${CLAUDE_PLUGIN_ROOT}/shared/shared-instructions.md)** - Cross-cutting concerns.
+
+# Add Flow
+
+Adds a Power Automate cloud flow to the current code app by fetching its metadata and swagger from the Power Automate RP, writing connection references into `power.config.json`, saving a schema file, and generating a typed TypeScript service.
+
+## Workflow
+
+1. Check Memory Bank → 2. Find Flow ID → 3. Add Flow → 4. Review Generated Files → 5. Build → 6. Update Memory Bank
+
+---
+
+### Step 1: Check Memory Bank
+
+Check for `memory-bank.md` per [shared-instructions.md](${CLAUDE_PLUGIN_ROOT}/shared/shared-instructions.md).
+
+### Step 2: Find the Flow ID
+
+The `--flow-id` must be the **Power Automate resource GUID** (the BAP/Power Automate resource ID, NOT the Dataverse `workflowidunique`).
+
+**If the user already has the flow ID**, skip to Step 3.
+
+**If the user does not have the flow ID**, run `/list-flows` to find it:
+
+```bash
+npx power-apps list-flows
+# Or filter by name:
+npx power-apps list-flows --search "<flow-name>"
+```
+
+The `workflowId` column in the output is the GUID to pass to `--flow-id`.
+
+> **Note:** Only **solution-aware flows** appear in `list-flows`. If the target flow is missing, direct the user to [Power Automate](https://make.powerautomate.com) → Solutions → add the flow to a solution first.
+
+### Step 3: Add Flow
+
+```bash
+npx power-apps add-flow --flow-id <guid>
+```
+
+**What this does:**
+
+1. Fetches the flow's metadata and swagger from the Power Automate RP.
+2. Filters connection references to `invoker`-sourced dependencies only (the ones the calling app must supply).
+3. For each dependency, queries the connector and connection APIs to determine `authenticationType` and `sharedConnectionId`.
+4. Writes a `shared_logicflows` connection reference (with `workflowDetails`) and stub dependency references into `power.config.json`.
+5. Saves the flow's swagger as a schema file under `schemas/logicflows/<FlowName>.Schema.json`.
+6. Runs codegen to produce a typed `<FlowName>Service.ts` model service.
+
+Re-adding the same flow is **idempotent** — it matches by `workflowEntityId` and reuses the existing UUID.
+
+**Failures:**
+
+- `Configuration file not found`: Make sure you're running from the project root (the directory containing `power.config.json`). STOP.
+- `Unable to retrieve connection '...'`: The user lacks access to an underlying connector connection used by the flow. They must ensure they have access to all connections the flow depends on. STOP.
+- Auth errors: Run `pwsh -NoProfile -Command "pac auth create"` and retry.
+- Any other non-zero exit: Report the exact output. STOP.
+
+### Step 4: Review Generated Files
+
+The command generates:
+
+- `power.config.json` — updated with a new `shared_logicflows` connection reference containing `workflowDetails` (workflow entity ID, display name, resource name, and dependency UUIDs)
+- `schemas/logicflows/<FlowName>.Schema.json` — the flow's swagger schema
+- `src/generated/services/<FlowName>Service.ts` — typed async service methods
+
+Show the user the generated service and a usage example:
+
+```typescript
+import { MyFlowService } from "../generated/services/MyFlowService";
+
+// Invoke the flow
+const result = await MyFlowService.executeAsync({
+  // Parameters match the flow's trigger inputs
+  inputParam: "value"
+});
+```
+
+**Inspecting the generated service:**
+
+Generated service files can be large. Use Grep to find available methods rather than reading the whole file:
+
+```
+Grep pattern="async \w+" path="src/generated/services/<FlowName>Service.ts"
+```
+
+See [connector-reference.md](${CLAUDE_PLUGIN_ROOT}/shared/connector-reference.md#inspecting-large-generated-files) for details.
+
+### Step 5: Build
+
+```bash
+npm run build
+```
+
+Fix any TypeScript errors before proceeding. Do NOT deploy yet.
+
+### Step 6: Update Memory Bank
+
+Update `memory-bank.md` with: flow name, flow ID, generated service file path, and any dependency connections wired up.

--- a/plugins/code-apps/skills/list-flows/SKILL.md
+++ b/plugins/code-apps/skills/list-flows/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: list-flows
+description: Lists solution-aware Power Automate cloud flows available in the current environment. Use when you need a flow ID before adding a flow to a code app, or when exploring available flows. Supports optional search filtering.
+user-invocable: true
+allowed-tools: Bash
+model: haiku
+---
+
+**📋 Shared Instructions: [shared-instructions.md](${CLAUDE_PLUGIN_ROOT}/shared/shared-instructions.md)** - Cross-cutting concerns (Windows CLI compatibility, memory bank, etc.).
+
+# List Flows
+
+Lists solution-aware Power Automate cloud flows in the default environment using the Power Apps CLI (`npx power-apps`).
+
+## Workflow
+
+1. Fetch Flows → 2. Present Results
+
+---
+
+### Step 1: Fetch Flows
+
+```bash
+npx power-apps list-flows
+```
+
+To filter by name, pass `--search`:
+
+```bash
+npx power-apps list-flows --search "<keyword>"
+```
+
+If `pac` is not authenticated or the environment is not set, tell the user to run:
+
+```bash
+pwsh -NoProfile -Command "pac auth create"
+pwsh -NoProfile -Command "pac env select --environment <environment-id>"
+```
+
+**Failures:**
+- Non-zero exit for any reason other than auth: Report the exact output. STOP.
+- No output or timeout: Run `pwsh -NoProfile -Command "pac env list"` to verify PAC can reach the environment, then retry once.
+
+### Step 2: Present Results
+
+Show the flow list to the user. The **Flow ID** (the `workflowId` / Power Automate resource GUID) is what goes into `--flow-id <guid>` when adding a flow with `/add-flow`.
+
+**If the needed flow is missing:**
+
+1. The flow must be **solution-aware** — only flows inside a solution appear in this list.
+2. Direct the user to [Power Automate](https://make.powerautomate.com) → Solutions → open the relevant solution → add or create the flow there.
+3. Re-run `/list-flows` after the flow has been added to a solution.
+
+**If `--search` returns no results:** Broaden the search term or run without `--search` to see all available flows.


### PR DESCRIPTION
## Summary

Adds two new skills to the `code-apps` plugin to support Power Automate flow capabilities introduced in the Code Apps CLI.

## New Skills

### `list-flows`
- Runs `npx power-apps list-flows [--search <keyword>]`
- Lists solution-aware flows available to add to a code app
- Returns `workflowId` (Power Automate resource GUID) needed for `add-flow`

### `add-flow`
- Runs `npx power-apps add-flow --flow-id <guid>`
- Fetches flow metadata + swagger, filters invoker dependencies, writes connection refs, generates `<FlowName>Service.ts`
- Documents idempotency behavior and usage examples for the generated service

## Updated Files
- `AGENTS.md` — both skills added to architecture tree and skills table
- `agents/code-app-architect.md` — flow row added to connector routing table
- `skills/add-datasource/SKILL.md` — flow routing entry added

## Related
Internal Code Apps PR: https://microsoft.ghe.com/bic/PowerPlatform-Managed-Host/pull/172