### PR TITLE
code-app plugin update for dataverse file/image columns

### DIFF
--- a/plugins/code-apps/agents/code-app-architect.md
+++ b/plugins/code-apps/agents/code-app-architect.md
@@ -99,7 +99,7 @@ pwsh -NoProfile -Command "pac code init --displayName '{app-name}' -e <environme
 - **Lookup fields** expose `_fieldname_value` (GUID, read-only) for reading and `@odata.bind` for writing.
 - **Formatted values** can be requested via `Prefer: odata.include-annotations` header for server-side date/currency/label formatting.
 - **useState with enums**: Explicitly type picklist state fields as `number` to avoid TypeScript literal type inference.
-- **File/Image columns**: Use the generated `upload`, `downloadFile`, `downloadImage`, and `deleteFileOrImage` service methods — never raw fetch. The model exports `FileColumnName`, `ImageColumnName`, and `UploadColumnName` union types for type-safe column references. See [dataverse-reference.md](${CLAUDE_PLUGIN_ROOT}/skills/add-dataverse/references/dataverse-reference.md) for full patterns.
+- **File/Image columns**: Use the generated `upload`, `downloadFile`, `downloadImage`, and `deleteFileOrImage` service methods — never raw fetch. The model exports table-prefixed union types for type-safe column references (for example, `AccountsFileColumnName`, `AccountsImageColumnName`, and `AccountsUploadColumnName`, depending on the table). See [dataverse-reference.md](${CLAUDE_PLUGIN_ROOT}/skills/add-dataverse/references/dataverse-reference.md) for full patterns.
 
 ### Connector Workarounds
 

--- a/plugins/code-apps/agents/code-app-architect.md
+++ b/plugins/code-apps/agents/code-app-architect.md
@@ -99,6 +99,7 @@ pwsh -NoProfile -Command "pac code init --displayName '{app-name}' -e <environme
 - **Lookup fields** expose `_fieldname_value` (GUID, read-only) for reading and `@odata.bind` for writing.
 - **Formatted values** can be requested via `Prefer: odata.include-annotations` header for server-side date/currency/label formatting.
 - **useState with enums**: Explicitly type picklist state fields as `number` to avoid TypeScript literal type inference.
+- **File/Image columns**: Use the generated `upload`, `downloadFile`, `downloadImage`, and `deleteFileOrImage` service methods — never raw fetch. The model exports `FileColumnName`, `ImageColumnName`, and `UploadColumnName` union types for type-safe column references. See [dataverse-reference.md](${CLAUDE_PLUGIN_ROOT}/skills/add-dataverse/references/dataverse-reference.md) for full patterns.
 
 ### Connector Workarounds
 

--- a/plugins/code-apps/skills/add-dataverse/SKILL.md
+++ b/plugins/code-apps/skills/add-dataverse/SKILL.md
@@ -10,7 +10,7 @@ model: opus
 
 **References:**
 
-- [dataverse-reference.md](./references/dataverse-reference.md) - Picklist fields, virtual fields, lookups, form patterns (CRITICAL)
+- [dataverse-reference.md](./references/dataverse-reference.md) - Picklist fields, virtual fields, lookups, file/image columns, form patterns (CRITICAL)
 - [api-authentication-reference.md](./references/api-authentication-reference.md) - Dataverse API auth, token, publisher prefix
 - [table-management-reference.md](./references/table-management-reference.md) - Query, create, extend tables and columns
 - [data-architecture-reference.md](./references/data-architecture-reference.md) - Relationship types, dependency tiers
@@ -102,8 +102,8 @@ Can add multiple tables by running the command for each one.
 
 The command generates:
 
-- `src/generated/models/{Table}Model.ts` -- TypeScript interfaces
-- `src/generated/services/{Table}Service.ts` -- CRUD methods (create, get, getAll, update, delete)
+- `src/generated/models/{Table}Model.ts` -- TypeScript interfaces, plus `FileColumnName`, `ImageColumnName`, `UploadColumnName` union types if the table has file/image columns
+- `src/generated/services/{Table}Service.ts` -- CRUD methods (create, get, getAll, update, delete) plus `upload`, `downloadFile`, `downloadImage`, `deleteFileOrImage` if file/image columns exist
 
 Show the user a usage example:
 
@@ -124,7 +124,7 @@ const accounts = result.data || [];
 - Use generated services (e.g., `AccountsService.getAll()`), not fetch/axios
 - Check `result.data` for actual data
 - Don't edit generated files unless needed
-- **Read [dataverse-reference.md](./references/dataverse-reference.md) before writing any Dataverse code** -- picklist fields, virtual fields, and lookups have critical gotchas
+- **Read [dataverse-reference.md](./references/dataverse-reference.md) before writing any Dataverse code** -- picklist fields, virtual fields, lookups, and file/image columns all have critical gotchas
 
 ### Step 7: Build
 

--- a/plugins/code-apps/skills/add-dataverse/SKILL.md
+++ b/plugins/code-apps/skills/add-dataverse/SKILL.md
@@ -102,7 +102,7 @@ Can add multiple tables by running the command for each one.
 
 The command generates:
 
-- `src/generated/models/{Table}Model.ts` -- TypeScript interfaces, plus `FileColumnName`, `ImageColumnName`, `UploadColumnName` union types if the table has file/image columns
+- `src/generated/models/{Table}Model.ts` -- TypeScript interfaces, plus `{Table}FileColumnName`, `{Table}ImageColumnName`, `{Table}UploadColumnName` union types if the table has file/image columns
 - `src/generated/services/{Table}Service.ts` -- CRUD methods (create, get, getAll, update, delete) plus `upload`, `downloadFile`, `downloadImage`, `deleteFileOrImage` if file/image columns exist
 
 Show the user a usage example:

