### PR TITLE
[Pages] Fix Web API pagination to use Prefer: odata.maxpagesize

### DIFF
--- a/plugins/power-pages/.claude-plugin/plugin.json
+++ b/plugins/power-pages/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "power-pages",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Create and deploy Power Pages sites using modern development approaches. Supports code sites (SPAs) with React, Angular, Vue, or Astro, with more site types coming soon.",
   "author": {
     "name": "Microsoft",

--- a/plugins/power-pages/agents/webapi-integration.md
+++ b/plugins/power-pages/agents/webapi-integration.md
@@ -235,7 +235,7 @@ Reference: `${CLAUDE_PLUGIN_ROOT}/references/webapi-service-patterns.md` — see
 
 ## Step 5: Create Service Layer
 
-Create a service module with CRUD operations for the target table. Place it following project conventions. Default: `src/shared/services/<tableName>Service.ts`. Implement list (paginated with `$top` + `@odata.nextLink`), get by ID, create (POST with `Prefer: return=representation` + Location header fallback), update (PATCH with `If-Match: *`), delete, and optionally M:N sync, count, aggregation, and file/image column operations.
+Create a service module with CRUD operations for the target table. Place it following project conventions. Default: `src/shared/services/<tableName>Service.ts`. Implement list (paginated with `Prefer: odata.maxpagesize=N` + `@odata.nextLink`), get by ID, create (POST with `Prefer: return=representation` + Location header fallback), update (PATCH with `If-Match: *`), delete, and optionally M:N sync, count, aggregation, and file/image column operations.
 
 Reference: `${CLAUDE_PLUGIN_ROOT}/references/webapi-service-patterns.md` — see "Service Layer (Step 5)" section. If the table has lookup or one-to-many relationships, implement `$expand` using the `buildExpandClause` helper from the core API client — see "Related Entities ($expand)" section for expand patterns, nested expand, collection paging, and when to fetch related records separately.
 
@@ -545,7 +545,7 @@ Only create this if the site's UI shows/hides controls based on user roles.
 1. **`/_api/` prefix** — Always use `/_api/` for Power Pages Web API URLs. Never use the Dataverse environment URL directly.
 2. **Anti-forgery token required on mutations** — The `__RequestVerificationToken` header must be set on POST, PATCH, PUT, and DELETE requests. The server only validates the anti-forgery token on mutating requests — GET requests do not require it. However, the shared client sends it on all requests for simplicity, which is harmless. Fetch the token from `/_layout/tokenhtml` and parse the value from the returned HTML. No `Authorization` bearer header is needed — Power Pages uses cookie-based session auth for authenticated users (JWT bearer tokens are also supported via middleware, but cookie auth is the standard client-side pattern).
 3. **No wildcard `$select`** — Always list specific columns. Wildcards expose unnecessary data and degrade performance.
-4. **Always paginate** — Every list/query MUST include `$top`. Use `$top`/`$count` for the first page and `@odata.nextLink` cursors for subsequent pages. Dataverse does **not** support `$skip` — never use it. Use `fetchAllPages` only when all records are genuinely needed (dropdowns, lookups, exports). Never fetch unbounded data.
+4. **Always paginate** — Every list/query MUST use the `Prefer: odata.maxpagesize=N` request header to control page size (e.g., `odata.maxpagesize=20`). Do NOT use `$top` for pagination — `$top` caps the total result set and prevents `@odata.nextLink` from being returned. Include `$count=true` on every list query to get the total record count via `@odata.count` (returned on all pages, including cursor pages). Use `@odata.nextLink` cursors (which contain `$skiptoken`) for subsequent pages. Power Pages does **not** support `$skip` — it returns error `9004010B: QueryParamNotSupported`. Use `$top` only as a safety cap when you genuinely want to limit total results (e.g., "top 5 recent items" for a dashboard widget), not for page-by-page navigation. If you include both `$top` and `Prefer: odata.maxpagesize`, `$top` is ignored. Use `fetchAllPages` only when all records are genuinely needed (dropdowns, lookups, exports) — it follows `@odata.nextLink` cursors internally with a safety cap of 100 iterations. Never fetch unbounded data.
 5. **Use `$count=true`** — Include on every list query to get total record count efficiently in `@odata.count` without fetching all rows. For count-only queries, combine with `$top=0`.
 6. **`@odata.bind` for lookups** — Set lookup relationships using `NavigationProperty@odata.bind` annotation with the target entity set path, not raw GUID values. The Navigation Property name is **case-sensitive** and must match the schema name (typically PascalCase like `cr4fc_Category`). Using the logical name (all lowercase) causes "Undeclared Property" errors.
 7. **Handle 204 responses** — PATCH and DELETE return empty bodies. Do not attempt to parse them.
@@ -600,7 +600,7 @@ Before confirming that work is done, verify every item below. Do not skip any ch
 - [ ] OneToMany relationship navigation properties are from the API's `ReferencedEntityNavigationPropertyName` (case-sensitive) — if expanding collection-valued properties
 
 ### Code Correctness
-- [ ] All list/query operations include `$top` — no unbounded fetches
+- [ ] All list/query operations use `Prefer: odata.maxpagesize=N` header for pagination — no `$top` for page-by-page navigation, no unbounded fetches
 - [ ] All queries use explicit `$select` with specific columns — no wildcards
 - [ ] All queries include `$count=true` for total record count
 - [ ] Lookups on POST/PATCH use `NavigationProperty@odata.bind` — not raw GUID writes to `_value` properties

--- a/plugins/power-pages/references/webapi-core-client.md
+++ b/plugins/power-pages/references/webapi-core-client.md
@@ -376,7 +376,7 @@ export const getFormattedValue = (
 
 const MAX_PAGINATION_ITERATIONS = 100;
 
-export const fetchAllPages = async <T>(initialUrl: string): Promise<T[]> => {
+export const fetchAllPages = async <T>(initialUrl: string, pageSize = 100): Promise<T[]> => {
   let nextUrl: string | undefined = initialUrl;
   const results: T[] = [];
   let iterations = 0;
@@ -387,7 +387,13 @@ export const fetchAllPages = async <T>(initialUrl: string): Promise<T[]> => {
       break;
     }
 
-    const response = await powerPagesFetch<ODataCollectionResponse<T>>(nextUrl);
+    // Prefer: odata.maxpagesize is required on every request (including nextLink cursors)
+    // to ensure @odata.nextLink is returned for subsequent pages.
+    const response = await powerPagesFetch<ODataCollectionResponse<T>>(nextUrl, {
+      headers: {
+        'Prefer': `odata.include-annotations="OData.Community.Display.V1.FormattedValue",odata.maxpagesize=${pageSize}`,
+      },
+    });
     if (!response) break;
 
     results.push(...(response.value ?? []));

--- a/plugins/power-pages/references/webapi-service-patterns.md
+++ b/plugins/power-pages/references/webapi-service-patterns.md
@@ -169,11 +169,11 @@ Create a service module with CRUD operations for the target table. Place it foll
 
 **Every list/query operation MUST be paginated.** Never fetch unbounded data. Two pagination approaches exist — choose based on the use case:
 
-**Cursor-based pagination (`$top` + `@odata.nextLink`)** — Use for UI list views with paging controls. The `list` function below uses this approach. Always include `$count=true` to get the total record count efficiently without fetching all rows. **Note:** Dataverse Web API does **not** support the `$skip` query option. Use `@odata.nextLink` from each response to fetch the next page.
+**Cursor-based pagination (`Prefer: odata.maxpagesize=N` + `@odata.nextLink`)** — Use for UI list views with paging controls. The `list` function below uses this approach. Always include `$count=true` to get the total record count efficiently without fetching all rows. **Note:** Power Pages does **not** support the `$skip` query option (returns error `9004010B: QueryParamNotSupported`). Use `@odata.nextLink` cursors (which contain `$skiptoken`) from each response to fetch the next page.
 
 **Client-side pagination (`fetchAllPages`)** — Use only when you genuinely need every record (e.g., populating a local dropdown, building a lookup map, exporting data). Uses the `fetchAllPages` helper from the core API client which follows `@odata.nextLink` with a safety iteration limit.
 
-**Never omit `$top`.** An API call without `$top` returns the server's default page size (typically 5000 records). Always set an explicit `$top` to control payload size.
+**Always use `Prefer: odata.maxpagesize=N` for pagination.** This request header controls the page size and ensures `@odata.nextLink` is returned for subsequent pages. Do NOT use `$top` for page-by-page navigation — `$top` caps the total result set and prevents `@odata.nextLink` from being returned. If you include both `$top` and `Prefer: odata.maxpagesize`, `$top` is ignored. Use `$top` only as a safety cap when you genuinely want to limit total results (e.g., `$top=5` for "top 5 recent items" on a dashboard widget, or `$top=0` for count-only queries).
 
 ### Select Columns
 
@@ -219,17 +219,22 @@ export const listProducts = async (params?: ListParams): Promise<PaginatedResult
   const pageSize = params?.pageSize ?? 10;
 
   // If we have a nextLink from a previous response, use it directly.
-  // Dataverse does NOT support $skip — pagination uses @odata.nextLink cursors.
+  // Power Pages does NOT support $skip — pagination uses @odata.nextLink cursors.
+  // Use Prefer: odata.maxpagesize to control page size (NOT $top).
+  // $top caps the total result set and prevents @odata.nextLink from being returned.
   const url = params?.nextLink ?? buildODataUrl('cr4fc_products', {
     '$select': PRODUCT_SELECT,
     '$expand': PRODUCT_EXPAND,
     '$orderby': params?.orderBy ?? 'createdon desc',
     '$count': 'true',
-    '$top': String(pageSize),
     '$filter': params?.filter,
   });
 
-  const response = await powerPagesFetch<ODataCollectionResponse<ProductEntity>>(url);
+  const response = await powerPagesFetch<ODataCollectionResponse<ProductEntity>>(url, {
+    headers: {
+      'Prefer': `odata.include-annotations="OData.Community.Display.V1.FormattedValue",odata.maxpagesize=${pageSize}`,
+    },
+  });
 
   return {
     items: (response?.value ?? []).map(mapProductEntity),
@@ -734,15 +739,19 @@ For large collections or when you need full paging control, fetch related record
 export const listOrderLines = async (orderId: string, params?: ListParams): Promise<PaginatedResult<OrderLine>> => {
   const pageSize = params?.pageSize ?? 20;
 
+  // Use Prefer: odata.maxpagesize to control page size (NOT $top).
   const url = params?.nextLink ?? buildODataUrl('cr4fc_orderlines', {
     '$select': 'cr4fc_orderlineid,cr4fc_productname,cr4fc_quantity,cr4fc_unitprice',
     '$filter': `_cr4fc_order_value eq ${orderId}`,
     '$orderby': params?.orderBy ?? 'cr4fc_quantity desc',
     '$count': 'true',
-    '$top': String(pageSize),
   });
 
-  const response = await powerPagesFetch<ODataCollectionResponse<OrderLineEntity>>(url);
+  const response = await powerPagesFetch<ODataCollectionResponse<OrderLineEntity>>(url, {
+    headers: {
+      'Prefer': `odata.include-annotations="OData.Community.Display.V1.FormattedValue",odata.maxpagesize=${pageSize}`,
+    },
+  });
 
   return {
     items: (response?.value ?? []).map(mapOrderLineEntity),


### PR DESCRIPTION
Replace $top-based pagination with Prefer: odata.maxpagesize=N header across Web API integration skill. $top caps the total result set and prevents @odata.nextLink from being returned, breaking pagination.

- Update fetchAllPages helper to accept pageSize param and send Prefer: odata.maxpagesize header on every request
- Update listProducts and listOrderLines examples to use Prefer header instead of $top for page size control
- Update Pagination Strategy docs to explain correct approach
- Update webapi-integration agent rule 4 and completion checklist
- Bump plugin version to 1.2.1