--- a/plugins/code-apps/skills/add-dataverse/references/dataverse-reference.md
+++ b/plugins/code-apps/skills/add-dataverse/references/dataverse-reference.md
@@ -174,6 +174,89 @@ const newRecord: any = {
 
 The `@odata.bind` value must be an entity set path with the GUID: `/<entitysetname>(<guid>)`
 
+## File and Image Columns
+
+Dataverse supports two special column types for binary content:
+
+| Type  | Dataverse Column Type | Max Size              | Notes                                               |
+|-------|-----------------------|-----------------------|-----------------------------------------------------|
+| File  | `FileType`            | 131 MB (configurable) | Any file type                                       |
+| Image | `ImageType`           | 30 MB                 | Converted to JPEG; supports full-size and thumbnail |
+
+The generated model exports type-safe union types for the file and image columns on the table. Use these types for all `columnName` arguments — never pass an arbitrary string:
+
+```typescript
+// Example from a table with two file columns and two image columns:
+type AccountsFileColumnName  = 'cr3d5_filecol' | 'cr3d5_filecol2';
+type AccountsImageColumnName = 'cr3d5_imagecol' | 'entityimage';
+type AccountsUploadColumnName = AccountsFileColumnName | AccountsImageColumnName;
+```
+
+The generated service exposes four methods for file/image operations.
+
+### `upload(id, columnName, file, fileDisplayName?)`
+
+Uploads a file or image to a record column. Accepts a standard browser `File` object directly.
+
+- `columnName` — must be `UploadColumnName` (works for both file and image columns)
+- `fileDisplayName` — optional friendly name shown in Dataverse; defaults to `file.name`
+- Returns `IOperationResult<void>`
+
+```tsx
+const [uploading, setUploading] = useState(false);
+
+const handleUpload = async () => {
+  setUploading(true);
+  const result = await AccountsService.upload(recordId, columnName, selectedFile, displayName);
+  setUploading(false);
+  if (result.error) {
+    showToast('Upload failed: ' + result.error.message, 'error');
+  } else {
+    showToast('File uploaded successfully', 'success');
+    onUploadSuccess?.();  // refresh parent list
+  }
+};
+
+<button onClick={handleUpload} disabled={uploading}>
+  {uploading ? 'Uploading...' : 'Upload'}
+</button>
+```
+
+### `downloadFile(id, columnName)`
+
+Downloads a file column and returns the raw bytes.
+
+- `columnName` — must be `FileColumnName` (file columns only, not image)
+- Returns `IOperationResult<Uint8Array>` — includes `result.fileName` with the original filename
+
+### `downloadImage(id, columnName, fullSize?)`
+
+Downloads an image column and returns the raw bytes. Pass `fullSize: true` for the original resolution; defaults to thumbnail.
+
+- `columnName` — must be `ImageColumnName` (image columns only, not file)
+- `fullSize` — optional boolean, default `false` (thumbnail)
+- Returns `IOperationResult<Uint8Array>`
+
+### `deleteFileOrImage(id, columnName)`
+
+Deletes the file or image stored in a column. Works for both file and image columns.
+
+- `columnName` — must be `UploadColumnName`
+- Returns `IOperationResult<void>`
+
+```tsx
+const result = await AccountsService.deleteFileOrImage(recordId, columnName);
+if (!result.error) {
+  onUploadSuccess?.();  // refresh parent list
+}
+```
+
+### Common Patterns
+
+- **Disable during operation**: Set a loading flag and disable upload/delete buttons while the call is in flight to prevent double-submits.
+- **Toast feedback**: Show success/error after upload and delete. Auto-dismiss after ~5 seconds.
+- **Refresh after mutation**: Call a refresh callback after upload or delete so the UI reflects the latest state.
+
 ## TypeScript useState with Choice Values - CRITICAL
 
 When using `useState` with enum constants, TypeScript infers literal types. Explicitly type as `number`:

--- a/plugins/code-apps/skills/add-dataverse/references/dataverse-reference.md
+++ b/plugins/code-apps/skills/add-dataverse/references/dataverse-reference.md
@@ -224,10 +224,10 @@ const handleUpload = async () => {
 
 ### `downloadFile(id, columnName)`
 
-Downloads a file column and returns the raw bytes.
+Downloads a file column. The file bytes are returned in `result.data`.
 
 - `columnName` — must be `FileColumnName` (file columns only, not image)
-- Returns `IOperationResult<Uint8Array>` — includes `result.fileName` with the original filename
+- Returns `IOperationResult<Uint8Array>` — use `result.data` for the raw bytes and `result.fileName` for the original filename
 
 ### `downloadImage(id, columnName, fullSize?)`
 

--- a/plugins/code-apps/skills/add-dataverse/references/dataverse-reference.md
+++ b/plugins/code-apps/skills/add-dataverse/references/dataverse-reference.md
@@ -200,7 +200,7 @@ Uploads a file or image to a record column. Accepts a standard browser `File` ob
 
 - `columnName` — must be `UploadColumnName` (works for both file and image columns)
 - `fileDisplayName` — optional friendly name shown in Dataverse; defaults to `file.name`
-- Returns `IOperationResult<void>`
+- Returns a result object with `success`, `data`, and `error` fields; for uploads, `data` is empty
 
 ```tsx
 const [uploading, setUploading] = useState(false);


### PR DESCRIPTION
This extends the Dataverse skill for image and file columns. Running the add-datasource command generates new functions. PR enriches the skill with additional methods and corresponding usage patterns.

Internal testing on the Agency Playground demonstrated that the Agent successfully recognized the enhanced skill and was able to scaffold a Code App from scratch with full support for file and image operations, including upload, download, and delete. It accurately identified and referenced the relevant skill during the process.