### PR TITLE
Adapt Power Platform skills for Codex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ Thumbs.db
 
 .playwright-mcp/
 .omx/
+.codex

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ ENV/
 Thumbs.db
 
 .playwright-mcp/
+.omx/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides guidance to AI Agents when working with code in this reposito
 
 ## What This Repo Is
 
-A **plugin marketplace** for Power Platform development by Microsoft. The marketplace manifest (`.claude-plugin/marketplace.json`) references individual plugins in `plugins/`. Each plugin has its own `AGENTS.md` with plugin-specific guidance.
+A repository of Power Platform development workflows grouped by plugin. The legacy Claude marketplace metadata still exists, but Codex should treat each `plugins/*/skills/<skill>/` directory as an individual skill package. Each plugin has its own `AGENTS.md` with plugin-specific guidance.
 
 ## Repository Structure
 
@@ -27,7 +27,7 @@ power-platform-skills/
 
 ## Local Development
 
-Test a plugin locally by launching your AI agent with the plugin path:
+For Codex, symlink or copy the skill folder you want into `$CODEX_HOME/skills` (or `~/.codex/skills`). For the legacy packaging, you can still launch Claude Code with a plugin path:
 
 ```bash
 claude --plugin-dir /path/to/plugins/<plugin-name>
@@ -39,14 +39,23 @@ No root-level build, lint, or test commands exist. Build/test tooling lives insi
 
 Each plugin follows this structure:
 
-- `.claude-plugin/plugin.json` — Plugin metadata (name, version, keywords)
+- `.claude-plugin/plugin.json` — Legacy plugin metadata (name, version, keywords)
 - `.mcp.json` — MCP server configuration (optional)
 - `agents/` — Agent definitions (`.md` files with YAML frontmatter)
 - `skills/` — Skill definitions, each in its own subdirectory with a `SKILL.md`
 - `scripts/` — Shared utility scripts referenced by skills and agents
 - `references/` — Shared reference documents used by multiple skills
 
-Skills are defined in `SKILL.md` files with YAML frontmatter (name, description, allowed-tools, model, hooks). The `allowed-tools` field must use a **comma-separated list** (e.g., `allowed-tools: Read, Write, Edit, Bash, Glob, Grep`) — not JSON array syntax (`["Read", "Write"]`) or YAML list syntax. Each skill may include validation scripts in a `scripts/` subdirectory, run as Stop hooks when the skill session ends.
+For Codex, `SKILL.md` frontmatter should stay minimal and focus on `name` and `description`. Some skills still contain Claude-era terminology in the body; when adapting or extending them, prefer Codex-native wording and keep the frontmatter lean.
+
+When a legacy workflow mentions Claude-specific concepts, translate them as follows:
+
+- `${CLAUDE_PLUGIN_ROOT}`: the plugin root directory that contains the current skill
+- `AskUserQuestion`: ask the user directly in a short plain-text message
+- `TaskCreate` / `TaskUpdate` / `TaskList`: maintain progress with `update_plan`
+- `EnterPlanMode` / `ExitPlanMode`: present a concise plan in normal Codex conversation flow
+- `Task` tool or specialist agents: do the work in the main Codex agent unless the user explicitly asks for delegation
+- `/skill-name`: open the corresponding sibling skill folder and follow that workflow directly
 
 ## Code Conventions
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,39 @@
 # Power Platform Skills
 
-Official agent skills/plugins for Power Platform development by Microsoft.
+Official Power Platform development skills by Microsoft. The repository started as a Claude Code/GitHub Copilot plugin marketplace and is now being adapted so the same workflows can be used as Codex skills.
 
 ## Overview
 
-This repository is a **plugin marketplace** containing Claude Code/GitHub Copilot plugins for Power Platform services. Each plugin provides skills, agents, and commands to help developers build on the Power Platform.
+This repository contains Power Platform workflows for Power Pages, Power Apps code apps, model-driven generative pages, and canvas apps. The source tree still groups content by plugin, but the primary unit for Codex is each `skills/*/SKILL.md` folder.
 
 ## Installation
 
-### Quick Install (Recommended)
+### Codex
+
+Codex discovers skills from folders that contain a `SKILL.md`. This repo keeps those folders under each plugin:
+
+- `plugins/power-pages/skills/*`
+- `plugins/code-apps/skills/*`
+- `plugins/model-apps/skills/*`
+- `plugins/canvas-apps/skills/*`
+
+To use selected skills with Codex, symlink or copy the skill folders you want into `$CODEX_HOME/skills` (or `~/.codex/skills` when `CODEX_HOME` is unset).
+
+Example:
+
+```bash
+mkdir -p "${CODEX_HOME:-$HOME/.codex}/skills"
+ln -s /path/to/power-platform-skills/plugins/power-pages/skills/create-site \
+  "${CODEX_HOME:-$HOME/.codex}/skills/power-pages-create-site"
+```
+
+The plugin-level `AGENTS.md` files describe how to interpret older Claude-specific terms that still appear inside some workflow documents.
+
+### Claude Code / GitHub Copilot
+
+The original plugin packaging is still present in `.claude-plugin/` for repositories that still consume this format.
+
+#### Quick Install (Recommended)
 
 Run the installer to set up all plugins with auto-update enabled:
 
@@ -78,10 +103,11 @@ Author Power Apps Canvas Apps using the Canvas Authoring MCP server.
 
 ## Local Development
 
-To develop and test plugins locally, follow these steps:
+To develop and test locally, follow these steps:
 
 1. Clone this repository
-1. Launch Claude Code with plugin path:
+1. For Codex, link the skill folder you want into `$CODEX_HOME/skills`
+1. For Claude Code, launch with plugin path:
 
     ```bash
     claude --plugin-dir /path/to/power-platform-skills/plugins/power-pages
@@ -92,7 +118,7 @@ To develop and test plugins locally, follow these steps:
 
 ## Running Without Interruption
 
-Plugins in this repo may invoke multiple tools (file edits, shell commands, MCP servers) during a session, which can result in frequent approval prompts. Use the options below to reduce or eliminate these interruptions.
+The workflows in this repo may invoke multiple tools during a session, which can result in frequent approval prompts. The options below apply to the original Claude Code and GitHub Copilot plugin packaging.
 
 > **Warning**: Auto-approval options give the agent the same access you have on your machine. Only use these in trusted or sandboxed environments.
 
@@ -156,16 +182,16 @@ See the [Copilot CLI docs](https://docs.github.com/en/copilot/how-tos/use-copilo
 ```text
 power-platform-skills/
 ├── .claude-plugin/
-│   └── marketplace.json      # Marketplace manifest (lists all plugins)
+│   └── marketplace.json      # Legacy marketplace manifest for Claude Code / Copilot
 ├── .claude/
 │   └── settings.json         # Auto-allowed tools (pac, node, dotnet, etc.)
 ├── plugins/
 │   ├── power-pages/          # Power Pages plugin
 │   │   ├── .claude-plugin/
-│   │   │   └── plugin.json
+│   │   │   └── plugin.json  # Legacy plugin packaging metadata
 │   │   ├── commands/
 │   │   ├── shared/
-│   │   └── skills/
+│   │   └── skills/          # Codex-compatible skill folders live here
 │   ├── model-apps/           # Model Apps plugin
 │   |   ├── .claude-plugin/
 │   │   └── plugin.json

--- a/README.md
+++ b/README.md
@@ -1,78 +1,96 @@
-# Power Platform Skills
+# Power Platform Skills / Power Platform Skills リポジトリ
 
-Official Power Platform development workflows by Microsoft, adapted for Codex while preserving the original Claude Code / GitHub Copilot plugin packaging.
+**EN**: Official Power Platform development workflows by Microsoft, adapted for Codex while preserving the original Claude Code / GitHub Copilot plugin packaging.
 
-This repository began as a plugin marketplace for Claude Code and GitHub Copilot. It now also supports **Codex-native skill usage**, where the primary unit of reuse is an individual `skills/<skill>/` folder containing a `SKILL.md`.
-
----
-
-## Status
-
-- **Codex support:** active
-- **Legacy Claude Code / GitHub Copilot packaging:** still present
-- **Repository layout:** still grouped by plugin
-- **Primary Codex execution unit:** one skill folder
-
-In practice, this means:
-
-- For **Codex**, you usually use a specific skill folder such as:
-  - `plugins/power-pages/skills/create-site`
-  - `plugins/code-apps/skills/add-dataverse`
-  - `plugins/model-apps/skills/genpage`
-  - `plugins/canvas-apps/skills/generate-canvas-app`
-- For **legacy plugin consumers**, `.claude-plugin/` manifests and plugin folders remain available.
+**JA**: Microsoft 提供の Power Platform 開発ワークフロー集です。現在は **Codex で自然に使える skill 集** として整備しつつ、従来の Claude Code / GitHub Copilot 向け plugin packaging も互換目的で保持しています。
 
 ---
 
-## What Changed From Claude Code To Codex
+## 1. Repository Status / リポジトリの現状
 
-The repo still carries historical Claude-oriented structure and vocabulary, but the skill documents have been updated so they can be followed naturally in Codex.
+**EN**
 
-### High-level shift
+- Codex support is active.
+- Legacy Claude Code / GitHub Copilot packaging is still present.
+- The repository is still grouped by plugin, but the primary Codex reuse unit is a **single skill folder** containing `SKILL.md`.
+- Most skill workflows have already been rewritten so Codex can follow them without Claude-specific orchestration tools.
 
-| Before | Now |
+**JA**
+
+- Codex 向けの利用は有効です。
+- 旧 Claude Code / GitHub Copilot 向け packaging も残っています。
+- ディレクトリ構成は plugin 単位のままですが、Codex での主な再利用単位は **`SKILL.md` を含む skill フォルダ単位** です。
+- 多くの skill は、Claude 専用の orchestration 前提を外し、Codex でそのまま追従できるように調整済みです。
+
+---
+
+## 2. What Changed From Claude Code To Codex / Claude Code から Codex への変更点
+
+### EN
+
+This repository originally assumed a Claude Code / plugin marketplace execution model. It now supports a Codex-first workflow.
+
+### JA
+
+このリポジトリはもともと Claude Code / plugin marketplace モデルを前提にしていましたが、現在は **Codex-first** で使えるように再構成されています。
+
+### High-level shift / 全体的な変化
+
+| Before / 以前 | Now / 現在 |
 |---|---|
 | Plugin-centric install and execution | Skill-centric install and execution |
-| Claude-specific orchestration terms in workflows | Codex-native guidance in `SKILL.md` plus plugin `AGENTS.md` |
-| Marketplace/plugin install was the main path | Symlinking or copying skills into Codex is the main path |
-| Some workflows assumed special question/task tools | Workflows now describe normal Codex conversation and `update_plan` usage |
+| Claude-specific orchestration terms in skill docs | Codex-native guidance in `SKILL.md` and plugin `AGENTS.md` |
+| Marketplace install was the default path | Symlinking/copying skill folders into Codex is the default path |
+| Some workflows assumed structured question/task tools | Workflows now assume normal Codex conversation and `update_plan` |
 
-### Translation rules used in this repo
+### Translation rules / 読み替えルール
 
-Many legacy docs originally assumed Claude-specific concepts. In Codex, interpret them like this:
+**EN**: Legacy terms still appear in some places. In Codex, interpret them as follows.
 
-| Legacy concept | Codex interpretation |
+**JA**: 古い用語が一部に残っていても、Codex では次のように読み替えてください。
+
+| Legacy term | Codex meaning |
 |---|---|
-| `AskUserQuestion` | Ask the user directly in normal chat |
-| `TaskCreate` / `TaskUpdate` / `TaskList` | Use `update_plan` |
-| `EnterPlanMode` / `ExitPlanMode` | Present a plan in normal conversation, get approval, continue |
-| `/skill-name` | Run the corresponding sibling skill workflow |
-| `${CLAUDE_PLUGIN_ROOT}` | The plugin root directory containing the current skill |
-| Specialist agent / Task tool instructions | Usually do the work in the main Codex agent unless explicit delegation is desired |
+| `AskUserQuestion` | Ask the user directly in normal chat / 通常会話で直接質問する |
+| `TaskCreate` / `TaskUpdate` / `TaskList` | Use `update_plan` / `update_plan` を使う |
+| `EnterPlanMode` / `ExitPlanMode` | Present a plan in normal conversation, get approval, continue / 通常会話で計画を提示して承認を得て続行する |
+| `/skill-name` | Run the sibling skill workflow / 対応する sibling skill のワークフローとして扱う |
+| `${CLAUDE_PLUGIN_ROOT}` | The plugin root directory containing the current skill / 現在の skill を含む plugin ルート |
+| Specialist agent / Task tool references | Usually perform the work in the main Codex agent / 通常はメインの Codex エージェントで実行する |
 
-### What was intentionally kept
+### What was intentionally kept / 意図的に残しているもの
 
-Some Claude/Copilot-oriented artifacts still remain because they are still useful or required:
+**EN**
+
+The following are intentionally retained for compatibility:
 
 - `.claude-plugin/marketplace.json`
 - `plugins/*/.claude-plugin/plugin.json`
 - legacy install instructions for Claude Code / GitHub Copilot
-- multi-tool support in some skills, especially:
-  - `plugins/canvas-apps/skills/configure-canvas-mcp`
+- multi-tool branches in some skills, especially `plugins/canvas-apps/skills/configure-canvas-mcp`
 
-These are **not** errors; they are compatibility surfaces.
+**JA**
+
+次のものは互換のため意図的に残しています。
+
+- `.claude-plugin/marketplace.json`
+- `plugins/*/.claude-plugin/plugin.json`
+- Claude Code / GitHub Copilot 向け旧インストール手順
+- 一部 skill のマルチツール分岐（特に `plugins/canvas-apps/skills/configure-canvas-mcp`）
+
+これらは未整理ではなく、**互換レイヤー**です。
 
 ---
 
-## What Is In This Repository
+## 3. What This Repository Contains / このリポジトリに含まれるもの
 
-This repo covers four Power Platform areas:
+### 3.1 Power Pages — `plugins/power-pages`
 
-### 1. Power Pages — `plugins/power-pages`
+**EN**: Create, deploy, activate, secure, and test modern Power Pages code sites.
 
-Build, deploy, activate, test, and secure modern Power Pages **code sites**.
+**JA**: Power Pages の code site を作成・デプロイ・有効化・保護・検証する skill 群です。
 
-Typical skills:
+Typical skills / 主な skill:
 
 - `create-site`
 - `deploy-site`
@@ -83,11 +101,13 @@ Typical skills:
 - `integrate-webapi`
 - `add-server-logic`
 
-### 2. Power Apps Code Apps — `plugins/code-apps`
+### 3.2 Code Apps — `plugins/code-apps`
 
-Build React + Vite + TypeScript code apps and connect them to Power Platform connectors.
+**EN**: Build React + Vite + TypeScript code apps and connect them to Power Platform connectors.
 
-Typical skills:
+**JA**: React + Vite + TypeScript ベースの code app を作成し、Power Platform connector と接続します。
+
+Typical skills / 主な skill:
 
 - `create-code-app`
 - `deploy`
@@ -97,19 +117,23 @@ Typical skills:
 - `add-office365`
 - `add-teams`
 
-### 3. Model Apps / Generative Pages — `plugins/model-apps`
+### 3.3 Model Apps / Generative Pages — `plugins/model-apps`
 
-Generate and deploy model-driven app generative pages.
+**EN**: Generate and deploy model-driven app generative pages.
 
-Typical skill:
+**JA**: model-driven app 向け generative page を生成・配置します。
+
+Typical skill / 主な skill:
 
 - `genpage`
 
-### 4. Canvas Apps — `plugins/canvas-apps`
+### 3.4 Canvas Apps — `plugins/canvas-apps`
 
-Generate or edit Canvas App YAML, and configure the Canvas Authoring MCP server.
+**EN**: Generate or edit Canvas App YAML and configure the Canvas Authoring MCP server.
 
-Typical skills:
+**JA**: Canvas App の YAML を生成・編集し、Canvas Authoring MCP server を設定します。
+
+Typical skills / 主な skill:
 
 - `configure-canvas-mcp`
 - `generate-canvas-app`
@@ -118,22 +142,22 @@ Typical skills:
 
 ---
 
-## Repository Structure
+## 4. Repository Structure / ディレクトリ構成
 
 ```text
 power-platform-skills/
 ├── .claude-plugin/
-│   └── marketplace.json          # Legacy marketplace manifest
+│   └── marketplace.json          # Legacy marketplace manifest / 旧 marketplace 定義
 ├── plugins/
 │   ├── power-pages/
 │   │   ├── .claude-plugin/
 │   │   │   └── plugin.json       # Legacy plugin metadata
-│   │   ├── AGENTS.md             # Plugin-specific guidance
+│   │   ├── AGENTS.md             # Plugin-specific guidance / plugin 固有ガイド
 │   │   ├── commands/             # Legacy command entry points
 │   │   ├── shared/               # Shared references/scripts/docs
 │   │   ├── scripts/              # Plugin scripts
 │   │   └── skills/
-│   │       └── <skill>/SKILL.md
+│   │       └── <skill>/SKILL.md  # Primary Codex skill unit / Codex の主利用単位
 │   ├── code-apps/
 │   ├── model-apps/
 │   └── canvas-apps/
@@ -141,47 +165,39 @@ power-platform-skills/
 └── README.md
 ```
 
-### Important layout note for Codex users
+### Important Codex note / Codex 利用時の重要事項
 
-Many skills reference files outside the skill folder, such as:
+**EN**: Many skills reference files outside the skill folder, such as `../../shared`, `../../references`, `../../scripts`, or `../../samples`. Because of that, **symlinking is safer than copying**.
 
-- `../../shared/...`
-- `../../references/...`
-- `../../scripts/...`
-- `../../samples/...`
-
-Because of that:
-
-- **Symlinking is the safest installation method**
-- If you **copy** a skill folder out of the repo, you may also need to copy supporting files it references
+**JA**: 多くの skill は `../../shared`、`../../references`、`../../scripts`、`../../samples` など skill フォルダ外のファイルを参照します。そのため、**copy より symlink の方が安全**です。
 
 ---
 
-## Using These Skills With Codex
+## 5. How To Use This Repo With Codex / Codex での使い方
 
-## 1. Clone the repository
+### Step 1 — Clone the repository / リポジトリを clone する
 
 ```bash
 git clone https://github.com/microsoft/power-platform-skills.git
 cd power-platform-skills
 ```
 
-## 2. Choose the skills you want
+### Step 2 — Choose the skill you want / 使いたい skill を選ぶ
 
-Examples:
+Examples / 例:
 
-- Power Pages site creation:
+- Power Pages site creation / Power Pages サイト作成
   - `plugins/power-pages/skills/create-site`
-- Dataverse integration for code apps:
+- Dataverse integration for code apps / code app に Dataverse を追加
   - `plugins/code-apps/skills/add-dataverse`
-- Model-driven generative pages:
+- Model-driven generative page / model-driven generative page 生成
   - `plugins/model-apps/skills/genpage`
-- Canvas app generation:
+- Canvas app generation / Canvas app 生成
   - `plugins/canvas-apps/skills/generate-canvas-app`
 
-## 3. Install them into Codex
+### Step 3 — Install into Codex / Codex に導入する
 
-### Recommended: symlink
+#### Recommended: symlink / 推奨: symlink
 
 ```bash
 mkdir -p "${CODEX_HOME:-$HOME/.codex}/skills"
@@ -190,157 +206,175 @@ ln -s /absolute/path/to/power-platform-skills/plugins/power-pages/skills/create-
   "${CODEX_HOME:-$HOME/.codex}/skills/power-pages-create-site"
 ```
 
-You can repeat that for as many skills as you want.
+**EN**: Repeat for any additional skills you want.
 
-### Alternative: copy
+**JA**: 必要な skill ごとに同様に追加してください。
 
-Copying can work, but be careful: a copied skill folder may no longer be able to find sibling `shared/`, `references/`, `scripts/`, or `samples/` content unless you copy those dependencies too.
+#### Alternative: copy / 代替: copy
 
-## 4. Use the skill in Codex
+**EN**: Copying can work, but you may also need to copy the referenced `shared/`, `references/`, `scripts/`, or `samples/` content.
 
-Once the skill is installed, invoke it by name or ask for the workflow it describes.
+**JA**: copy でも動く場合はありますが、参照先の `shared/`、`references/`、`scripts/`、`samples/` も必要に応じて一緒に持っていく必要があります。
 
-Examples:
+### Step 4 — Invoke the workflow / ワークフローを使う
+
+Examples / 例:
 
 - “Create a Power Pages site for an HR dashboard”
 - “Add Dataverse to my code app”
 - “Generate a model-driven generative page for Accounts”
 - “Configure the Canvas Authoring MCP server for Codex”
 
-### How Codex should interpret the repo
+### How Codex should interpret this repo / Codex がこの repo をどう解釈すべきか
 
-- `AGENTS.md` files define project and plugin behavior
-- Each `SKILL.md` defines the workflow itself
-- `references/`, `shared/`, `scripts/`, and `samples/` are supporting assets
-- Slash-style references inside docs usually point to **sibling skills**, not literal shell commands
-
----
-
-## Codex Usage Patterns
-
-### Prefer a skill over ad hoc prompting
-
-If a request clearly matches a skill, use the skill workflow instead of improvising from scratch.
-
-### Read only the references you need
-
-Skills often point at shared references. In Codex, load only the files needed for the current task rather than bulk-loading everything.
-
-### Use `update_plan` for multi-phase skills
-
-Many workflows were originally written with explicit task-management tools in mind. In Codex, the intended equivalent is `update_plan`.
-
-### Ask users directly in normal chat
-
-Where older docs mention structured question tools, Codex should simply ask concise questions in the conversation.
+- `AGENTS.md` defines repository or plugin-wide behavior / `AGENTS.md` は repo 全体または plugin 全体の規約
+- `SKILL.md` defines the workflow itself / `SKILL.md` は workflow 本体
+- `references/`, `shared/`, `scripts/`, and `samples/` are support assets / `references/`, `shared/`, `scripts/`, `samples/` は補助資産
+- Slash-style references usually mean sibling skill workflows, not literal shell commands / slash 形式の参照は通常 shell command ではなく sibling skill のこと
 
 ---
 
-## Common Prerequisites
+## 6. Codex Usage Conventions / Codex での利用規約
 
-The exact requirements depend on the plugin, but common tooling includes:
+### EN
+
+- Prefer using a skill when the request clearly matches one.
+- Read only the supporting references you actually need.
+- Use `update_plan` for multi-phase workflows.
+- Ask the user directly in normal chat where legacy docs previously assumed structured question tools.
+- Keep work in the main Codex agent unless explicit delegation is useful and authorized.
+
+### JA
+
+- 要求が skill に明確に対応するなら、即興対応より skill を優先してください。
+- 参照資料は必要なものだけ読み込んでください。
+- 複数フェーズの workflow では `update_plan` を使ってください。
+- 旧ドキュメントが構造化質問ツールを前提にしていても、Codex では通常会話で直接確認してください。
+- 明示的に必要な場合を除き、作業はメインの Codex エージェントで進めてください。
+
+---
+
+## 7. Common Prerequisites / 共通前提条件
+
+### Common tooling / 共通ツール
 
 - **Node.js**
 - **Power Platform CLI (`pac`)**
 - **Git**
-- **PowerShell / `pwsh`** for workflows that call Windows-oriented CLI surfaces from bash
+- **PowerShell / `pwsh`** （bash から Windows 指向 CLI を呼ぶ workflow 用）
 
-Additional plugin-specific requirements:
+### Plugin-specific notes / plugin ごとの補足
 
-### Power Pages
+#### Power Pages
 
 - PAC CLI authentication
-- Azure CLI authentication for some Dataverse / Power Platform REST operations
-- A previously created or deployed code site for certain workflows
+- Azure CLI authentication for some REST / Dataverse operations
+- Some skills require a previously deployed code site
 
-### Code Apps
+#### Code Apps
 
 - Node.js
 - PAC CLI
-- Power Platform environment access
+- Access to the target Power Platform environment
 
-### Model Apps
+#### Model Apps
 
 - PAC CLI with model app / genpage support
 - Access to the target Dataverse environment
 
-### Canvas Apps
+#### Canvas Apps
 
 - **.NET 10 SDK**
 - Canvas Authoring MCP server setup
-- A compatible Studio / coauthoring workflow
+- Compatible Studio / coauthoring environment
 
 ---
 
-## Local Development
+## 8. Local Development / ローカル開発
 
-There is **no root-level universal build or test command** for the entire repository.
+### EN
+
+There is **no single root-level build or test command** for the whole repository.
 
 Instead:
 
-- inspect the relevant plugin folder
-- follow its `AGENTS.md`
-- run only the commands needed for the skill or script you are editing
+1. work within the relevant plugin folder
+2. follow that plugin's `AGENTS.md`
+3. run only the commands required for the skill or script you are editing
 
-Typical local workflow:
+### JA
 
-1. Clone the repo
-2. Edit a skill under `plugins/<plugin>/skills/<skill>/`
-3. Update adjacent references/scripts if needed
-4. Symlink the skill into Codex
-5. Test the workflow from Codex against the intended scenario
+このリポジトリ全体に対する **単一の root-level build/test コマンドはありません**。
 
-### Important development conventions
+代わりに、
 
-- Prefer **small, reviewable diffs**
-- Reuse shared scripts and references rather than duplicating logic
-- Keep plugin-specific conventions in the plugin's `AGENTS.md`
-- If a skill references shared scripts or reference docs, keep those links accurate
+1. 対象 plugin 配下で作業し、
+2. その plugin の `AGENTS.md` に従い、
+3. 編集対象 skill / script に必要なコマンドだけ実行してください。
+
+### Typical local flow / 典型的な作業手順
+
+1. Clone the repo / repo を clone
+2. Edit a skill under `plugins/<plugin>/skills/<skill>/` / 対象 skill を編集
+3. Update adjacent references/scripts if needed / 必要に応じて references/scripts も更新
+4. Symlink the skill into Codex / Codex に symlink
+5. Test the workflow in Codex / Codex で実地確認
+
+### Development conventions / 開発上の基本方針
+
+- Prefer small, reviewable diffs / 差分は小さく保つ
+- Reuse shared scripts and references / shared script や reference を再利用する
+- Update plugin `AGENTS.md` if conventions change / 規約が変わったら plugin の `AGENTS.md` も更新する
+- Keep skill references accurate / skill 内の参照を壊さない
 
 ---
 
-## Legacy Claude Code / GitHub Copilot Packaging
+## 9. Legacy Claude Code / GitHub Copilot Packaging / 旧 Claude Code / GitHub Copilot Packaging
 
-The original plugin packaging is still available.
+### EN
 
-### Marketplace manifest
+The legacy plugin packaging remains available for users who still depend on it.
 
-The legacy marketplace definition lives at:
+### JA
+
+旧 plugin packaging も、まだそれを必要とする利用者向けに維持されています。
+
+### Marketplace manifest / marketplace 定義
 
 - `.claude-plugin/marketplace.json`
 
-Current legacy plugin entries include:
+Current legacy entries / 現在の legacy plugin entry:
 
 - `power-pages`
 - `model-apps`
 - `canvas-apps`
 - `code-apps-preview`
 
-### Quick install for legacy plugin consumers
+### Quick install / 旧方式の簡易インストール
 
-**Windows (PowerShell):**
+**Windows (PowerShell)**
 
 ```powershell
 iwr https://raw.githubusercontent.com/microsoft/power-platform-skills/main/scripts/install.js -OutFile install.js; node install.js; del install.js
 ```
 
-**macOS / Linux / Windows (cmd-compatible shell):**
+**macOS / Linux / Windows (cmd-compatible shell)**
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/microsoft/power-platform-skills/main/scripts/install.js | node
 ```
 
-### Manual legacy install
+### Manual legacy install / 手動インストール
 
-Inside Claude Code or GitHub Copilot CLI:
+Inside Claude Code or GitHub Copilot CLI / Claude Code または GitHub Copilot CLI 内で:
 
-1. Add the marketplace
+1. Add the marketplace / marketplace を追加
 
    ```bash
    /plugin marketplace add microsoft/power-platform-skills
    ```
 
-2. Install the desired plugin
+2. Install the desired plugin / 必要な plugin をインストール
 
    ```bash
    /plugin install power-pages@power-platform-skills
@@ -349,41 +383,39 @@ Inside Claude Code or GitHub Copilot CLI:
    /plugin install canvas-apps@power-platform-skills
    ```
 
-### Why these instructions remain
+### Why this section remains / この説明を残している理由
 
-Because the repo is in a transition state:
+**EN**: The repo is in a compatibility phase: Codex users consume **skills**, legacy plugin users consume **plugins**.
 
-- Codex users consume **skills**
-- Legacy plugin users consume **plugins**
-
-Both entrypoints remain useful, so this README documents both.
+**JA**: この repo は互換維持フェーズにあり、Codex 利用者は **skill**、旧 plugin 利用者は **plugin** を消費します。
 
 ---
 
-## Known Migration Notes
+## 10. Known Migration Notes / 移行時の注意点
 
-These are intentional and useful to know when reading the repo:
+1. **Plugin naming is historical / plugin 名は歴史的事情がある**
+   - Example: the legacy marketplace entry is `code-apps-preview`, while the repo folder is `plugins/code-apps`.
+   - 例: legacy marketplace では `code-apps-preview`、repo 上のフォルダは `plugins/code-apps`
 
-1. **Plugin naming is historical**
-   - For example, the legacy marketplace entry is `code-apps-preview`, while the repo folder is `plugins/code-apps`.
+2. **Some docs still mention slash commands / slash command 表記が残る場合がある**
+   - In Codex, these usually mean sibling skill workflows.
+   - Codex では通常 sibling skill の意味です。
 
-2. **Some docs still mention slash commands**
-   - In Codex, these usually mean “run the sibling skill workflow”.
-
-3. **Some skills are multi-tool by design**
+3. **Some skills are intentionally multi-tool / 一部 skill は意図的にマルチツール対応**
    - `configure-canvas-mcp` still includes Codex, Claude Code, and Copilot branches.
+   - `configure-canvas-mcp` は Codex / Claude Code / Copilot 分岐を保持しています。
 
-4. **The repo is Codex-adapted, not fully Claude-erased**
-   - Legacy manifests and compatibility docs intentionally remain.
+4. **The repo is Codex-adapted, not Claude-erased / Codex 対応済みだが Claude 記述を完全削除したわけではない**
+   - Compatibility files and explanations remain on purpose.
+   - 互換ファイルや説明は意図的に残しています。
 
-5. **Symlinking beats copying**
-   - Because many skills depend on sibling references/scripts.
+5. **Symlinking is safer than copying / copy より symlink が安全**
+   - Many skills depend on sibling references or scripts.
+   - 多くの skill が sibling reference/script に依存します。
 
 ---
 
-## Recommended Starting Points
-
-If you're new to this repo, these are good entry skills:
+## 11. Recommended Entry Skills / 初めて使う場合のおすすめ skill
 
 ### Power Pages
 
@@ -406,7 +438,7 @@ If you're new to this repo, these are good entry skills:
 
 ---
 
-## Documentation
+## 12. Documentation / 参考資料
 
 - [Power Pages Code Sites](https://learn.microsoft.com/en-us/power-pages/configure/create-code-sites)
 - [Power Pages REST API](https://learn.microsoft.com/en-us/rest/api/power-platform/powerpages/websites)
@@ -416,26 +448,34 @@ If you're new to this repo, these are good entry skills:
 
 ---
 
-## Contributing
+## 13. Contributing / コントリビューション
 
-See [CONTRIBUTING.md](CONTRIBUTING.md).
+**EN**: See [CONTRIBUTING.md](CONTRIBUTING.md).
 
-When contributing:
+**JA**: 詳細は [CONTRIBUTING.md](CONTRIBUTING.md) を参照してください。
 
-- update the relevant `SKILL.md`
-- update plugin `AGENTS.md` if conventions changed
-- update this `README.md` if the Codex vs legacy usage model changes
+When contributing / 変更時の基本方針:
 
----
-
-## License
-
-The code in this repo is licensed under the [MIT](LICENSE) license.
+- update the relevant `SKILL.md` / 対象 `SKILL.md` を更新する
+- update plugin `AGENTS.md` if conventions changed / 規約変更時は plugin `AGENTS.md` も更新する
+- update this README if the Codex/legacy usage model changes / Codex/legacy の使い分けが変わったら README も更新する
 
 ---
 
-## Trademarks
+## 14. License / ライセンス
 
-This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft trademarks or logos is subject to and must follow [Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/legal/intellectualproperty/trademarks/usage/general).
+**EN**: The code in this repo is licensed under the [MIT](LICENSE) license.
+
+**JA**: このリポジトリのコードは [MIT](LICENSE) ライセンスです。
+
+---
+
+## 15. Trademarks / 商標
+
+**EN**: This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft trademarks or logos is subject to and must follow [Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/legal/intellectualproperty/trademarks/usage/general).
 
 Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship. Any use of third-party trademarks or logos are subject to those third-party's policies.
+
+**JA**: このプロジェクトには、プロジェクト、製品、サービスに関する商標またはロゴが含まれる場合があります。Microsoft の商標またはロゴの使用は、[Microsoft の Trademark & Brand Guidelines](https://www.microsoft.com/legal/intellectualproperty/trademarks/usage/general) に従う必要があります。
+
+本プロジェクトを改変した版で Microsoft の商標またはロゴを使用する場合、Microsoft の支援や後援を示唆したり、混同を招いたりしてはいけません。第三者商標の使用については、その第三者のポリシーに従ってください。

--- a/README.md
+++ b/README.md
@@ -1,218 +1,410 @@
 # Power Platform Skills
 
-Official Power Platform development skills by Microsoft. The repository started as a Claude Code/GitHub Copilot plugin marketplace and is now being adapted so the same workflows can be used as Codex skills.
+Official Power Platform development workflows by Microsoft, adapted for Codex while preserving the original Claude Code / GitHub Copilot plugin packaging.
 
-## Overview
+This repository began as a plugin marketplace for Claude Code and GitHub Copilot. It now also supports **Codex-native skill usage**, where the primary unit of reuse is an individual `skills/<skill>/` folder containing a `SKILL.md`.
 
-This repository contains Power Platform workflows for Power Pages, Power Apps code apps, model-driven generative pages, and canvas apps. The source tree still groups content by plugin, but the primary unit for Codex is each `skills/*/SKILL.md` folder.
+---
 
-## Installation
+## Status
 
-### Codex
+- **Codex support:** active
+- **Legacy Claude Code / GitHub Copilot packaging:** still present
+- **Repository layout:** still grouped by plugin
+- **Primary Codex execution unit:** one skill folder
 
-Codex discovers skills from folders that contain a `SKILL.md`. This repo keeps those folders under each plugin:
+In practice, this means:
 
-- `plugins/power-pages/skills/*`
-- `plugins/code-apps/skills/*`
-- `plugins/model-apps/skills/*`
-- `plugins/canvas-apps/skills/*`
+- For **Codex**, you usually use a specific skill folder such as:
+  - `plugins/power-pages/skills/create-site`
+  - `plugins/code-apps/skills/add-dataverse`
+  - `plugins/model-apps/skills/genpage`
+  - `plugins/canvas-apps/skills/generate-canvas-app`
+- For **legacy plugin consumers**, `.claude-plugin/` manifests and plugin folders remain available.
 
-To use selected skills with Codex, symlink or copy the skill folders you want into `$CODEX_HOME/skills` (or `~/.codex/skills` when `CODEX_HOME` is unset).
+---
 
-Example:
+## What Changed From Claude Code To Codex
 
-```bash
-mkdir -p "${CODEX_HOME:-$HOME/.codex}/skills"
-ln -s /path/to/power-platform-skills/plugins/power-pages/skills/create-site \
-  "${CODEX_HOME:-$HOME/.codex}/skills/power-pages-create-site"
-```
+The repo still carries historical Claude-oriented structure and vocabulary, but the skill documents have been updated so they can be followed naturally in Codex.
 
-The plugin-level `AGENTS.md` files describe how to interpret older Claude-specific terms that still appear inside some workflow documents.
+### High-level shift
 
-### Claude Code / GitHub Copilot
+| Before | Now |
+|---|---|
+| Plugin-centric install and execution | Skill-centric install and execution |
+| Claude-specific orchestration terms in workflows | Codex-native guidance in `SKILL.md` plus plugin `AGENTS.md` |
+| Marketplace/plugin install was the main path | Symlinking or copying skills into Codex is the main path |
+| Some workflows assumed special question/task tools | Workflows now describe normal Codex conversation and `update_plan` usage |
 
-The original plugin packaging is still present in `.claude-plugin/` for repositories that still consume this format.
+### Translation rules used in this repo
 
-#### Quick Install (Recommended)
+Many legacy docs originally assumed Claude-specific concepts. In Codex, interpret them like this:
 
-Run the installer to set up all plugins with auto-update enabled:
+| Legacy concept | Codex interpretation |
+|---|---|
+| `AskUserQuestion` | Ask the user directly in normal chat |
+| `TaskCreate` / `TaskUpdate` / `TaskList` | Use `update_plan` |
+| `EnterPlanMode` / `ExitPlanMode` | Present a plan in normal conversation, get approval, continue |
+| `/skill-name` | Run the corresponding sibling skill workflow |
+| `${CLAUDE_PLUGIN_ROOT}` | The plugin root directory containing the current skill |
+| Specialist agent / Task tool instructions | Usually do the work in the main Codex agent unless explicit delegation is desired |
 
-**Windows (PowerShell)**:
+### What was intentionally kept
 
-```powershell
-iwr https://raw.githubusercontent.com/microsoft/power-platform-skills/main/scripts/install.js -OutFile install.js; node install.js; del install.js
-```
+Some Claude/Copilot-oriented artifacts still remain because they are still useful or required:
 
-**Mac OS/Linux/Windows (cmd)**:
+- `.claude-plugin/marketplace.json`
+- `plugins/*/.claude-plugin/plugin.json`
+- legacy install instructions for Claude Code / GitHub Copilot
+- multi-tool support in some skills, especially:
+  - `plugins/canvas-apps/skills/configure-canvas-mcp`
 
-```bash
-curl -fsSL https://raw.githubusercontent.com/microsoft/power-platform-skills/main/scripts/install.js | node
-```
+These are **not** errors; they are compatibility surfaces.
 
-The installer automatically:
+---
 
-- Installs `pac` CLI if not already installed
-- Detects available tools (Claude Code, GitHub Copilot CLI)
-- Registers the plugin marketplace and installs all listed plugins
-- Enables auto-update so plugins stay current
+## What Is In This Repository
 
-### Manual Installation
+This repo covers four Power Platform areas:
 
-If you prefer to install manually, run these commands inside a Claude Code or GitHub Copilot CLI session:
+### 1. Power Pages — `plugins/power-pages`
 
-1. Add the marketplace
+Build, deploy, activate, test, and secure modern Power Pages **code sites**.
 
-    ```bash
-    /plugin marketplace add microsoft/power-platform-skills
-    ```
+Typical skills:
 
-2. Install the desired plugin
+- `create-site`
+- `deploy-site`
+- `activate-site`
+- `test-site`
+- `setup-datamodel`
+- `setup-auth`
+- `integrate-webapi`
+- `add-server-logic`
 
-    ```bash
-    /plugin install power-pages@power-platform-skills
-    /plugin install model-apps@power-platform-skills
-    /plugin install code-apps@power-platform-skills
-    /plugin install canvas-apps@power-platform-skills
-    ```
+### 2. Power Apps Code Apps — `plugins/code-apps`
 
-## Available Plugins
+Build React + Vite + TypeScript code apps and connect them to Power Platform connectors.
 
-### [Power Pages](plugins/power-pages/README.md) (`plugins/power-pages`)
+Typical skills:
 
-Create and deploy Power Pages sites using modern development approaches.
+- `create-code-app`
+- `deploy`
+- `list-connections`
+- `add-dataverse`
+- `add-sharepoint`
+- `add-office365`
+- `add-teams`
 
-**Currently supported**: Code Sites (SPAs) with React, Angular, Vue, or Astro
+### 3. Model Apps / Generative Pages — `plugins/model-apps`
 
-### [Model Apps](plugins/model-apps/README.md) (`plugins/model-apps`)
+Generate and deploy model-driven app generative pages.
 
-Build and deploy Power Apps generative pages for model-driven apps.
+Typical skill:
 
-**Stack**: React + TypeScript + Fluent, deployed via PAC CLI
+- `genpage`
 
-### [Code Apps](plugins/code-apps/AGENTS.md) (`plugins/code-apps`)
+### 4. Canvas Apps — `plugins/canvas-apps`
 
-Build and deploy Power Apps code apps connected to Power Platform via connectors.
+Generate or edit Canvas App YAML, and configure the Canvas Authoring MCP server.
 
-**Stack**: React + Vite + TypeScript, deployed via PAC CLI
+Typical skills:
 
-### [Canvas Apps](plugins/canvas-apps/AGENTS.md) (`plugins/canvas-apps`)
+- `configure-canvas-mcp`
+- `generate-canvas-app`
+- `edit-canvas-app`
+- `add-data-source`
 
-Author Power Apps Canvas Apps using the Canvas Authoring MCP server.
-
-**Stack**: PA YAML (`.pa.yaml`) authored via `CanvasAuthoringMcpServer`, requires .NET 10 SDK
-
-## Local Development
-
-To develop and test locally, follow these steps:
-
-1. Clone this repository
-1. For Codex, link the skill folder you want into `$CODEX_HOME/skills`
-1. For Claude Code, launch with plugin path:
-
-    ```bash
-    claude --plugin-dir /path/to/power-platform-skills/plugins/power-pages
-    claude --plugin-dir /path/to/power-platform-skills/plugins/model-apps
-    claude --plugin-dir /path/to/power-platform-skills/plugins/code-apps
-    claude --plugin-dir /path/to/power-platform-skills/plugins/canvas-apps
-    ```
-
-## Running Without Interruption
-
-The workflows in this repo may invoke multiple tools during a session, which can result in frequent approval prompts. The options below apply to the original Claude Code and GitHub Copilot plugin packaging.
-
-> **Warning**: Auto-approval options give the agent the same access you have on your machine. Only use these in trusted or sandboxed environments.
-
-### Claude Code
-
-#### Option 1 — Permission mode (recommended)
-
-Set the `acceptEdits` mode to auto-approve file edits while still prompting for shell commands:
-
-```jsonc
-// .claude/settings.json (project-level) or ~/.claude/settings.json (user-level)
-{
-  "defaultMode": "acceptEdits",
-  "permissions": {
-    "allow": [
-      "Bash(npm run *)",
-      "Bash(git *)",
-      "Bash(pac *)"
-      // add other commands your workflow needs
-    ]
-  }
-}
-```
-
-#### Option 2 — Allow all tools
-
-Press <kbd>Shift</kbd>+<kbd>Tab</kbd> during a session to cycle to **auto-accept** mode, or launch with:
-
-```bash
-claude --dangerously-skip-permissions
-```
-
-See the [Claude Code permissions docs](https://code.claude.com/docs/en/permissions) for the full reference.
-
-### GitHub Copilot CLI
-
-#### Option 1 — Allow specific tools (recommended)
-
-Pre-approve only the tools your workflow needs:
-
-```bash
-copilot --allow-tool 'write' --allow-tool 'shell(npm run build)' --allow-tool 'shell(pac *)'
-```
-
-#### Option 2 — Allow all tools in Copilot
-
-```bash
-copilot --allow-all-tools
-```
-
-To allow everything except dangerous commands:
-
-```bash
-copilot --allow-all-tools --deny-tool 'shell(rm)' --deny-tool 'shell(git push)'
-```
-
-See the [Copilot CLI docs](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/use-copilot-cli) for the full reference.
+---
 
 ## Repository Structure
 
 ```text
 power-platform-skills/
 ├── .claude-plugin/
-│   └── marketplace.json      # Legacy marketplace manifest for Claude Code / Copilot
-├── .claude/
-│   └── settings.json         # Auto-allowed tools (pac, node, dotnet, etc.)
+│   └── marketplace.json          # Legacy marketplace manifest
 ├── plugins/
-│   ├── power-pages/          # Power Pages plugin
+│   ├── power-pages/
 │   │   ├── .claude-plugin/
-│   │   │   └── plugin.json  # Legacy plugin packaging metadata
-│   │   ├── commands/
-│   │   ├── shared/
-│   │   └── skills/          # Codex-compatible skill folders live here
-│   ├── model-apps/           # Model Apps plugin
-│   |   ├── .claude-plugin/
-│   │   └── plugin.json
-│   |   ├── commands/
-│   |   ├── skills/
-│   |   ├── shared/           # Shared references + samples
-│   |   └── github/           # GitHub Copilot instructions
-│   ├── code-apps/            # Code Apps plugin
-│   │   ├── .claude-plugin/
-│   │   │   └── plugin.json
-│   │   ├── agents/
-│   │   ├── skills/
-│   │   └── shared/           # Shared instructions + references
-│   └── canvas-apps/          # Canvas Apps plugin
-│       ├── .claude-plugin/
-│       │   └── plugin.json
-│       ├── references/       # Technical + design guides
-│       └── skills/
-├── AGENTS.md                 # Development guidelines
+│   │   │   └── plugin.json       # Legacy plugin metadata
+│   │   ├── AGENTS.md             # Plugin-specific guidance
+│   │   ├── commands/             # Legacy command entry points
+│   │   ├── shared/               # Shared references/scripts/docs
+│   │   ├── scripts/              # Plugin scripts
+│   │   └── skills/
+│   │       └── <skill>/SKILL.md
+│   ├── code-apps/
+│   ├── model-apps/
+│   └── canvas-apps/
+├── AGENTS.md                     # Repository-wide guidance
 └── README.md
 ```
+
+### Important layout note for Codex users
+
+Many skills reference files outside the skill folder, such as:
+
+- `../../shared/...`
+- `../../references/...`
+- `../../scripts/...`
+- `../../samples/...`
+
+Because of that:
+
+- **Symlinking is the safest installation method**
+- If you **copy** a skill folder out of the repo, you may also need to copy supporting files it references
+
+---
+
+## Using These Skills With Codex
+
+## 1. Clone the repository
+
+```bash
+git clone https://github.com/microsoft/power-platform-skills.git
+cd power-platform-skills
+```
+
+## 2. Choose the skills you want
+
+Examples:
+
+- Power Pages site creation:
+  - `plugins/power-pages/skills/create-site`
+- Dataverse integration for code apps:
+  - `plugins/code-apps/skills/add-dataverse`
+- Model-driven generative pages:
+  - `plugins/model-apps/skills/genpage`
+- Canvas app generation:
+  - `plugins/canvas-apps/skills/generate-canvas-app`
+
+## 3. Install them into Codex
+
+### Recommended: symlink
+
+```bash
+mkdir -p "${CODEX_HOME:-$HOME/.codex}/skills"
+
+ln -s /absolute/path/to/power-platform-skills/plugins/power-pages/skills/create-site \
+  "${CODEX_HOME:-$HOME/.codex}/skills/power-pages-create-site"
+```
+
+You can repeat that for as many skills as you want.
+
+### Alternative: copy
+
+Copying can work, but be careful: a copied skill folder may no longer be able to find sibling `shared/`, `references/`, `scripts/`, or `samples/` content unless you copy those dependencies too.
+
+## 4. Use the skill in Codex
+
+Once the skill is installed, invoke it by name or ask for the workflow it describes.
+
+Examples:
+
+- “Create a Power Pages site for an HR dashboard”
+- “Add Dataverse to my code app”
+- “Generate a model-driven generative page for Accounts”
+- “Configure the Canvas Authoring MCP server for Codex”
+
+### How Codex should interpret the repo
+
+- `AGENTS.md` files define project and plugin behavior
+- Each `SKILL.md` defines the workflow itself
+- `references/`, `shared/`, `scripts/`, and `samples/` are supporting assets
+- Slash-style references inside docs usually point to **sibling skills**, not literal shell commands
+
+---
+
+## Codex Usage Patterns
+
+### Prefer a skill over ad hoc prompting
+
+If a request clearly matches a skill, use the skill workflow instead of improvising from scratch.
+
+### Read only the references you need
+
+Skills often point at shared references. In Codex, load only the files needed for the current task rather than bulk-loading everything.
+
+### Use `update_plan` for multi-phase skills
+
+Many workflows were originally written with explicit task-management tools in mind. In Codex, the intended equivalent is `update_plan`.
+
+### Ask users directly in normal chat
+
+Where older docs mention structured question tools, Codex should simply ask concise questions in the conversation.
+
+---
+
+## Common Prerequisites
+
+The exact requirements depend on the plugin, but common tooling includes:
+
+- **Node.js**
+- **Power Platform CLI (`pac`)**
+- **Git**
+- **PowerShell / `pwsh`** for workflows that call Windows-oriented CLI surfaces from bash
+
+Additional plugin-specific requirements:
+
+### Power Pages
+
+- PAC CLI authentication
+- Azure CLI authentication for some Dataverse / Power Platform REST operations
+- A previously created or deployed code site for certain workflows
+
+### Code Apps
+
+- Node.js
+- PAC CLI
+- Power Platform environment access
+
+### Model Apps
+
+- PAC CLI with model app / genpage support
+- Access to the target Dataverse environment
+
+### Canvas Apps
+
+- **.NET 10 SDK**
+- Canvas Authoring MCP server setup
+- A compatible Studio / coauthoring workflow
+
+---
+
+## Local Development
+
+There is **no root-level universal build or test command** for the entire repository.
+
+Instead:
+
+- inspect the relevant plugin folder
+- follow its `AGENTS.md`
+- run only the commands needed for the skill or script you are editing
+
+Typical local workflow:
+
+1. Clone the repo
+2. Edit a skill under `plugins/<plugin>/skills/<skill>/`
+3. Update adjacent references/scripts if needed
+4. Symlink the skill into Codex
+5. Test the workflow from Codex against the intended scenario
+
+### Important development conventions
+
+- Prefer **small, reviewable diffs**
+- Reuse shared scripts and references rather than duplicating logic
+- Keep plugin-specific conventions in the plugin's `AGENTS.md`
+- If a skill references shared scripts or reference docs, keep those links accurate
+
+---
+
+## Legacy Claude Code / GitHub Copilot Packaging
+
+The original plugin packaging is still available.
+
+### Marketplace manifest
+
+The legacy marketplace definition lives at:
+
+- `.claude-plugin/marketplace.json`
+
+Current legacy plugin entries include:
+
+- `power-pages`
+- `model-apps`
+- `canvas-apps`
+- `code-apps-preview`
+
+### Quick install for legacy plugin consumers
+
+**Windows (PowerShell):**
+
+```powershell
+iwr https://raw.githubusercontent.com/microsoft/power-platform-skills/main/scripts/install.js -OutFile install.js; node install.js; del install.js
+```
+
+**macOS / Linux / Windows (cmd-compatible shell):**
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/microsoft/power-platform-skills/main/scripts/install.js | node
+```
+
+### Manual legacy install
+
+Inside Claude Code or GitHub Copilot CLI:
+
+1. Add the marketplace
+
+   ```bash
+   /plugin marketplace add microsoft/power-platform-skills
+   ```
+
+2. Install the desired plugin
+
+   ```bash
+   /plugin install power-pages@power-platform-skills
+   /plugin install model-apps@power-platform-skills
+   /plugin install code-apps@power-platform-skills
+   /plugin install canvas-apps@power-platform-skills
+   ```
+
+### Why these instructions remain
+
+Because the repo is in a transition state:
+
+- Codex users consume **skills**
+- Legacy plugin users consume **plugins**
+
+Both entrypoints remain useful, so this README documents both.
+
+---
+
+## Known Migration Notes
+
+These are intentional and useful to know when reading the repo:
+
+1. **Plugin naming is historical**
+   - For example, the legacy marketplace entry is `code-apps-preview`, while the repo folder is `plugins/code-apps`.
+
+2. **Some docs still mention slash commands**
+   - In Codex, these usually mean “run the sibling skill workflow”.
+
+3. **Some skills are multi-tool by design**
+   - `configure-canvas-mcp` still includes Codex, Claude Code, and Copilot branches.
+
+4. **The repo is Codex-adapted, not fully Claude-erased**
+   - Legacy manifests and compatibility docs intentionally remain.
+
+5. **Symlinking beats copying**
+   - Because many skills depend on sibling references/scripts.
+
+---
+
+## Recommended Starting Points
+
+If you're new to this repo, these are good entry skills:
+
+### Power Pages
+
+- `plugins/power-pages/skills/create-site`
+- `plugins/power-pages/skills/deploy-site`
+
+### Code Apps
+
+- `plugins/code-apps/skills/create-code-app`
+- `plugins/code-apps/skills/add-datasource`
+
+### Model Apps
+
+- `plugins/model-apps/skills/genpage`
+
+### Canvas Apps
+
+- `plugins/canvas-apps/skills/configure-canvas-mcp`
+- `plugins/canvas-apps/skills/generate-canvas-app`
+
+---
 
 ## Documentation
 
@@ -222,18 +414,28 @@ power-platform-skills/
 - [Power Apps Code Apps](https://learn.microsoft.com/power-apps/developer/code-apps/)
 - [PAC CLI Reference](https://learn.microsoft.com/en-us/power-platform/developer/cli/reference)
 
+---
+
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guide.
+See [CONTRIBUTING.md](CONTRIBUTING.md).
+
+When contributing:
+
+- update the relevant `SKILL.md`
+- update plugin `AGENTS.md` if conventions changed
+- update this `README.md` if the Codex vs legacy usage model changes
+
+---
 
 ## License
 
 The code in this repo is licensed under the [MIT](LICENSE) license.
 
+---
+
 ## Trademarks
 
-This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft
-trademarks or logos is subject to and must follow
-[Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/legal/intellectualproperty/trademarks/usage/general).
-Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
-Any use of third-party trademarks or logos are subject to those third-party's policies.
+This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft trademarks or logos is subject to and must follow [Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/legal/intellectualproperty/trademarks/usage/general).
+
+Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship. Any use of third-party trademarks or logos are subject to those third-party's policies.

--- a/plugins/canvas-apps/AGENTS.md
+++ b/plugins/canvas-apps/AGENTS.md
@@ -1,16 +1,16 @@
 # AGENTS.md — Canvas Apps Plugin
 
-This file provides guidance to AI Agents when working with the **canvas-apps** plugin.
+This file provides guidance to AI agents when working with the **canvas-apps** plugin as Codex skills.
 
 ## What This Plugin Is
 
 A plugin for authoring Power Apps Canvas Apps. The Canvas Authoring MCP server (`CanvasAuthoringMcpServer`) exposes tools that agents use to generate, validate, and compile Canvas App YAML files (`.pa.yaml`) in conjunction with a running coauthoring studio session.
 
-Skills orchestrate specialist agents via the `Task` tool. Agents are not invoked directly by users.
+For Codex, run these workflows in a single agent by default. Do not depend on specialist sub-agents unless the user explicitly asks for delegated work.
 
 ## Local Development
 
-Test this plugin locally:
+For Codex, symlink or copy the relevant `skills/*` folder into `$CODEX_HOME/skills`. For the legacy packaging, you can still test the plugin locally with:
 
 ```bash
 claude --plugin-dir /path/to/plugins/canvas-apps
@@ -19,22 +19,22 @@ claude --plugin-dir /path/to/plugins/canvas-apps
 ## Architecture
 
 ```
-.claude-plugin/plugin.json     ← Plugin metadata (name, version, keywords)
+.claude-plugin/plugin.json     ← Legacy plugin metadata
 AGENTS.md                      ← Plugin guidance for AI agents (this file)
 CLAUDE.md                      ← Symlink → AGENTS.md
 references/
   TechnicalGuide.md            ← YAML syntax, control selection, layout strategies, Power Fx patterns
   DesignGuide.md               ← Aesthetic guidelines, anti-patterns, design process
 agents/
-  canvas-app-planner.md        ← Plans app design; invoked by generate-canvas-app (sequential)
-  canvas-screen-builder.md     ← Builds one screen; invoked by generate-canvas-app (parallel)
-  canvas-edit-planner.md       ← Plans complex edits; invoked by edit-canvas-app (sequential)
-  canvas-screen-editor.md      ← Applies edits to one screen; invoked by edit-canvas-app (parallel)
+  canvas-app-planner.md        ← Legacy persona reference for planning
+  canvas-screen-builder.md     ← Legacy persona reference for screen building
+  canvas-edit-planner.md       ← Legacy persona reference for edit planning
+  canvas-screen-editor.md      ← Legacy persona reference for screen editing
 skills/
   configure-canvas-mcp/
-    SKILL.md                   ← Registers the Canvas Authoring MCP server with Claude Code
+    SKILL.md                   ← Registers the Canvas Authoring MCP server
   generate-canvas-app/
-    SKILL.md                   ← Orchestrates canvas-app-planner + canvas-screen-builder agents
+    SKILL.md                   ← Generates a complete Canvas App in a single Codex workflow
   edit-canvas-app/
     SKILL.md                   ← Edits pa.yaml source files for an existing Canvas App
   add-data-source/
@@ -45,21 +45,19 @@ skills/
 
 | Skill | Description |
 |-------|-------------|
-| `/configure-canvas-mcp` | Register the Canvas Authoring MCP server with Claude Code |
-| `/generate-canvas-app` | Generate a complete Canvas App from a natural language description |
-| `/edit-canvas-app` | Edit an existing Canvas App from a natural language description of changes |
-| `/add-data-source` | Guide the user to add a data source, connection, or API connector in Studio, then verify it is available |
+| `configure-canvas-mcp` | Register the Canvas Authoring MCP server |
+| `generate-canvas-app` | Generate a complete Canvas App from a natural language description |
+| `edit-canvas-app` | Edit an existing Canvas App from a natural language description of changes |
+| `add-data-source` | Guide the user to add a data source, connection, or API connector in Studio, then verify it is available |
 
-## Agents
+## Codex Translation Layer
 
-Agents are invoked by skills via the `Task` tool — they are not user-invocable.
+Some legacy files still mention Claude-specific orchestration. Translate them this way in Codex:
 
-| Agent | Invoked By | Description |
-|-------|-----------|-------------|
-| `canvas-app-planner` | `generate-canvas-app` | Discovers resources, designs the app, presents plan for approval, writes plan document |
-| `canvas-screen-builder` | `generate-canvas-app` | Writes YAML for one screen based on the plan; runs in parallel with other builders; app validation/compilation is performed later by `generate-canvas-app` using `compile_canvas` |
-| `canvas-edit-planner` | `edit-canvas-app` | Reads existing .pa.yaml files, plans complex edits, presents edit plan for approval, writes canvas-edit-plan.md |
-| `canvas-screen-editor` | `edit-canvas-app` | Applies targeted edits to one screen's .pa.yaml; runs in parallel with other editors |
+- `Task` or specialist agents means do the work in the main Codex agent
+- `AskUserQuestion` means ask the user directly in a short plain-text message
+- `TaskCreate` / `TaskUpdate` / `TaskList` mean maintain progress with `update_plan`
+- `${CLAUDE_PLUGIN_ROOT}` means the `plugins/canvas-apps` directory
 
 ## MCP Tools
 

--- a/plugins/canvas-apps/skills/add-data-source/SKILL.md
+++ b/plugins/canvas-apps/skills/add-data-source/SKILL.md
@@ -3,6 +3,11 @@ name: add-data-source
 description: Guide the user to add a data source, connection, or API connector to a Canvas App via Power Apps Studio, then verify and continue. USE WHEN the user asks to add a data source, add a connection, add an API, add a connector, connect to SharePoint / Dataverse / SQL / Excel / OneDrive / Teams / Office 365, or any similar request to make new data available to the app. DO NOT USE WHEN the user is asking to list or describe existing data sources — call list_data_sources or list_apis directly instead.
 ---
 
+## Codex Notes
+
+- Ask the user directly in chat whenever you are waiting for them to complete Studio steps.
+- Keep the workflow in the main Codex agent; this skill is primarily a guide-and-verify loop.
+
 Data sources, connections, and API connectors cannot be added by the coding agent — they must be added through the Power Apps Studio interface. This skill informs the user, guides them to add the connection in their Studio session, verifies it is available via the MCP server, and then continues with any pending work.
 
 ## Phase 0 — Identify the Connection Type

--- a/plugins/canvas-apps/skills/add-data-source/SKILL.md
+++ b/plugins/canvas-apps/skills/add-data-source/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: add-data-source
-version: 1.0.0
 description: Guide the user to add a data source, connection, or API connector to a Canvas App via Power Apps Studio, then verify and continue. USE WHEN the user asks to add a data source, add a connection, add an API, add a connector, connect to SharePoint / Dataverse / SQL / Excel / OneDrive / Teams / Office 365, or any similar request to make new data available to the app. DO NOT USE WHEN the user is asking to list or describe existing data sources — call list_data_sources or list_apis directly instead.
-author: Microsoft Corporation
-user-invocable: false
-allowed-tools: AskUserQuestion, mcp__canvas-authoring__list_data_sources, mcp__canvas-authoring__list_apis, mcp__canvas-authoring__get_data_source_schema, mcp__canvas-authoring__describe_api
 ---
 
 Data sources, connections, and API connectors cannot be added by the coding agent — they must be added through the Power Apps Studio interface. This skill informs the user, guides them to add the connection in their Studio session, verifies it is available via the MCP server, and then continues with any pending work.
@@ -35,7 +31,7 @@ Explain that this step requires action in their Studio session. Tell the user:
 
 ## Phase 2 — Wait for Confirmation
 
-Use `AskUserQuestion` to pause until the user has completed the steps in Studio:
+Ask the user directly to reply when they have completed the steps in Studio:
 
 > "Please add the data source or connection in your Power Apps Studio session. Reply here when it's ready and I'll verify the connection before continuing."
 
@@ -58,7 +54,7 @@ Scan the results for the connection the user added:
 2. Check that their Studio session is still active (the MCP server must be connected to a live coauthoring session).
 3. Let you know when ready to try again.
 
-Use `AskUserQuestion` to wait for their follow-up, then re-run Phase 3.
+Ask the user to confirm when ready, then re-run Phase 3.
 
 ## Phase 4 — Continue
 

--- a/plugins/canvas-apps/skills/configure-canvas-mcp/SKILL.md
+++ b/plugins/canvas-apps/skills/configure-canvas-mcp/SKILL.md
@@ -1,15 +1,11 @@
 ---
 name: configure-canvas-mcp
-version: 1.0.0
-description: Configure the Canvas Authoring MCP server for Claude Code, VS Code Copilot, or GitHub Copilot CLI. USE WHEN "configure MCP", "set up MCP server", "MCP not working", "connect Canvas Apps MCP", "canvas-authoring not available", "MCP not configured", "set up canvas apps". DO NOT USE WHEN prerequisites are missing — direct the user to install .NET 10 SDK first.
-author: Microsoft Corporation
-user-invocable: true
-allowed-tools: Bash, AskUserQuestion, Read, Edit, Write
+description: Configure the Canvas Authoring MCP server for Codex, Claude Code, VS Code Copilot, or GitHub Copilot CLI. Use when the user asks to configure MCP, set up the canvas-authoring server, or troubleshoot Canvas Apps MCP access. Do not use when prerequisites are missing.
 ---
 
 # Configure the Canvas Authoring MCP Server
 
-This skill registers the Canvas Authoring MCP server with Claude Code, VS Code Copilot, or GitHub Copilot CLI using the user's Power Platform environment ID.
+This skill registers the Canvas Authoring MCP server using the user's Power Platform environment ID. When the target tool is Codex, reuse the same server command and environment variables in the user's Codex MCP configuration.
 
 ## Instructions
 
@@ -29,17 +25,18 @@ Then wait for the user to install it before continuing. If they say it's install
 
 ### 1. Determine which tool to configure
 
-Determine whether the user needs to configure MCP for VS Code Copilot, GitHub Copilot CLI, or Claude Code:
+Determine whether the user needs to configure MCP for Codex, VS Code Copilot, GitHub Copilot CLI, or Claude Code:
 - If explicitly mentioned in prompt, use that.
 - Otherwise, determine which tool the user is running from the context.
 - Only if choosing based on the context is impossible, ask the user:
 
 > Which tool would you like to configure the Canvas Authoring (canvas-authoring) MCP server for?
-> 1. **VS Code Copilot**
-> 2. **GitHub Copilot CLI**
-> 3. **Claude**
+> 1. **Codex**
+> 2. **VS Code Copilot**
+> 3. **GitHub Copilot CLI**
+> 4. **Claude**
 
-Based on the result, set the `TOOL_TYPE` variable to `vscode-copilot`, `copilot`, or `claude`. Store this for use in all subsequent steps.
+Based on the result, set the `TOOL_TYPE` variable to `codex`, `vscode-copilot`, `copilot`, or `claude`. Store this for use in all subsequent steps.
 
 ### 2. Determine the MCP scope
 

--- a/plugins/canvas-apps/skills/configure-canvas-mcp/SKILL.md
+++ b/plugins/canvas-apps/skills/configure-canvas-mcp/SKILL.md
@@ -5,6 +5,11 @@ description: Configure the Canvas Authoring MCP server for Codex, Claude Code, V
 
 # Configure the Canvas Authoring MCP Server
 
+## Codex Notes
+
+- Ask the user directly in chat whenever the workflow needs clarification or approval.
+- When the target tool is Codex, prioritize the Codex-specific registration path; the Claude/Copilot branches remain only for multi-tool support.
+
 This skill registers the Canvas Authoring MCP server using the user's Power Platform environment ID. When the target tool is Codex, reuse the same server command and environment variables in the user's Codex MCP configuration.
 
 ## Instructions

--- a/plugins/canvas-apps/skills/edit-canvas-app/SKILL.md
+++ b/plugins/canvas-apps/skills/edit-canvas-app/SKILL.md
@@ -5,6 +5,11 @@ description: Edit an existing Power Apps canvas app. USE WHEN the user wants to 
 
 # Edit a Canvas App
 
+## Codex Notes
+
+- Use `update_plan` when the requested edit spans multiple phases or multiple screens.
+- Keep the implementation in the main Codex agent unless the user explicitly asks for delegation.
+
 Make the following changes to the existing Canvas App:
 
 $ARGUMENTS

--- a/plugins/canvas-apps/skills/edit-canvas-app/SKILL.md
+++ b/plugins/canvas-apps/skills/edit-canvas-app/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: edit-canvas-app
-version: 2.0.0
 description: Edit an existing Power Apps canvas app. USE WHEN the user wants to modify, update, change, or edit an existing Canvas App or pa.yaml files.
-author: Microsoft Corporation
-user-invocable: true
-allowed-tools: Read, Write, Edit, Bash, Task, TaskCreate, TaskUpdate, TaskList, mcp__canvas-authoring__sync_canvas, mcp__canvas-authoring__compile_canvas
 ---
 
 # Edit a Canvas App
@@ -19,7 +15,7 @@ This skill uses two paths depending on edit complexity:
 
 - **Simple edits** (single control/property changes, formula tweaks) — handled inline
 - **Complex edits** (multiple screens, new screens, structural changes, new data sources) —
-  orchestrated via specialist agents: `canvas-edit-planner` + parallel `canvas-screen-editor`
+  planned and implemented directly by the main Codex agent
 
 ---
 
@@ -99,7 +95,7 @@ change the navigation flow across the app.
 
 ## Phase 3a — Simple: Direct Edit
 
-Read `${CLAUDE_PLUGIN_ROOT}/references/TechnicalGuide.md` before making changes.
+Read `plugins/canvas-apps/references/TechnicalGuide.md` before making changes.
 
 Apply the changes directly:
 
@@ -116,65 +112,25 @@ Apply the changes directly:
 
 ## Phase 3b — Complex: Plan
 
-Invoke the `canvas-edit-planner` agent using the `Task` tool.
+Plan the edits directly in the main Codex agent:
 
-Pass a prompt that includes:
-
-- The user's edit requirements: `$ARGUMENTS`
-- The working directory (absolute path where `.pa.yaml` files were synced)
-- The plugin root path: `${CLAUDE_PLUGIN_ROOT}`
-- The list of synced `.pa.yaml` files found in the working directory
-
-Example prompt:
-
-> You are the canvas-edit-planner agent. Plan the following edits to an existing Canvas App:
->
-> [paste $ARGUMENTS here]
->
-> Working directory: [absolute working directory path]
-> Plugin root: ${CLAUDE_PLUGIN_ROOT}
-> Synced files: [list of .pa.yaml filenames]
->
-> Follow the instructions in your agent file. Write canvas-edit-plan.md to the working
-> directory. Return the list of screens to modify/add and the plan document path when complete.
-
-**Wait for the planner to finish.** The planner will present the edit plan to the user via
-plan mode and wait for approval before returning. Do not proceed to Phase 4 until the planner
-task completes successfully.
+1. Read `plugins/canvas-apps/references/TechnicalGuide.md`
+2. Review the synced `.pa.yaml` files
+3. Create a concise plan with `update_plan`
+4. Present the edit plan to the user when the request is ambiguous, high-impact, or changes multiple screens
+5. Once the plan is settled, move to implementation
 
 ---
 
 ## Phase 4 — Edit (Complex path only)
 
-After the planner completes, read `canvas-edit-plan.md` from the working directory.
+Implement the planned edits directly:
 
-Extract the list of screens to modify and screens to add from the plan's tables.
-
-Invoke one `canvas-screen-editor` agent per affected screen. **Fire all invocations in a
-single message** (parallel execution) — do not wait for one editor to finish before starting
-the next.
-
-For each screen, pass a prompt that includes:
-
-- Screen name (e.g., "Home")
-- Target file name (e.g., "Home.pa.yaml")
-- Action: "Modify" (existing screen) or "Add" (new screen)
-- Absolute path to `canvas-edit-plan.md`
-- Working directory
-
-Example prompt per screen:
-
-> You are the canvas-screen-editor agent. [Modify / Add] the **[Screen Name]** screen.
->
-> - Action: [Modify / Add]
-> - Target file: [ScreenName].pa.yaml
-> - Plan document: [absolute path to canvas-edit-plan.md]
-> - Working directory: [absolute working directory path]
->
-> Follow the instructions in your agent file. [Edit / Write] [ScreenName].pa.yaml and return
-> your result when done. Do not call compile_canvas — validation is handled by the skill.
-
-Wait for all screen-editor tasks to complete before proceeding.
+1. Modify existing screen files in place
+2. Create any new screen files that are required
+3. Keep `App.pa.yaml` in sync with screen additions or navigation changes
+4. When a new data source is required, pause and direct the user to the `add-data-source` workflow before continuing
+5. Keep edits grouped so the next compile pass validates the full batch of related changes
 
 ---
 
@@ -199,9 +155,6 @@ Track how many `compile_canvas` passes were needed.
 ---
 
 ## Phase 6 — Summary
-
-Delete `canvas-edit-plan.md` from the working directory using `Bash`:
-`rm <working-directory>/canvas-edit-plan.md`
 
 Present a final summary:
 

--- a/plugins/canvas-apps/skills/generate-canvas-app/SKILL.md
+++ b/plugins/canvas-apps/skills/generate-canvas-app/SKILL.md
@@ -5,6 +5,11 @@ description: Generate a complete, visually distinctive Power Apps canvas app wit
 
 # Generate a Canvas App
 
+## Codex Notes
+
+- Use `update_plan` for the main phases of planning, generation, validation, and iteration.
+- Keep the implementation in the main Codex agent unless the user explicitly asks for delegation.
+
 Generate a complete Power Apps canvas app for the following requirements:
 
 $ARGUMENTS

--- a/plugins/canvas-apps/skills/generate-canvas-app/SKILL.md
+++ b/plugins/canvas-apps/skills/generate-canvas-app/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: generate-canvas-app
-version: 2.0.0
 description: Generate a complete, visually distinctive Power Apps canvas app with YAML. USE WHEN the user wants to create, build, or generate a Canvas App or pa.yaml files.
-author: Microsoft Corporation
-user-invocable: true
-allowed-tools: Read, Write, Edit, Bash, Task, TaskCreate, TaskUpdate, TaskList, mcp__canvas-authoring__compile_canvas
 ---
 
 # Generate a Canvas App
@@ -15,15 +11,8 @@ $ARGUMENTS
 
 ## Overview
 
-This skill orchestrates two specialist agents:
-
-1. **`canvas-app-planner`** — discovers available controls and data sources, designs the app,
-   presents a screen plan for your approval, then writes a shared plan document
-2. **`canvas-screen-builder`** — writes exactly one screen's YAML; multiple builders run in
-   parallel after the plan is approved
-
-You (the skill) coordinate the agents and own the compilation + error-fixing loop after all
-screens are written.
+This skill runs as a single Codex workflow. Plan the app, write the `.pa.yaml` files directly,
+compile them with `compile_canvas`, and iterate until the app validates cleanly.
 
 ---
 
@@ -36,74 +25,50 @@ Before planning, derive a short folder name from the user's requirements:
 3. Create the folder using `Bash`: `mkdir -p <folder-name>`
 4. Resolve its absolute path — this is the **working directory** for all subsequent phases
 
-Pass this absolute path as the working directory in every agent prompt below.
-
 ---
 
 ## Phase 1 — Plan
 
-Invoke the `canvas-app-planner` agent using the `Task` tool.
+Read these references before planning:
 
-Pass a prompt that includes:
+- `plugins/canvas-apps/references/TechnicalGuide.md`
+- `plugins/canvas-apps/references/DesignGuide.md`
 
-- The user's requirements: `$ARGUMENTS`
-- The working directory (the absolute path resolved in Phase 0)
-- The plugin root path: `${CLAUDE_PLUGIN_ROOT}`
+Then do the planning work directly:
 
-Example prompt:
+1. Inspect available building blocks with MCP tools as needed:
+   - `list_controls` for control availability
+   - `list_data_sources` and `list_apis` for available data
+   - `describe_control`, `describe_api`, or `get_data_source_schema` for anything you intend to use
+2. Create a short implementation plan with `update_plan`
+3. Produce a concrete screen plan in the conversation:
+   - screen name
+   - purpose
+   - important controls
+   - data sources or collections
+   - notable formulas or interactions
+4. If the requirements are ambiguous or the app has meaningful product choices, ask the user to approve or adjust the screen plan before writing files
+5. Write `App.pa.yaml` and one `.pa.yaml` file per screen into the working directory
 
-> You are the canvas-app-planner agent. Plan a Canvas App for the following requirements:
->
-> [paste $ARGUMENTS here]
->
-> Working directory: [absolute path from Phase 0]
-> Plugin root: ${CLAUDE_PLUGIN_ROOT}
->
-> Follow the instructions in your agent file. Write canvas-app-plan.md and App.pa.yaml to
-> the working directory. Return the screen list and plan document path when complete.
-
-**Wait for the planner to finish.** The planner will present the screen plan to the user via
-plan mode and wait for approval before returning. Do not proceed to Phase 2 until the planner
-task completes successfully.
+Do not depend on planner or builder sub-agents.
 
 ---
 
 ## Phase 2 — Build
 
-After the planner completes, read `canvas-app-plan.md` from the working directory.
+Implement the app directly in the working directory:
 
-Extract the screen list from the `## Screens` table — collect each screen name and its
-target file name.
-
-Invoke one `canvas-screen-builder` agent per screen. **Fire all invocations in a single
-message** (parallel execution) — do not wait for one screen to finish before starting the next.
-
-For each screen, pass a prompt that includes:
-
-- Screen name (e.g., "Home")
-- Target file name (e.g., "Home.pa.yaml")
-- Absolute path to `canvas-app-plan.md`
-- Working directory
-
-Example prompt per screen:
-
-> You are the canvas-screen-builder agent. Implement the **[Screen Name]** screen.
->
-> - Target file: [ScreenName].pa.yaml
-> - Plan document: [absolute path to canvas-app-plan.md]
-> - Working directory: [absolute path from Phase 0]
->
-> Follow the instructions in your agent file. Write [ScreenName].pa.yaml and return your
-> result when done. Do not call compile_canvas — validation is handled by the skill.
-
-Wait for all screen-builder tasks to complete before proceeding.
+1. Create `App.pa.yaml`
+2. Create the planned screen files
+3. Keep formulas, control names, and properties consistent with the technical reference
+4. Reuse a small number of layout patterns instead of inventing incompatible YAML shapes
+5. If the user asked for a distinctive visual treatment, reflect it with control hierarchy, spacing, color, and typography choices that are valid for Canvas Apps
 
 ---
 
 ## Phase 3 — Validate and Fix
 
-After all screen-builders have finished writing their files, call `compile_canvas` on the
-working directory.
+After writing the app files, call `compile_canvas` on the working directory.
 
 **On success:** Proceed to Phase 4.
 
@@ -122,9 +87,6 @@ Track how many `compile_canvas` passes were needed.
 ---
 
 ## Phase 4 — Summary
-
-Delete `canvas-app-plan.md` from the working directory using `Bash`:
-`rm <working-directory>/canvas-app-plan.md`
 
 Present a final summary:
 

--- a/plugins/code-apps/AGENTS.md
+++ b/plugins/code-apps/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md — Power Apps Plugin
 
-This file provides guidance to AI Agents when working with the **power-apps** plugin.
+This file provides guidance to AI agents when working with the **code-apps** plugin as Codex skills.
 
 ## What This Plugin Is
 
@@ -8,7 +8,7 @@ A plugin for building and deploying Power Apps code apps using React + Vite + Ty
 
 ## Local Development
 
-Test this plugin locally:
+For Codex, symlink or copy the relevant `skills/*` folder into `$CODEX_HOME/skills`. For the legacy packaging, you can still test the plugin locally with:
 
 ```bash
 claude --plugin-dir /path/to/plugins/power-apps
@@ -17,7 +17,7 @@ claude --plugin-dir /path/to/plugins/power-apps
 ## Architecture
 
 ```
-.claude-plugin/plugin.json        <- Plugin metadata (name, version, keywords)
+.claude-plugin/plugin.json        <- Legacy plugin metadata
 AGENTS.md                         <- Plugin guidance for AI agents (this file)
 agents/
   code-app-architect.md           <- Agent persona for architecture decisions
@@ -67,19 +67,29 @@ skills/
 
 | Skill | Description |
 |-------|-------------|
-| `/create-code-app` | Scaffold, configure, and deploy a new Power Apps code app |
-| `/deploy` | Build and deploy an existing code app |
-| `/list-connections` | List Power Platform connections to find connection IDs |
-| `/add-datasource` | Add a data source (routes to the appropriate add-* skill) |
-| `/add-dataverse` | Add Dataverse tables with generated TypeScript models and services |
-| `/add-sharepoint` | Add SharePoint Online connector |
-| `/add-azuredevops` | Add Azure DevOps connector |
-| `/add-teams` | Add Microsoft Teams connector |
-| `/add-excel` | Add Excel Online (Business) connector |
-| `/add-onedrive` | Add OneDrive for Business connector |
-| `/add-office365` | Add Office 365 Outlook connector |
-| `/add-mcscopilot` | Add Copilot Studio agent connector |
-| `/add-connector` | Add any other Power Platform connector |
+| `create-code-app` | Scaffold, configure, and deploy a new Power Apps code app |
+| `deploy` | Build and deploy an existing code app |
+| `list-connections` | List Power Platform connections to find connection IDs |
+| `add-datasource` | Add a data source and route to the appropriate add-* workflow |
+| `add-dataverse` | Add Dataverse tables with generated TypeScript models and services |
+| `add-sharepoint` | Add SharePoint Online connector |
+| `add-azuredevops` | Add Azure DevOps connector |
+| `add-teams` | Add Microsoft Teams connector |
+| `add-excel` | Add Excel Online (Business) connector |
+| `add-onedrive` | Add OneDrive for Business connector |
+| `add-office365` | Add Office 365 Outlook connector |
+| `add-mcscopilot` | Add Copilot Studio agent connector |
+| `add-connector` | Add any other Power Platform connector |
+
+## Codex Translation Layer
+
+Some skill bodies still use Claude-era terms. Interpret them this way in Codex:
+
+- `${CLAUDE_PLUGIN_ROOT}` means the `plugins/code-apps` directory
+- `AskUserQuestion` means ask a short plain-text question directly
+- `TaskCreate` / `TaskUpdate` / `TaskList` mean maintain progress with `update_plan`
+- `EnterPlanMode` / `ExitPlanMode` mean enter or leave a normal Codex planning step
+- `/add-*` means open the sibling skill folder and follow that workflow
 
 ## Key Concepts
 
@@ -115,7 +125,7 @@ npx degit microsoft/PowerAppsCodeApps/templates/vite {folder} --force
 
 After modifying this plugin:
 
-1. Run `claude --debug` to see plugin loading details
-2. Test skill invocation with `/create-code-app`
+1. For legacy packaging, run `claude --debug` to see plugin loading details
+2. Test the `create-code-app` workflow from Codex or the legacy `/create-code-app` entrypoint
 3. Verify connector-first guardrails are enforced
 4. Test Windows CLI compatibility (`pac` via `pwsh`)

--- a/plugins/code-apps/skills/add-azuredevops/SKILL.md
+++ b/plugins/code-apps/skills/add-azuredevops/SKILL.md
@@ -7,6 +7,11 @@ description: Adds Azure DevOps connector to a Power Apps code app. Use when quer
 
 # Add Azure DevOps
 
+## Codex Notes
+
+- Ask the user directly in chat whenever the workflow needs clarification or approval.
+- Treat `/list-connections` as the sibling skill workflow in this plugin.
+
 ## Workflow
 
 1. Check Memory Bank → 2. Add Connector → 3. Apply HttpRequest Fix → 4. Configure → 5. Build → 6. Update Memory Bank

--- a/plugins/code-apps/skills/add-azuredevops/SKILL.md
+++ b/plugins/code-apps/skills/add-azuredevops/SKILL.md
@@ -1,12 +1,9 @@
 ---
 name: add-azuredevops
 description: Adds Azure DevOps connector to a Power Apps code app. Use when querying work items, creating bugs, managing pipelines, or making ADO API calls.
-user-invocable: true
-allowed-tools: Read, Edit, Write, Grep, Glob, Bash, LSP, TaskCreate, TaskUpdate, TaskList, TaskGet, AskUserQuestion, Skill
-model: sonnet
 ---
 
-**📋 Shared Instructions: [shared-instructions.md](${CLAUDE_PLUGIN_ROOT}/shared/shared-instructions.md)** - Cross-cutting concerns.
+**📋 Shared Instructions: [shared-instructions.md](../../shared/shared-instructions.md)** - Cross-cutting concerns.
 
 # Add Azure DevOps
 
@@ -18,11 +15,11 @@ model: sonnet
 
 ### Step 1: Check Memory Bank
 
-Check for `memory-bank.md` per [shared-instructions.md](${CLAUDE_PLUGIN_ROOT}/shared/shared-instructions.md).
+Check for `memory-bank.md` per [shared-instructions.md](../../shared/shared-instructions.md).
 
 ### Step 2: Add Connector
 
-**First, find the connection ID** (see [connector-reference.md](${CLAUDE_PLUGIN_ROOT}/shared/connector-reference.md)):
+**First, find the connection ID** (see [connector-reference.md](../../shared/connector-reference.md)):
 
 Run the `/list-connections` skill. Find the Azure DevOps connection in the output. If none exists, direct the user to create one using the environment-specific Connections URL — construct it from the active environment ID in context (from `power.config.json` or a prior step): `https://make.powerapps.com/environments/<environment-id>/connections` → **+ New connection** → search for the connector → Create.
 
@@ -94,7 +91,7 @@ await AzureDevOpsService.HttpRequest({
 
 Docs: [Azure DevOps REST API](https://learn.microsoft.com/en-us/rest/api/azure/devops/?view=azure-devops-rest-7.2)
 
-Use `Grep` to find specific methods in `src/generated/services/AzureDevOpsService.ts` (generated files can be very large -- see [connector-reference.md](${CLAUDE_PLUGIN_ROOT}/shared/connector-reference.md#inspecting-large-generated-files)).
+Use `Grep` to find specific methods in `src/generated/services/AzureDevOpsService.ts` (generated files can be very large -- see [connector-reference.md](../../shared/connector-reference.md#inspecting-large-generated-files)).
 
 ### Step 5: Build
 

--- a/plugins/code-apps/skills/add-connector/SKILL.md
+++ b/plugins/code-apps/skills/add-connector/SKILL.md
@@ -1,12 +1,9 @@
 ---
 name: add-connector
 description: Adds any Power Platform connector to a Power Apps code app. Generic fallback for connectors not covered by a specific skill.
-user-invocable: true
-allowed-tools: Read, Edit, Write, Grep, Glob, Bash, LSP, TaskCreate, TaskUpdate, TaskList, TaskGet, AskUserQuestion, Skill
-model: sonnet
 ---
 
-**📋 Shared Instructions: [shared-instructions.md](${CLAUDE_PLUGIN_ROOT}/shared/shared-instructions.md)** - Cross-cutting concerns.
+**📋 Shared Instructions: [shared-instructions.md](../../shared/shared-instructions.md)** - Cross-cutting concerns.
 
 # Add Connector (Generic)
 
@@ -28,7 +25,7 @@ Fallback skill for any connector not covered by a specific `/add-*` skill. For c
 
 ### Step 1: Check Memory Bank
 
-Check for `memory-bank.md` per [shared-instructions.md](${CLAUDE_PLUGIN_ROOT}/shared/shared-instructions.md).
+Check for `memory-bank.md` per [shared-instructions.md](../../shared/shared-instructions.md).
 
 ### Step 2: Identify Connector
 
@@ -59,7 +56,7 @@ Common connector API names:
 
 ### Step 3: Add Connector
 
-**First, find the connection ID** (see [connector-reference.md](${CLAUDE_PLUGIN_ROOT}/shared/connector-reference.md)):
+**First, find the connection ID** (see [connector-reference.md](../../shared/connector-reference.md)):
 
 Run the `/list-connections` skill. Find the connector in the output. If none exists, direct the user to create one using the environment-specific Connections URL — construct it from the active environment ID in context (from `power.config.json` or a prior step): `https://make.powerapps.com/environments/<environment-id>/connections` → **+ New connection** → search for the connector → Create.
 

--- a/plugins/code-apps/skills/add-connector/SKILL.md
+++ b/plugins/code-apps/skills/add-connector/SKILL.md
@@ -7,6 +7,11 @@ description: Adds any Power Platform connector to a Power Apps code app. Generic
 
 # Add Connector (Generic)
 
+## Codex Notes
+
+- Ask the user directly in chat whenever the workflow needs clarification or approval.
+- Treat `/add-*` references as sibling skill workflows in this plugin.
+
 Fallback skill for any connector not covered by a specific `/add-*` skill. For common connectors, prefer the dedicated skills:
 
 - `/add-dataverse` -- Dataverse tables

--- a/plugins/code-apps/skills/add-datasource/SKILL.md
+++ b/plugins/code-apps/skills/add-datasource/SKILL.md
@@ -1,12 +1,9 @@
 ---
 name: add-datasource
 description: Adds a data source or connector to a Power Apps code app. Asks what the user wants to accomplish and routes to the appropriate specialized skill.
-user-invocable: true
-allowed-tools: Read, Edit, Write, Grep, Glob, Bash, LSP, TaskCreate, TaskUpdate, TaskList, TaskGet, AskUserQuestion, Skill
-model: sonnet
 ---
 
-**📋 Shared Instructions: [shared-instructions.md](${CLAUDE_PLUGIN_ROOT}/shared/shared-instructions.md)** - Cross-cutting concerns.
+**📋 Shared Instructions: [shared-instructions.md](../../shared/shared-instructions.md)** - Cross-cutting concerns.
 
 # Add Data Source
 
@@ -16,7 +13,7 @@ Router skill that understands the user's goal and connects them to the right dat
 
 ### Check Memory Bank
 
-Check for `memory-bank.md` per [shared-instructions.md](${CLAUDE_PLUGIN_ROOT}/shared/shared-instructions.md).
+Check for `memory-bank.md` per [shared-instructions.md](../../shared/shared-instructions.md).
 
 ### Understand the Goal
 

--- a/plugins/code-apps/skills/add-datasource/SKILL.md
+++ b/plugins/code-apps/skills/add-datasource/SKILL.md
@@ -7,6 +7,11 @@ description: Adds a data source or connector to a Power Apps code app. Asks what
 
 # Add Data Source
 
+## Codex Notes
+
+- Ask the user directly in chat whenever the workflow needs clarification or approval.
+- Treat `/add-*` references as sibling skill workflows in this plugin.
+
 Router skill that understands the user's goal and connects them to the right data source -- without requiring them to know Power Platform terminology.
 
 ## Workflow

--- a/plugins/code-apps/skills/add-dataverse/SKILL.md
+++ b/plugins/code-apps/skills/add-dataverse/SKILL.md
@@ -3,6 +3,8 @@ name: add-dataverse
 description: Adds Dataverse tables to a Power Apps code app with generated TypeScript models and services. Can also create new Dataverse tables. Use when connecting to Dataverse, adding tables, creating schema, or querying Dataverse data.
 ---
 
+> **Plugin check**: Run `node "../../scripts/check-version.js"` from the plugin root — if it outputs a message, show it to the user before proceeding.
+
 **📋 Shared Instructions: [shared-instructions.md](../../shared/shared-instructions.md)** - Cross-cutting concerns.
 
 **References:**
@@ -13,6 +15,12 @@ description: Adds Dataverse tables to a Power Apps code app with generated TypeS
 - [data-architecture-reference.md](./references/data-architecture-reference.md) - Relationship types, dependency tiers
 
 # Add Dataverse
+
+## Codex Notes
+
+- Use `update_plan` to track the major workflow phases for this skill.
+- Ask the user directly in chat whenever the workflow needs clarification or approval.
+- Present plans in normal chat and get approval there; do not rely on legacy plan-mode wording.
 
 Two paths: **existing tables** (skip to Step 5) or **new tables** (full workflow).
 
@@ -36,8 +44,8 @@ Check memory bank for project context. Ask the user:
 - Ask about the data they need and design an appropriate schema
 - Use standard Dataverse tables when appropriate (`contact` for people, `account` for organizations)
 - Build a dependency graph -- see [data-architecture-reference.md](./references/data-architecture-reference.md) for tier classification
-- Enter plan mode with `EnterPlanMode`, present ER model with tables, columns, relationships, and creation order
-- Get approval with `ExitPlanMode`
+- Present the ER model in chat with tables, columns, relationships, and creation order
+- Get approval before continuing
 
 ### Step 2: Setup API Auth (if creating tables)
 
@@ -65,7 +73,7 @@ $existingTables = Invoke-RestMethod -Uri "$baseUrl/EntityDefinitions?`$filter=Is
 
 See [table-management-reference.md](./references/table-management-reference.md) for `Find-SimilarTables`, `Compare-TableSchemas`, and `Build-TableNameMapping` functions.
 
-Present findings to user with `AskUserQuestion`:
+Present findings to the user directly and confirm which path to take:
 
 - Tables that can be **reused** (already exist with matching columns)
 - Tables that need **extension** (exist but missing columns)

--- a/plugins/code-apps/skills/add-dataverse/SKILL.md
+++ b/plugins/code-apps/skills/add-dataverse/SKILL.md
@@ -1,12 +1,9 @@
 ---
 name: add-dataverse
 description: Adds Dataverse tables to a Power Apps code app with generated TypeScript models and services. Can also create new Dataverse tables. Use when connecting to Dataverse, adding tables, creating schema, or querying Dataverse data.
-user-invocable: true
-allowed-tools: Read, Edit, Write, Grep, Glob, Bash, LSP, TaskCreate, TaskUpdate, TaskList, TaskGet, AskUserQuestion, Skill, EnterPlanMode, ExitPlanMode
-model: opus
 ---
 
-**📋 Shared Instructions: [shared-instructions.md](${CLAUDE_PLUGIN_ROOT}/shared/shared-instructions.md)** - Cross-cutting concerns.
+**📋 Shared Instructions: [shared-instructions.md](../../shared/shared-instructions.md)** - Cross-cutting concerns.
 
 **References:**
 

--- a/plugins/code-apps/skills/add-excel/SKILL.md
+++ b/plugins/code-apps/skills/add-excel/SKILL.md
@@ -1,12 +1,9 @@
 ---
 name: add-excel
 description: Adds Excel Online (Business) connector to a Power Apps code app. Use when reading or writing Excel workbook data from OneDrive or SharePoint.
-user-invocable: true
-allowed-tools: Read, Edit, Write, Grep, Glob, Bash, LSP, TaskCreate, TaskUpdate, TaskList, TaskGet, AskUserQuestion, Skill
-model: sonnet
 ---
 
-**📋 Shared Instructions: [shared-instructions.md](${CLAUDE_PLUGIN_ROOT}/shared/shared-instructions.md)** - Cross-cutting concerns.
+**📋 Shared Instructions: [shared-instructions.md](../../shared/shared-instructions.md)** - Cross-cutting concerns.
 
 # Add Excel Online
 
@@ -18,7 +15,7 @@ model: sonnet
 
 ### Step 1: Check Memory Bank
 
-Check for `memory-bank.md` per [shared-instructions.md](${CLAUDE_PLUGIN_ROOT}/shared/shared-instructions.md).
+Check for `memory-bank.md` per [shared-instructions.md](../../shared/shared-instructions.md).
 
 ### Step 2: Gather
 
@@ -30,7 +27,7 @@ Ask the user:
 
 ### Step 3: Add Connector
 
-**First, find the connection ID** (see [connector-reference.md](${CLAUDE_PLUGIN_ROOT}/shared/connector-reference.md)):
+**First, find the connection ID** (see [connector-reference.md](../../shared/connector-reference.md)):
 
 Run the `/list-connections` skill. Find the Excel Online (Business) connection in the output. If none exists, direct the user to create one using the environment-specific Connections URL — construct it from the active environment ID in context (from `power.config.json` or a prior step): `https://make.powerapps.com/environments/<environment-id>/connections` → **+ New connection** → search for the connector → Create.
 
@@ -76,7 +73,7 @@ await ExcelOnlineBusinessService.AddRowIntoTable({
 - For SharePoint, use the site path and drive ID
 - The `body` is a flat key-value object matching column headers -- do NOT wrap in `{ items: ... }`
 
-Use `Grep` to find specific methods in `src/generated/services/ExcelOnlineBusinessService.ts` (generated files can be very large -- see [connector-reference.md](${CLAUDE_PLUGIN_ROOT}/shared/connector-reference.md#inspecting-large-generated-files)).
+Use `Grep` to find specific methods in `src/generated/services/ExcelOnlineBusinessService.ts` (generated files can be very large -- see [connector-reference.md](../../shared/connector-reference.md#inspecting-large-generated-files)).
 
 ### Step 5: Build
 

--- a/plugins/code-apps/skills/add-excel/SKILL.md
+++ b/plugins/code-apps/skills/add-excel/SKILL.md
@@ -7,6 +7,11 @@ description: Adds Excel Online (Business) connector to a Power Apps code app. Us
 
 # Add Excel Online
 
+## Codex Notes
+
+- Ask the user directly in chat whenever the workflow needs clarification or approval.
+- Treat `/list-connections` as the sibling skill workflow in this plugin.
+
 ## Workflow
 
 1. Check Memory Bank → 2. Gather → 3. Add Connector → 4. Configure → 5. Build → 6. Update Memory Bank

--- a/plugins/code-apps/skills/add-mcscopilot/SKILL.md
+++ b/plugins/code-apps/skills/add-mcscopilot/SKILL.md
@@ -7,6 +7,11 @@ description: Adds Microsoft Copilot Studio connector to a Power Apps code app. U
 
 # Add Microsoft Copilot Studio
 
+## Codex Notes
+
+- Ask the user directly in chat whenever the workflow needs clarification or approval.
+- Treat `/list-connections` as the sibling skill workflow in this plugin.
+
 ## Workflow
 
 1. Check Memory Bank → 2. Add Connector → 3. Configure → 4. Build → 5. Update Memory Bank

--- a/plugins/code-apps/skills/add-mcscopilot/SKILL.md
+++ b/plugins/code-apps/skills/add-mcscopilot/SKILL.md
@@ -1,12 +1,9 @@
 ---
 name: add-mcscopilot
 description: Adds Microsoft Copilot Studio connector to a Power Apps code app. Use when invoking Copilot Studio agents, sending prompts to agents, or integrating agent responses.
-user-invocable: true
-allowed-tools: Read, Edit, Write, Grep, Glob, Bash, LSP, TaskCreate, TaskUpdate, TaskList, TaskGet, AskUserQuestion, Skill
-model: sonnet
 ---
 
-**📋 Shared Instructions: [shared-instructions.md](${CLAUDE_PLUGIN_ROOT}/shared/shared-instructions.md)** - Cross-cutting concerns.
+**📋 Shared Instructions: [shared-instructions.md](../../shared/shared-instructions.md)** - Cross-cutting concerns.
 
 # Add Microsoft Copilot Studio
 
@@ -18,11 +15,11 @@ model: sonnet
 
 ### Step 1: Check Memory Bank
 
-Check for `memory-bank.md` per [shared-instructions.md](${CLAUDE_PLUGIN_ROOT}/shared/shared-instructions.md).
+Check for `memory-bank.md` per [shared-instructions.md](../../shared/shared-instructions.md).
 
 ### Step 2: Add Connector
 
-**First, find the connection ID** (see [connector-reference.md](${CLAUDE_PLUGIN_ROOT}/shared/connector-reference.md)):
+**First, find the connection ID** (see [connector-reference.md](../../shared/connector-reference.md)):
 
 Run the `/list-connections` skill. Find the Microsoft Copilot Studio connection in the output. If none exists, direct the user to create one using the environment-specific Connections URL — construct it from the active environment ID in context (from `power.config.json` or a prior step): `https://make.powerapps.com/environments/<environment-id>/connections` → **+ New connection** → search for the connector → Create.
 
@@ -66,7 +63,7 @@ if (agentResponse) {
 }
 ```
 
-Use `Grep` to find specific methods in the generated service file (generated files can be very large — see [connector-reference.md](${CLAUDE_PLUGIN_ROOT}/shared/connector-reference.md#inspecting-large-generated-files)).
+Use `Grep` to find specific methods in the generated service file (generated files can be very large — see [connector-reference.md](../../shared/connector-reference.md#inspecting-large-generated-files)).
 
 #### Known Issues
 

--- a/plugins/code-apps/skills/add-office365/SKILL.md
+++ b/plugins/code-apps/skills/add-office365/SKILL.md
@@ -1,12 +1,9 @@
 ---
 name: add-office365
 description: Adds Office 365 Outlook connector to a Power Apps code app. Use when accessing calendars, sending emails, reading inbox, or managing Outlook events.
-user-invocable: true
-allowed-tools: Read, Edit, Write, Grep, Glob, Bash, LSP, TaskCreate, TaskUpdate, TaskList, TaskGet, AskUserQuestion, Skill
-model: sonnet
 ---
 
-**📋 Shared Instructions: [shared-instructions.md](${CLAUDE_PLUGIN_ROOT}/shared/shared-instructions.md)** - Cross-cutting concerns.
+**📋 Shared Instructions: [shared-instructions.md](../../shared/shared-instructions.md)** - Cross-cutting concerns.
 
 # Add Office 365 Outlook
 
@@ -18,11 +15,11 @@ model: sonnet
 
 ### Step 1: Check Memory Bank
 
-Check for `memory-bank.md` per [shared-instructions.md](${CLAUDE_PLUGIN_ROOT}/shared/shared-instructions.md).
+Check for `memory-bank.md` per [shared-instructions.md](../../shared/shared-instructions.md).
 
 ### Step 2: Add Connector
 
-**First, find the connection ID** (see [connector-reference.md](${CLAUDE_PLUGIN_ROOT}/shared/connector-reference.md)):
+**First, find the connection ID** (see [connector-reference.md](../../shared/connector-reference.md)):
 
 Run the `/list-connections` skill. Find the Office 365 Outlook connection in the output (API name contains `office365`). If none exists, direct the user to create one using the environment-specific Connections URL — construct it from the active environment ID in context (from `power.config.json` or a prior step): `https://make.powerapps.com/environments/<environment-id>/connections` → **+ New connection** → search for the connector → Create.
 

--- a/plugins/code-apps/skills/add-office365/SKILL.md
+++ b/plugins/code-apps/skills/add-office365/SKILL.md
@@ -7,6 +7,11 @@ description: Adds Office 365 Outlook connector to a Power Apps code app. Use whe
 
 # Add Office 365 Outlook
 
+## Codex Notes
+
+- Ask the user directly in chat whenever the workflow needs clarification or approval.
+- Treat `/list-connections` as the sibling skill workflow in this plugin.
+
 ## Workflow
 
 1. Check Memory Bank -> 2. Add Connector -> 3. Review Generated Service -> 4. Configure -> 5. Build -> 6. Update Memory Bank

--- a/plugins/code-apps/skills/add-onedrive/SKILL.md
+++ b/plugins/code-apps/skills/add-onedrive/SKILL.md
@@ -1,12 +1,9 @@
 ---
 name: add-onedrive
 description: Adds OneDrive for Business connector to a Power Apps code app. Use when uploading, downloading, listing, or managing files in OneDrive.
-user-invocable: true
-allowed-tools: Read, Edit, Write, Grep, Glob, Bash, LSP, TaskCreate, TaskUpdate, TaskList, TaskGet, AskUserQuestion, Skill
-model: sonnet
 ---
 
-**📋 Shared Instructions: [shared-instructions.md](${CLAUDE_PLUGIN_ROOT}/shared/shared-instructions.md)** - Cross-cutting concerns.
+**📋 Shared Instructions: [shared-instructions.md](../../shared/shared-instructions.md)** - Cross-cutting concerns.
 
 # Add OneDrive for Business
 
@@ -18,11 +15,11 @@ model: sonnet
 
 ### Step 1: Check Memory Bank
 
-Check for `memory-bank.md` per [shared-instructions.md](${CLAUDE_PLUGIN_ROOT}/shared/shared-instructions.md).
+Check for `memory-bank.md` per [shared-instructions.md](../../shared/shared-instructions.md).
 
 ### Step 2: Add Connector
 
-**First, find the connection ID** (see [connector-reference.md](${CLAUDE_PLUGIN_ROOT}/shared/connector-reference.md)):
+**First, find the connection ID** (see [connector-reference.md](../../shared/connector-reference.md)):
 
 Run the `/list-connections` skill. Find the OneDrive for Business connection in the output. If none exists, direct the user to create one using the environment-specific Connections URL — construct it from the active environment ID in context (from `power.config.json` or a prior step): `https://make.powerapps.com/environments/<environment-id>/connections` → **+ New connection** → search for the connector → Create.
 
@@ -66,7 +63,7 @@ await OneDriveForBusinessService.CreateFile({
 - Use `folderPath` for creating files by path, `id` for accessing existing files
 - Binary file content may need base64 encoding/decoding depending on the operation
 
-Use `Grep` to find specific methods in `src/generated/services/OneDriveForBusinessService.ts` (generated files can be very large -- see [connector-reference.md](${CLAUDE_PLUGIN_ROOT}/shared/connector-reference.md#inspecting-large-generated-files)).
+Use `Grep` to find specific methods in `src/generated/services/OneDriveForBusinessService.ts` (generated files can be very large -- see [connector-reference.md](../../shared/connector-reference.md#inspecting-large-generated-files)).
 
 ### Step 4: Build
 

--- a/plugins/code-apps/skills/add-onedrive/SKILL.md
+++ b/plugins/code-apps/skills/add-onedrive/SKILL.md
@@ -7,6 +7,11 @@ description: Adds OneDrive for Business connector to a Power Apps code app. Use 
 
 # Add OneDrive for Business
 
+## Codex Notes
+
+- Ask the user directly in chat whenever the workflow needs clarification or approval.
+- Treat `/list-connections` as the sibling skill workflow in this plugin.
+
 ## Workflow
 
 1. Check Memory Bank → 2. Add Connector → 3. Configure → 4. Build → 5. Update Memory Bank

--- a/plugins/code-apps/skills/add-sharepoint/SKILL.md
+++ b/plugins/code-apps/skills/add-sharepoint/SKILL.md
@@ -3,6 +3,8 @@ name: add-sharepoint
 description: Adds SharePoint Online connector to a Power Apps code app. Use when reading lists, managing documents, or integrating with SharePoint sites. Can also create new SharePoint lists.
 ---
 
+> **Plugin check**: Run `node "../../scripts/check-version.js"` from the plugin root — if it outputs a message, show it to the user before proceeding.
+
 **📋 Shared Instructions: [shared-instructions.md](../../shared/shared-instructions.md)** - Cross-cutting concerns.
 
 **References:**
@@ -12,6 +14,12 @@ description: Adds SharePoint Online connector to a Power Apps code app. Use when
 - [list-management-reference.md](./references/list-management-reference.md) - Query, create, extend lists and columns
 
 # Add SharePoint
+
+## Codex Notes
+
+- Use `update_plan` to track the major workflow phases for this skill.
+- Ask the user directly in chat whenever the workflow needs clarification or approval.
+- Present plans in normal chat and get approval there instead of relying on legacy plan-mode wording.
 
 Two paths: **existing lists** (skip to Step 6) or **new lists** (full workflow).
 
@@ -38,8 +46,8 @@ Ask the user:
 
 - Ask about the data they need and design an appropriate schema
 - Reuse existing lists when possible (don't duplicate)
-- Enter plan mode with `EnterPlanMode`, present the list designs with columns and types
-- Get approval with `ExitPlanMode`
+- Present the list designs in chat with columns and types
+- Get approval before continuing
 
 ### Step 3: Setup Graph API Auth (if creating lists)
 
@@ -65,7 +73,7 @@ $existingLists = Invoke-RestMethod -Uri "https://graph.microsoft.com/v1.0/sites/
 
 See [list-management-reference.md](./references/list-management-reference.md) for `Find-SimilarLists`, `Compare-ListSchemas`, and `Get-ListSchema` functions.
 
-Present findings to user with `AskUserQuestion`:
+Present findings to the user directly and confirm which path to take:
 
 - Lists that can be **reused** (already exist with matching columns)
 - Lists that need **extension** (exist but missing columns)

--- a/plugins/code-apps/skills/add-sharepoint/SKILL.md
+++ b/plugins/code-apps/skills/add-sharepoint/SKILL.md
@@ -1,12 +1,9 @@
 ---
 name: add-sharepoint
 description: Adds SharePoint Online connector to a Power Apps code app. Use when reading lists, managing documents, or integrating with SharePoint sites. Can also create new SharePoint lists.
-user-invocable: true
-allowed-tools: Read, Edit, Write, Grep, Glob, Bash, LSP, TaskCreate, TaskUpdate, TaskList, TaskGet, AskUserQuestion, Skill, EnterPlanMode, ExitPlanMode
-model: opus
 ---
 
-**📋 Shared Instructions: [shared-instructions.md](${CLAUDE_PLUGIN_ROOT}/shared/shared-instructions.md)** - Cross-cutting concerns.
+**📋 Shared Instructions: [shared-instructions.md](../../shared/shared-instructions.md)** - Cross-cutting concerns.
 
 **References:**
 
@@ -26,7 +23,7 @@ Two paths: **existing lists** (skip to Step 6) or **new lists** (full workflow).
 
 ### Step 1: Check Memory Bank
 
-Check for `memory-bank.md` per [shared-instructions.md](${CLAUDE_PLUGIN_ROOT}/shared/shared-instructions.md).
+Check for `memory-bank.md` per [shared-instructions.md](../../shared/shared-instructions.md).
 
 ### Step 2: Plan
 
@@ -84,7 +81,7 @@ Get explicit confirmation before creating. Use safe functions from [list-managem
 
 ### Step 6: Get Connection ID
 
-Find the SharePoint Online connection ID (see [connector-reference.md](${CLAUDE_PLUGIN_ROOT}/shared/connector-reference.md)):
+Find the SharePoint Online connection ID (see [connector-reference.md](../../shared/connector-reference.md)):
 
 Run the `/list-connections` skill. Find the SharePoint Online connection in the output. If none exists, direct the user to create one using the environment-specific Connections URL — construct it from the active environment ID in context (from `power.config.json` or a prior step): `https://make.powerapps.com/environments/<environment-id>/connections` → **+ New connection** → search for the connector → Create.
 
@@ -173,7 +170,7 @@ const content = await SharePointOnlineService.GetFileContent({
 - Document library operations use folder/file IDs or server-relative URLs
 - Choice columns use **string values**, not integer picklist codes (unlike Dataverse)
 
-Use `Grep` to find specific methods in `src/generated/services/SharePointOnlineService.ts` (generated files can be very large -- see [connector-reference.md](${CLAUDE_PLUGIN_ROOT}/shared/connector-reference.md#inspecting-large-generated-files)).
+Use `Grep` to find specific methods in `src/generated/services/SharePointOnlineService.ts` (generated files can be very large -- see [connector-reference.md](../../shared/connector-reference.md#inspecting-large-generated-files)).
 
 ### Step 11: Build
 

--- a/plugins/code-apps/skills/add-teams/SKILL.md
+++ b/plugins/code-apps/skills/add-teams/SKILL.md
@@ -1,12 +1,9 @@
 ---
 name: add-teams
 description: Adds Microsoft Teams connector to a Power Apps code app. Use when sending Teams messages, posting to channels, or integrating with Teams chat.
-user-invocable: true
-allowed-tools: Read, Edit, Write, Grep, Glob, Bash, LSP, TaskCreate, TaskUpdate, TaskList, TaskGet, AskUserQuestion, Skill
-model: sonnet
 ---
 
-**📋 Shared Instructions: [shared-instructions.md](${CLAUDE_PLUGIN_ROOT}/shared/shared-instructions.md)** - Cross-cutting concerns.
+**📋 Shared Instructions: [shared-instructions.md](../../shared/shared-instructions.md)** - Cross-cutting concerns.
 
 # Add Teams
 
@@ -18,11 +15,11 @@ model: sonnet
 
 ### Step 1: Check Memory Bank
 
-Check for `memory-bank.md` per [shared-instructions.md](${CLAUDE_PLUGIN_ROOT}/shared/shared-instructions.md).
+Check for `memory-bank.md` per [shared-instructions.md](../../shared/shared-instructions.md).
 
 ### Step 2: Add Connector
 
-**First, find the connection ID** (see [connector-reference.md](${CLAUDE_PLUGIN_ROOT}/shared/connector-reference.md)):
+**First, find the connection ID** (see [connector-reference.md](../../shared/connector-reference.md)):
 
 Run the `/list-connections` skill. Find the Teams connection in the output. If none exists, direct the user to create one using the environment-specific Connections URL — construct it from the active environment ID in context (from `power.config.json` or a prior step): `https://make.powerapps.com/environments/<environment-id>/connections` → **+ New connection** → search for the connector → Create.
 
@@ -49,7 +46,7 @@ await TeamsService.PostMessageToConversation({
 });
 ```
 
-Use `Grep` to find specific methods in `src/generated/services/TeamsService.ts` (generated files can be very large -- see [connector-reference.md](${CLAUDE_PLUGIN_ROOT}/shared/connector-reference.md#inspecting-large-generated-files)).
+Use `Grep` to find specific methods in `src/generated/services/TeamsService.ts` (generated files can be very large -- see [connector-reference.md](../../shared/connector-reference.md#inspecting-large-generated-files)).
 
 ### Step 4: Build
 

--- a/plugins/code-apps/skills/add-teams/SKILL.md
+++ b/plugins/code-apps/skills/add-teams/SKILL.md
@@ -7,6 +7,11 @@ description: Adds Microsoft Teams connector to a Power Apps code app. Use when s
 
 # Add Teams
 
+## Codex Notes
+
+- Ask the user directly in chat whenever the workflow needs clarification or approval.
+- Treat `/list-connections` as the sibling skill workflow in this plugin.
+
 ## Workflow
 
 1. Check Memory Bank → 2. Add Connector → 3. Configure → 4. Build → 5. Update Memory Bank

--- a/plugins/code-apps/skills/create-code-app/SKILL.md
+++ b/plugins/code-apps/skills/create-code-app/SKILL.md
@@ -3,6 +3,8 @@ name: create-code-app
 description: Creates Power Apps code apps using React and Vite. Use when building code apps, scaffolding projects, or deploying to Power Platform.
 ---
 
+> **Plugin check**: Run `node "../../scripts/check-version.js"` from the plugin root — if it outputs a message, show it to the user before proceeding.
+
 **📋 Shared Instructions: [shared-instructions.md](../../shared/shared-instructions.md)** - Cross-cutting concerns.
 
 **References:**
@@ -11,6 +13,13 @@ description: Creates Power Apps code apps using React and Vite. Use when buildin
 - [troubleshooting.md](./references/troubleshooting.md) - Common issues, npm scripts, resources
 
 # Create Power Apps Code App
+
+## Codex Notes
+
+- Use `update_plan` to track the major workflow phases for this skill.
+- Ask the user directly in chat whenever the workflow needs clarification or approval.
+- Treat `/add-*` references as the sibling skill workflows in this plugin.
+- Present implementation plans in normal chat and get approval there instead of relying on legacy plan-mode wording.
 
 ## Workflow
 
@@ -71,13 +80,12 @@ Once you have their description:
 
 ### Step 3: Plan
 
-1. Enter plan mode with `EnterPlanMode`
-2. Design the full implementation approach:
+1. Summarize the full implementation approach in chat:
    - Which `/add-*` skills to run for data sources
    - App architecture: components, pages, state management
    - Feature list with priority order
-3. Present plan for approval, include `allowedPrompts` from [prerequisites-reference.md](./references/prerequisites-reference.md)
-4. Exit plan mode with `ExitPlanMode` when approved
+2. Present the plan for approval, including the `allowedPrompts` guidance from [prerequisites-reference.md](./references/prerequisites-reference.md)
+3. Revise if needed, then continue once approved
 
 ### Step 4: Auth & Select Environment
 
@@ -118,7 +126,7 @@ npm install
 
 **Notes:**
 
-- Use `--force` to overwrite if the directory already has files (e.g., `.claude` from a planning session)
+- Use `--force` to overwrite if the directory already has files (for example `.codex`, `.claude`, or other local planning artifacts)
 - If targeting an existing directory, use `.` as the folder name: `npx degit microsoft/PowerAppsCodeApps/templates/vite . --force`
 - If `npx degit` fails (network issues, npm not found), retry once, then ask the user to run manually
 
@@ -169,7 +177,7 @@ This ensures progress is saved even if the session ends unexpectedly.
 
 ### Step 8: Add Data Sources
 
-Invoke the `/add-*` skills identified in the plan (Step 3). Run each in sequence. **Pass context as arguments** so sub-skills skip redundant questions (project path, connector name, etc.):
+Run the sibling `add-*` skill workflows identified in the plan (Step 3), one at a time. **Pass context as arguments** so follow-on skill runs skip redundant questions (project path, connector name, etc.):
 
 | App needs to...                            | Invoke             |
 | ------------------------------------------ | ------------------ |

--- a/plugins/code-apps/skills/create-code-app/SKILL.md
+++ b/plugins/code-apps/skills/create-code-app/SKILL.md
@@ -1,12 +1,9 @@
 ---
 name: create-code-app
 description: Creates Power Apps code apps using React and Vite. Use when building code apps, scaffolding projects, or deploying to Power Platform.
-user-invocable: true
-allowed-tools: Read, Edit, Write, Grep, Glob, Bash, LSP, TaskCreate, TaskUpdate, TaskList, TaskGet, AskUserQuestion, Skill, EnterPlanMode, ExitPlanMode
-model: opus
 ---
 
-**📋 Shared Instructions: [shared-instructions.md](${CLAUDE_PLUGIN_ROOT}/shared/shared-instructions.md)** - Cross-cutting concerns.
+**📋 Shared Instructions: [shared-instructions.md](../../shared/shared-instructions.md)** - Cross-cutting concerns.
 
 **References:**
 
@@ -23,7 +20,7 @@ model: opus
 
 ### Step 0: Check Memory Bank
 
-Check for `memory-bank.md` per [shared-instructions.md](${CLAUDE_PLUGIN_ROOT}/shared/shared-instructions.md). Skip completed steps.
+Check for `memory-bank.md` per [shared-instructions.md](../../shared/shared-instructions.md). Skip completed steps.
 
 ### Step 1: Validate Prerequisites
 
@@ -103,7 +100,7 @@ After clearing, there is no need to run `auth create`. The tool picks up the sys
 - **Environment matches user's target**: Confirm and proceed.
 - **On a different environment or no target set**: Run `pwsh -NoProfile -Command "pac env list"`, show up to 10 options, let the user pick, and run `pwsh -NoProfile -Command "pac env select --environment <id>"`.
 
-See [preferred-environment.md](${CLAUDE_PLUGIN_ROOT}/shared/preferred-environment.md) for details.
+See [preferred-environment.md](../../shared/preferred-environment.md) for details.
 
 **Critical:** Capture the environment ID for Step 7.
 
@@ -194,7 +191,7 @@ Each `/add-*` skill runs `npm run build` to catch errors. Do NOT deploy yet.
 
 **This is the core step.** Build the actual app features described in the plan from Step 3.
 
-1. **Review generated services**: Use `Grep` to find methods in generated service files (they can be very large -- see [connector-reference.md](${CLAUDE_PLUGIN_ROOT}/shared/connector-reference.md#inspecting-large-generated-files)). Do NOT read entire generated files.
+1. **Review generated services**: Use `Grep` to find methods in generated service files (they can be very large -- see [connector-reference.md](../../shared/connector-reference.md#inspecting-large-generated-files)). Do NOT read entire generated files.
 2. **Build components**: Create React components for each screen/feature in the plan
 3. **Connect data**: Wire components to generated services (use `*Service.getAll()`, `*Service.create()`, etc.)
 4. **Apply theme**: Use the user's theme preference (default: dark theme per development standards)
@@ -204,7 +201,7 @@ Each `/add-*` skill runs `npm run build` to catch errors. Do NOT deploy yet.
 **Key rules:**
 
 - Use generated services for all data access -- never use fetch/axios directly
-- Read [dataverse-reference.md](${CLAUDE_PLUGIN_ROOT}/skills/add-dataverse/references/dataverse-reference.md) if working with Dataverse (picklist fields, virtual fields, lookups have critical gotchas)
+- Read [dataverse-reference.md](../../skills/add-dataverse/references/dataverse-reference.md) if working with Dataverse (picklist fields, virtual fields, lookups have critical gotchas)
 - Remove unused imports before building (TS6133 strict mode)
 - Don't edit files in `src/generated/` unless fixing known issues
 

--- a/plugins/code-apps/skills/deploy/SKILL.md
+++ b/plugins/code-apps/skills/deploy/SKILL.md
@@ -7,6 +7,10 @@ description: Builds and deploys a Power Apps code app to Power Platform. Use whe
 
 # Deploy
 
+## Codex Notes
+
+- Ask the user directly in chat whenever the workflow needs clarification or approval.
+
 Builds and deploys the app in the current directory to Power Platform.
 
 ## Workflow

--- a/plugins/code-apps/skills/deploy/SKILL.md
+++ b/plugins/code-apps/skills/deploy/SKILL.md
@@ -1,12 +1,9 @@
 ---
 name: deploy
 description: Builds and deploys a Power Apps code app to Power Platform. Use when deploying changes, redeploying an existing app, or pushing updates.
-user-invocable: true
-allowed-tools: Read, Edit, Write, Grep, Glob, Bash
-model: sonnet
 ---
 
-**📋 Shared Instructions: [shared-instructions.md](${CLAUDE_PLUGIN_ROOT}/shared/shared-instructions.md)** - Cross-cutting concerns.
+**📋 Shared Instructions: [shared-instructions.md](../../shared/shared-instructions.md)** - Cross-cutting concerns.
 
 # Deploy
 

--- a/plugins/code-apps/skills/list-connections/SKILL.md
+++ b/plugins/code-apps/skills/list-connections/SKILL.md
@@ -7,6 +7,10 @@ description: Lists Power Platform connections in the current environment. Use wh
 
 # List Connections
 
+## Codex Notes
+
+- Present the results directly in chat and call out the connection IDs the user is likely to need next.
+
 Lists all Power Platform connections in the default environment using the Power Platform CLI (`pac`).
 
 ## Workflow

--- a/plugins/code-apps/skills/list-connections/SKILL.md
+++ b/plugins/code-apps/skills/list-connections/SKILL.md
@@ -1,12 +1,9 @@
 ---
 name: list-connections
 description: Lists Power Platform connections in the current environment. Use when you need a connection ID before adding a connector to a code app.
-user-invocable: true
-allowed-tools: Bash
-model: haiku
 ---
 
-**📋 Shared Instructions: [shared-instructions.md](${CLAUDE_PLUGIN_ROOT}/shared/shared-instructions.md)** - Cross-cutting concerns (Windows CLI compatibility, memory bank, etc.).
+**📋 Shared Instructions: [shared-instructions.md](../../shared/shared-instructions.md)** - Cross-cutting concerns (Windows CLI compatibility, memory bank, etc.).
 
 # List Connections
 

--- a/plugins/model-apps/AGENTS.md
+++ b/plugins/model-apps/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md — Model Apps Plugin
 
-This file provides guidance to AI Agents when working with the **model-apps** plugin.
+This file provides guidance to AI agents when working with the **model-apps** plugin as Codex skills.
 
 ## What This Plugin Is
 
@@ -10,7 +10,7 @@ Single-session workflow — each `/genpage` invocation completes the full cycle:
 
 ## Local Development
 
-Test this plugin locally:
+For Codex, symlink or copy the relevant `skills/*` folder into `$CODEX_HOME/skills`. For the legacy packaging, you can still test the plugin locally with:
 
 ```bash
 claude --plugin-dir /path/to/plugins/model-apps
@@ -19,7 +19,7 @@ claude --plugin-dir /path/to/plugins/model-apps
 ## Architecture
 
 ```
-.claude-plugin/plugin.json     ← Plugin metadata (name, version, keywords)
+.claude-plugin/plugin.json     ← Legacy plugin metadata
 .mcp.json                      ← MCP server config (Playwright for browser verification)
 AGENTS.md                      ← Plugin guidance for AI agents (this file)
 CLAUDE.md                      ← Symlink → AGENTS.md
@@ -31,14 +31,14 @@ scripts/
   launch-playwright-mcp.js     ← Playwright MCP server launcher (detects system browser)
 skills/
   genpage/
-    SKILL.md                   ← Skill definition with frontmatter (model, allowed-tools)
+    SKILL.md                   ← Skill definition
 ```
 
 ## Skills
 
 | Skill | Description |
 |-------|-------------|
-| `/genpage` | Build and deploy a generative page for a model-driven Power App |
+| `genpage` | Build and deploy a generative page for a model-driven Power App |
 
 ## Key Concepts
 
@@ -65,20 +65,20 @@ TypeScript type definitions generated from Dataverse metadata. Contains entity t
 - **Accessibility** — WCAG AA, ARIA labels, keyboard navigation, semantic HTML
 - **Complete code** — no placeholders, TODOs, or ellipses in final output
 
-## Skill Authoring Guidelines
+## Codex Translation Layer
 
-- Keep SKILL.md under 500 lines
-- Use short, descriptive `name` field (e.g., `genpage`)
-- Write descriptions in third person ("Creates X" not "This skill guides you through creating X")
-- Use progressive disclosure: SKILL.md for workflow, reference files for details
-- Link to references inline: `See [troubleshooting.md](../../references/troubleshooting.md)`
+Some skill bodies still use Claude-era terms. Interpret them this way in Codex:
+
+- `AskUserQuestion` means ask the user directly in a short plain-text message
+- `TaskCreate` / `TaskUpdate` / `TaskList` mean maintain progress with `update_plan`
+- `/genpage` means the `genpage` skill
 
 ## Testing Changes
 
 After modifying this plugin:
 
-1. Run `claude --debug` to see plugin loading details
-2. Test skill invocation with `/genpage`
+1. For legacy packaging, run `claude --debug` to see plugin loading details
+2. Test the `genpage` workflow from Codex or the legacy `/genpage` entrypoint
 3. Verify tool restrictions work (should only allow pac, powershell, node commands)
 4. Test with both Dataverse entity pages and mock data pages
 5. Verify Playwright browser verification works (navigate, snapshot, click, screenshot)

--- a/plugins/model-apps/skills/genpage/SKILL.md
+++ b/plugins/model-apps/skills/genpage/SKILL.md
@@ -1,12 +1,6 @@
 ---
 name: genpage
-version: 1.0.0
 description: Creates, updates, and deploys Power Apps generative pages for model-driven apps using React v17, TypeScript, and Fluent UI V9. Completes workflow from requirements to deployment. Uses PAC CLI to deploy the page code. Use it when user asks to build, retrieve, or update a page in an existing Microsoft Power Apps model-driven app. Use it when user mentions "generative page", "page in a model-driven", or "genux".
-author: Microsoft Corporation
-argument-hint: "[optional: page description or 'deploy' or 'update']"
-user-invocable: true
-model: sonnet
-allowed-tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, AskUserQuestion, TaskCreate, TaskUpdate, TaskList
 ---
 
 # Power Apps Generative Pages Builder

--- a/plugins/model-apps/skills/genpage/SKILL.md
+++ b/plugins/model-apps/skills/genpage/SKILL.md
@@ -26,6 +26,12 @@ description: Creates, updates, and deploys Power Apps generative pages for model
 - **Accessibility** — WCAG AA, ARIA labels, keyboard navigation, semantic HTML
 - **Complete code** — no placeholders, TODOs, or ellipses in final output
 
+## Codex Notes
+
+- Use `update_plan` to track the major workflow phases for this skill.
+- Ask the user directly in chat whenever the workflow needs clarification or approval.
+- Treat `/genpage` as this skill's normal invocation name in Codex.
+
 ---
 
 ## Instructions
@@ -89,17 +95,17 @@ Note the output. If multiple languages are configured (or any non-English langua
 
 Ask these questions one at a time:
 
-1. **"Create a new generative page or edit an existing one?"** (use `AskUserQuestion`)
+1. **"Create a new generative page or edit an existing one?"**
    - If new: continue to next question
    - If edit: ask for the app and page to edit, download it with `pac model genpage download --app-id <app-id> --page-id <page-id> --output-directory ./output-dir`, then ask what changes to make
-2. **"Describe the page you'd like to build"** (use `AskUserQuestion`) — present two example descriptions as options and let the user type their own via the "Other" option:
+2. **"Describe the page you'd like to build"** — present two example descriptions as options and let the user type their own via the "Other" option:
    - **Option 1:** "Build a page showing Account records as a gallery of cards using modern look & feel. All cards should have fixed size and tall enough to fit 4 lines of titles. Include name, entityimage on the top and, website, email, phone number. Make the component fill 100% of the space. Make the gallery scrollable. Use data from the Account table. Make each card clickable to open the Account record in a new window. The target URL should be current location path with following query string parameters: pagetype=entityrecord&etn=[entityname]&id=[recordid] where entityname is account and id is accountid."
    - **Option 2:** "Design a vertically scrollable checklist interface for Task records using a clean, flat layout. Each task should be a row with a left-aligned checkbox, subject in bold and right-aligned due date and priority. Use neutral tones for background and soft color tags for priority (e.g., red for High, gray for Low). Completed tasks should show a strikethrough and reduced opacity. Allow inline editing of due date with a date picker. On hover, rows should highlight with another background. Clicking a task opens the Task record in a new window using: pagetype=entityrecord&etn=[entityname]&id=[recordid] where entityname is task and id is related record id."
    - **Other (Recommended):** User types their own description
-3. **"Will the page use Dataverse entities or mock data?"** (use `AskUserQuestion`)
+3. **"Will the page use Dataverse entities or mock data?"**
    - If entities: ask which entities and fields (use logical names — singular, lowercase)
    - If mock data: confirm you'll generate realistic sample data
-4. **"Any specific requirements?"** (use `AskUserQuestion`) — styling, features (search, filtering, sorting), accessibility, responsive behavior, interactions
+4. **"Any specific requirements?"** — styling, features (search, filtering, sorting), accessibility, responsive behavior, interactions
 
 If the user provided a description with the `/genpage` command, acknowledge it and skip question 2. If the selected description already specifies a data source (e.g., Option 1 mentions Account table, Option 2 mentions Task records), skip question 3 as well.
 
@@ -310,7 +316,7 @@ pac model genpage upload `
 
 ### Step 9: Verify in Browser
 
-After successful deployment, ask the user (use `AskUserQuestion`):
+After successful deployment, ask the user directly:
 > "Would you like to verify the page in the browser using Playwright? This will open the page and test interactive elements."
 
 Options: **Yes, verify in browser** / **Skip verification**

--- a/plugins/power-pages/AGENTS.md
+++ b/plugins/power-pages/AGENTS.md
@@ -6,6 +6,8 @@ A plugin for creating, deploying, and managing Power Pages code sites. Supports 
 
 Read `PLUGIN_DEVELOPMENT_GUIDE.md` for UX and reliability standards when creating new skills and agents.
 
+For Codex, symlink or copy the relevant `skills/*` folder into `$CODEX_HOME/skills`. The legacy Claude packaging still exists, but Codex should treat each skill folder as the unit of reuse.
+
 ## Key Conventions
 
 - **DRY** — Never duplicate logic. Shared scripts live in `scripts/` (e.g., `generate-uuid.js`, `scripts/lib/validation-helpers.js`). Shared reference docs live in `references/`. Always check for existing helpers before writing new code.
@@ -14,9 +16,9 @@ Read `PLUGIN_DEVELOPMENT_GUIDE.md` for UX and reliability standards when creatin
 - **Power Pages config loading** must reuse `scripts/lib/powerpages-config.js` anywhere a script reads `.powerpages-site` table-permission or site-setting YAML. Keep that module focused on loading/parsing code-site config only; put validation or business rules in separate validator modules.
 - **Script changes require tests** — Whenever you add a new script or modify an existing script, add or update `node:test` coverage under `scripts/tests/`. Prefer one `*.test.js` file per script/module being tested, and keep the PowerShell test command passing: `$files = Get-ChildItem .\plugins\power-pages\scripts\tests\*.test.js | ForEach-Object { $_.FullName }` followed by `node --test $files`. Validator changes are not an exception; they must always ship with test coverage.
 - **Dataverse-backed validation** must stay opt-in for local runs only. Do not require live Dataverse connectivity in CI workflows or default test runs; gate it behind explicit local flags such as `--validate-dataverse-relationships`.
-- **Reference docs** shared across skills live in `references/` — reference via `${CLAUDE_PLUGIN_ROOT}/references/` paths, don't duplicate.
+- **Reference docs** shared across skills live in `references/` — prefer relative paths from the current skill (`../../references/...`) and don't duplicate.
 - **Templates** use `__PLACEHOLDER__` tokens (e.g., `__SITE_NAME__`) replaced during scaffolding. The `gitignore` file is stored without the dot prefix and renamed to `.gitignore` during scaffolding.
-- **Hooks** are defined centrally in `hooks/hooks.json`, using `PostToolUse` with matcher `Skill` so validation runs when a tracked Power Pages skill completes.
+- **Hooks** are legacy Claude packaging behavior. For Codex, run validation explicitly as part of the workflow instead of depending on hook registration.
 
 ## Skill Development Conventions
 
@@ -28,7 +30,7 @@ Every skill is a sequence of phases (typically 5-8): Prerequisites, Discover/Gat
 
 ### Task Tracking
 
-Create all tasks upfront at Phase 1 start using `TaskCreate` (one per phase). Each task needs `subject` (imperative), `activeForm` (present continuous for spinner), and `description`. Mark `in_progress` when starting, `completed` when done. Include a progress tracking table at the end of the SKILL.md.
+Create and maintain a concise plan with `update_plan`. Include one step per major phase and move steps through `pending`, `in_progress`, and `completed`.
 
 ### SKILL.md Frontmatter
 
@@ -37,35 +39,29 @@ Create all tasks upfront at Phase 1 start using `TaskCreate` (one per phase). Ea
 name: <skill-name>
 description: >-
   <when to use this skill>
-user-invocable: true
-argument-hint: <optional>
-allowed-tools: Read, Write, Edit, Bash, Glob, Grep, Task, TaskCreate, TaskUpdate, TaskList, AskUserQuestion
-model: opus
 ---
 ```
-
-Note: `allowed-tools` must be a comma-separated list, not JSON array or YAML list syntax. Do not add `hooks` to skill frontmatter; Power Pages skills register lifecycle hooks centrally.
 
 ### Plugin Version Check
 
 Every SKILL.md must include the following line immediately after the closing `---` of the frontmatter (before the `#` title):
 
 ```markdown
-> **Plugin check**: Run `node "${CLAUDE_PLUGIN_ROOT}/scripts/check-version.js"` — if it outputs a message, show it to the user before proceeding.
+> **Plugin check**: Run `node "../../scripts/check-version.js"` from the plugin root — if it outputs a message, show it to the user before proceeding.
 ```
 
 This runs a lightweight check comparing the local plugin version against `origin/main` and shows an update notice if a newer version is available.
 
 ### Key Patterns
 
-- **User confirmation** — Pause with `AskUserQuestion` after gathering requirements, after presenting a plan, after implementation, and before deployment.
-- **Deployment prompt** — Skills that modify site artifacts should end by asking "Ready to deploy?" and invoke `/deploy-site` if yes.
-- **Lifecycle hooks** — If a skill needs command validation or checklist enforcement, update `hooks/hooks.json` and `scripts/lib/powerpages-hook-utils.js`. Do not define hook registration in individual `SKILL.md` files.
+- **User confirmation** — Ask the user directly after gathering requirements, after presenting a plan, after implementation, and before deployment.
+- **Deployment prompt** — Skills that modify site artifacts should end by asking whether the user wants to run the `deploy-site` workflow next.
+- **Lifecycle hooks** — Do not rely on hook registration for Codex workflows; call the validation steps explicitly.
 - **Graceful failure** — Track API call results, never auto-rollback, report failures clearly, continue with remaining items.
 - **Token refresh** — Refresh Azure CLI token every ~20 records / 3-4 tables / ~60 seconds.
 - **Git commits** — Commit after every significant milestone (each page/component, design foundations, phase completion).
-- **Agent spawning** — Process sequentially (not parallel), wait for completion, present output for approval.
-- **Skill tracking** — Every skill must record usage in its final phase via `> Reference: ${CLAUDE_PLUGIN_ROOT}/references/skill-tracking-reference.md` (pointer pattern, not hardcoded command). When adding a new skill, also add its entry to the skill name mapping table in `references/skill-tracking-reference.md`.
+- **Agent spawning** — Keep work in the main Codex agent unless the user explicitly asks for delegated parallel work.
+- **Skill tracking** — Every skill must record usage in its final phase via `> Reference: ../../references/skill-tracking-reference.md` (pointer pattern, not hardcoded command). When adding a new skill, also add its entry to the skill name mapping table in `references/skill-tracking-reference.md`.
 - **Dataverse API calls** — Use deterministic Node.js scripts (in the skill's `scripts/` directory) for Dataverse API queries. Scripts should import `getAuthToken` and `makeRequest` from `scripts/lib/validation-helpers.js`. Never use inline PowerShell `Invoke-RestMethod` for API calls — scripts are more reliable, testable, and cross-platform.
 
 ## Common Review Pitfalls
@@ -74,7 +70,7 @@ These patterns have caused repeated PR review feedback. Check for them before su
 
 - **Phase cross-references break silently** — When renumbering or reordering phases in a SKILL.md, also update: `references/` docs that mention phase numbers, the Key Decision Points section, and any other files that cross-reference this skill's phases. After any phase reorder, grep for the old phase number across the skill directory and its references.
 - **Validators must match the exact constraint** — If the rule is "no exports at all", block all `module.exports`/`exports` — don't just check if exported names are in an allowlist. If the rule is "try/catch required", verify both `try` AND `catch` exist. Re-read the exact constraint from SKILL.md and test the boundary cases.
-- **Hook scripts run on every Skill tool use** — The PostToolUse hook fires for all tracked skills, so unconditional `process.stderr.write` creates noise. Gate debug logging behind `process.env.DEBUG`. Only errors should go to stderr unconditionally.
+- **Hook scripts run on every Skill tool use** — This only applies to the legacy Claude packaging. Gate debug logging behind `process.env.DEBUG`. Only errors should go to stderr unconditionally.
 - **Template placeholders in `<script>` blocks need special care** — `render-template.js` injects string values as-is (no encoding), which is safe for HTML text contexts but risky inside JavaScript. Avoid declaring JS variables with `"__PLACEHOLDER__"` in script blocks; prefer reading from the DOM or using `JSON.stringify` for JS contexts.
 - **Guidance must be consistent within a skill** — If one section says "always use raw fetch", a framework-specific table in the same file must not recommend a different HTTP client without qualification. Reviewers will flag contradictions.
 

--- a/plugins/power-pages/skills/activate-site/SKILL.md
+++ b/plugins/power-pages/skills/activate-site/SKILL.md
@@ -8,13 +8,19 @@ description: >
   Power Platform environment via the Power Platform REST API.
 ---
 
-> **Plugin check**: Run `node "${CLAUDE_PLUGIN_ROOT}/scripts/check-version.js"` — if it outputs a message, show it to the user before proceeding.
+> **Plugin check**: Run `node "../../scripts/check-version.js"` from the plugin root — if it outputs a message, show it to the user before proceeding.
 
 # Activate Power Pages Site
 
 Provision a new Power Pages website in a Power Platform environment via the Power Platform REST API.
 
 > **Prerequisite:** This skill expects an existing Power Pages code site created via `/create-site`. Run that skill first if the site does not exist yet.
+
+## Codex Notes
+
+- Use `update_plan` for phase tracking throughout this skill.
+- Ask the user directly in normal chat whenever the workflow needs clarification or approval.
+- Treat `${CLAUDE_PLUGIN_ROOT}` references as paths rooted at `plugins/power-pages`.
 
 ## Core Principles
 
@@ -123,7 +129,7 @@ Look for `powerpages.config.json` in the current directory or one level of subdi
 **/powerpages.config.json
 ```
 
-Read the file and extract the `siteName` field. If not found, ask the user for the site name using `AskUserQuestion`.
+Read the file and extract the `siteName` field. If not found, ask the user directly for the site name.
 
 #### 2.2 Generate Subdomain Suggestion
 
@@ -145,7 +151,7 @@ This outputs a string like `site-a3f2b1`. Resolve the correct site URL domain fr
 | `UsGovDod` | `appsplatform.us` |
 | `China` | `powerappsportals.cn` |
 
-Present the generated subdomain to the user and ask them to accept or enter their own using `AskUserQuestion`:
+Present the generated subdomain to the user and ask them directly to accept it or enter their own:
 
 | Question | Header | Options |
 |----------|--------|---------|
@@ -177,7 +183,7 @@ Parse the output to find the website record that matches the site name. Extract 
 
 ### Actions
 
-Present all activation parameters to the user using `AskUserQuestion`:
+Present all activation parameters to the user and ask for explicit approval in chat:
 
 | Question | Header | Options |
 |----------|--------|---------|
@@ -282,7 +288,7 @@ After the summary, suggest:
 
 ### Progress Tracking
 
-Use `TaskCreate` at the start to track progress through each phase:
+Use `update_plan` at the start to track progress through each phase:
 
 | Task | Description |
 |------|-------------|
@@ -292,7 +298,7 @@ Use `TaskCreate` at the start to track progress through each phase:
 | Phase 4 | Activate & Poll — run activation script, handle result |
 | Phase 5 | Present Summary — show site URL and next steps |
 
-Mark each task complete with `TaskUpdate` as you finish each phase.
+Mark each phase complete in `update_plan` as you finish it.
 
 ### Key Decision Points
 

--- a/plugins/power-pages/skills/activate-site/SKILL.md
+++ b/plugins/power-pages/skills/activate-site/SKILL.md
@@ -6,9 +6,6 @@ description: >
   "provision portal", "turn on my site", "enable website",
   or wants to activate/provision a Power Pages website in their
   Power Platform environment via the Power Platform REST API.
-user-invocable: true
-allowed-tools: Read, Bash, Glob, Grep, AskUserQuestion, TaskCreate, TaskUpdate, TaskList
-model: sonnet
 ---
 
 > **Plugin check**: Run `node "${CLAUDE_PLUGIN_ROOT}/scripts/check-version.js"` — if it outputs a message, show it to the user before proceeding.

--- a/plugins/power-pages/skills/add-cloud-flow/SKILL.md
+++ b/plugins/power-pages/skills/add-cloud-flow/SKILL.md
@@ -13,7 +13,7 @@ description: >
   new pages or components without re-creating metadata.
 ---
 
-> **Plugin check**: Run `node "${CLAUDE_PLUGIN_ROOT}/scripts/check-version.js"` — if it outputs a message, show it to the user before proceeding.
+> **Plugin check**: Run `node "../../scripts/check-version.js"` from the plugin root — if it outputs a message, show it to the user before proceeding.
 
 # Add Cloud Flow
 
@@ -24,13 +24,19 @@ Connect one or more Power Automate cloud flows to a Power Pages code site, or wi
 
 For already-registered flows, the skill skips metadata and role creation and goes straight to client-side integration — wiring the existing flow into new UI locations.
 
+## Codex Notes
+
+- Use `update_plan` for phase tracking throughout this skill.
+- Ask the user directly in normal chat whenever the workflow needs clarification or approval.
+- Treat `${CLAUDE_PLUGIN_ROOT}` references as paths rooted at `plugins/power-pages`.
+
 ## Core Principles
 
 - **Multiple flows in one run**: The user can add several flows at once. All flows are planned together and implemented together before asking for deployment.
 - **Ask before acting**: Present a full HTML plan (all flows, roles, reasoning) before creating any files.
 - **Web roles drive access**: Every flow must have at least one web role. Anonymous Users role is valid but must be confirmed.
 - **Scenario determines roles**: Understand what each flow does and who triggers it before picking roles.
-- **Use TaskCreate/TaskUpdate**: Track all phases upfront before starting any work.
+- **Use `update_plan`**: Track all phases upfront before starting any work.
 
 > **Prerequisites:**
 > - An existing Power Pages code site with `.powerpages-site` deployed
@@ -78,7 +84,7 @@ Look for the `.powerpages-site` folder in the project root.
 
 **If not found**:
 
-Use `AskUserQuestion`:
+Ask the user directly:
 
 | Question | Options |
 |----------|---------|
@@ -192,7 +198,7 @@ Already registered (available for additional frontend integration):
   3. Support Ticket Handler — Already connected, can be wired into more pages
 ```
 
-Use `AskUserQuestion`:
+Ask the user directly:
 
 | Question | Options |
 |----------|---------|
@@ -220,7 +226,7 @@ For each selected flow, identify its scenario from the name and description:
 | **Admin action** | Bulk processing, content approval, data export | Admins / specific roles only |
 | **Background / system** | Scheduled sync, enrichment | Not triggered by portal users directly |
 
-If a flow's scenario is unclear, use `AskUserQuestion` per flow:
+If a flow's scenario is unclear, ask the user directly per flow:
 
 | Question | Context |
 |----------|---------|
@@ -345,7 +351,7 @@ Open the rendered file in the default browser (`open` on macOS, `start` on Windo
 
 Give a brief CLI summary: number of flows, scenarios, role count, any anonymous-role warnings.
 
-Use `AskUserQuestion`:
+Ask the user directly:
 
 | Question | Options |
 |----------|---------|
@@ -585,13 +591,13 @@ Use `--skillName "AddCloudFlow"`.
 
 ### 8.4 Ask to Deploy
 
-Use `AskUserQuestion`:
+Ask the user directly:
 
 | Question | Options |
 |----------|---------|
 | Everything is ready. Deploy the site to make the flows live? | Yes, deploy now (Recommended), No, I'll deploy later |
 
-**If "Yes"**: Invoke `/deploy-site`. After it succeeds, use `AskUserQuestion`:
+**If "Yes"**: Invoke `/deploy-site`. After it succeeds, ask the user directly:
 
 | Question | Options |
 |----------|---------|
@@ -636,7 +642,7 @@ Use `AskUserQuestion`:
 
 ### Progress Tracking
 
-Before starting Phase 1, create a task list with all phases using `TaskCreate`:
+Before starting Phase 1, create a plan with all phases using `update_plan`:
 
 | Task subject | activeForm | Description |
 |-------------|------------|-------------|
@@ -649,7 +655,7 @@ Before starting Phase 1, create a task list with all phases using `TaskCreate`:
 | Client-side integration | Generating client-side code | Create typed service functions and wire into UI |
 | Verify and summarize | Validating and summarizing | Validate YAMLs, record skill usage, present summary, offer deployment |
 
-Mark each task `in_progress` when starting and `completed` when done via `TaskUpdate`.
+Mark each phase `in_progress` when starting and `completed` when done via `update_plan`.
 
 ---
 

--- a/plugins/power-pages/skills/add-cloud-flow/SKILL.md
+++ b/plugins/power-pages/skills/add-cloud-flow/SKILL.md
@@ -11,9 +11,6 @@ description: >
   client-side code to call the flows, and presents an HTML plan showing roles and reasoning
   for each flow. Already-registered flows can be selected for frontend-only integration into
   new pages or components without re-creating metadata.
-user-invocable: true
-allowed-tools: Read, Write, Edit, Bash, Grep, Glob, AskUserQuestion, Skill, Task, TaskCreate, TaskUpdate, TaskList
-model: opus
 ---
 
 > **Plugin check**: Run `node "${CLAUDE_PLUGIN_ROOT}/scripts/check-version.js"` — if it outputs a message, show it to the user before proceeding.

--- a/plugins/power-pages/skills/add-sample-data/SKILL.md
+++ b/plugins/power-pages/skills/add-sample-data/SKILL.md
@@ -8,16 +8,22 @@ description: >
   so they can test and demo their Power Pages site.
 ---
 
-> **Plugin check**: Run `node "${CLAUDE_PLUGIN_ROOT}/scripts/check-version.js"` — if it outputs a message, show it to the user before proceeding.
+> **Plugin check**: Run `node "../../scripts/check-version.js"` from the plugin root — if it outputs a message, show it to the user before proceeding.
 
 # Add Sample Data
 
 Populate Dataverse tables with sample records via OData API so users can test and demo their Power Pages sites.
 
+## Codex Notes
+
+- Use `update_plan` for phase tracking throughout this skill.
+- Ask the user directly in normal chat whenever the workflow needs clarification or approval.
+- Treat `${CLAUDE_PLUGIN_ROOT}` references as paths rooted at `plugins/power-pages`.
+
 ## Core Principles
 
 - **Respect insertion order**: Always insert parent/referenced tables before child/referencing tables so lookup IDs are available when needed.
-- **Use TaskCreate/TaskUpdate**: Track all progress throughout all phases -- create the todo list upfront with all phases before starting any work.
+- **Use `update_plan`**: Track all progress throughout all phases — create the plan upfront with all phases before starting any work.
 - **Fail gracefully**: On insertion failure, log the error and continue with remaining records -- never attempt automated rollback.
 
 **Initial request:** $ARGUMENTS
@@ -84,11 +90,11 @@ Show the user the list of discovered tables with their columns so they can choos
 
 ### 3.1 Select Tables
 
-Use `AskUserQuestion` to ask which tables they want to populate (use `multiSelect: true`). List all discovered tables as options.
+Ask the user directly which tables they want to populate (multi-select is fine). List all discovered tables as options.
 
 ### 3.2 Select Record Count
 
-Use `AskUserQuestion` to ask how many sample records per table:
+Ask the user directly how many sample records per table:
 
 | Option | Description |
 |--------|-------------|
@@ -268,7 +274,7 @@ After the summary, suggest:
 
 ### Throughout All Phases
 
-- **Use TaskCreate/TaskUpdate** to track progress at every phase
+- **Use `update_plan`** to track progress at every phase
 - **Ask for user confirmation** at key decision points (see list below)
 - **Respect insertion order** -- always insert parent tables before child tables
 - **Fail gracefully** -- log errors and continue, never rollback automatically
@@ -282,7 +288,7 @@ After the summary, suggest:
 
 ### Progress Tracking
 
-Before starting Phase 1, create a task list with all phases using `TaskCreate`:
+Before starting Phase 1, create a plan with all phases using `update_plan`:
 
 | Task subject | activeForm | Description |
 |-------------|------------|-------------|
@@ -293,7 +299,7 @@ Before starting Phase 1, create a task list with all phases using `TaskCreate`:
 | Insert sample data | Inserting records | Execute OData POST calls with relationship handling and token refresh |
 | Verify and summarize | Verifying results | Confirm record counts, present summary, suggest next steps |
 
-Mark each task `in_progress` when starting it and `completed` when done via `TaskUpdate`. This gives the user visibility into progress and keeps the workflow deterministic.
+Mark each phase `in_progress` when starting it and `completed` when done via `update_plan`. This gives the user visibility into progress and keeps the workflow deterministic.
 
 ---
 

--- a/plugins/power-pages/skills/add-sample-data/SKILL.md
+++ b/plugins/power-pages/skills/add-sample-data/SKILL.md
@@ -6,9 +6,6 @@ description: >
   "insert demo data", "fill tables with data", "create test data",
   or wants to populate their Dataverse tables with sample records
   so they can test and demo their Power Pages site.
-user-invocable: true
-allowed-tools: Read, Write, Bash, Grep, Glob, AskUserQuestion, Task, TaskCreate, TaskUpdate, TaskList, mcp__plugin_power-pages_microsoft-learn__microsoft_docs_search, mcp__plugin_power-pages_microsoft-learn__microsoft_code_sample_search, mcp__plugin_power-pages_microsoft-learn__microsoft_docs_fetch
-model: sonnet
 ---
 
 > **Plugin check**: Run `node "${CLAUDE_PLUGIN_ROOT}/scripts/check-version.js"` — if it outputs a message, show it to the user before proceeding.

--- a/plugins/power-pages/skills/add-seo/SKILL.md
+++ b/plugins/power-pages/skills/add-seo/SKILL.md
@@ -8,13 +8,19 @@ description: >
   Power Pages code site after creating it with /create-site.
 ---
 
-> **Plugin check**: Run `node "${CLAUDE_PLUGIN_ROOT}/scripts/check-version.js"` — if it outputs a message, show it to the user before proceeding.
+> **Plugin check**: Run `node "../../scripts/check-version.js"` from the plugin root — if it outputs a message, show it to the user before proceeding.
 
 # Add SEO
 
 Add essential SEO assets to a Power Pages code site: `robots.txt`, `sitemap.xml`, and meta tags.
 
 > **Prerequisite:** This skill expects an existing Power Pages code site created via `/create-site`. Run that skill first if the site does not exist yet.
+
+## Codex Notes
+
+- Use `update_plan` for phase tracking throughout this skill.
+- Ask the user directly in normal chat whenever the workflow needs clarification or approval.
+- Treat `${CLAUDE_PLUGIN_ROOT}` references as paths rooted at `plugins/power-pages`.
 
 ## Core Principles
 
@@ -81,7 +87,7 @@ Build a list of all routes (e.g., `/`, `/about`, `/contact`, `/blog`).
 
 ### Actions
 
-Use `AskUserQuestion` to collect SEO preferences:
+Ask the user directly to collect SEO preferences:
 
 #### Call 1
 
@@ -119,7 +125,7 @@ Present the SEO additions that will be made as a clear, inline summary:
 3. **Meta tags to add to index.html** — title, description, viewport, charset, Open Graph, Twitter Card
 4. **Favicon** — link tag and placeholder SVG
 
-After presenting the plan, use `AskUserQuestion` to get approval:
+After presenting the plan, ask for approval directly in chat:
 
 | Question | Header | Options |
 |----------|--------|---------|
@@ -353,7 +359,7 @@ After the summary, suggest:
 
 ### Progress Tracking
 
-Use `TaskCreate` at the start to track each phase:
+Use `update_plan` at the start to track each phase:
 
 | Task | Description |
 |------|-------------|
@@ -365,7 +371,7 @@ Use `TaskCreate` at the start to track each phase:
 | Phase 6 | Add meta tags, Open Graph, and favicon |
 | Phase 7 | Verify via Playwright and commit |
 
-Update each task with `TaskUpdate` as it is completed.
+Update each phase in `update_plan` as it is completed.
 
 ### Key Decision Points
 

--- a/plugins/power-pages/skills/add-seo/SKILL.md
+++ b/plugins/power-pages/skills/add-seo/SKILL.md
@@ -6,9 +6,6 @@ description: >
   "add open graph tags", "add favicon", "make site searchable",
   or wants to add SEO essentials (robots.txt, sitemap.xml, meta tags) to their
   Power Pages code site after creating it with /create-site.
-user-invocable: true
-allowed-tools: Read, Write, Edit, Grep, Glob, Bash, AskUserQuestion, Task, TaskCreate, TaskUpdate, TaskList, mcp__plugin_power-pages_playwright__browser_navigate, mcp__plugin_power-pages_playwright__browser_snapshot, mcp__plugin_power-pages_playwright__browser_click, mcp__plugin_power-pages_playwright__browser_close
-model: sonnet
 ---
 
 > **Plugin check**: Run `node "${CLAUDE_PLUGIN_ROOT}/scripts/check-version.js"` — if it outputs a message, show it to the user before proceeding.

--- a/plugins/power-pages/skills/add-server-logic/SKILL.md
+++ b/plugins/power-pages/skills/add-server-logic/SKILL.md
@@ -12,11 +12,18 @@ description: >
   "server-side code", or wants to move logic from the browser to the server in their Power Pages site.
 ---
 
-> **Plugin check**: Run `node "${CLAUDE_PLUGIN_ROOT}/scripts/check-version.js"` — if it outputs a message, show it to the user before proceeding.
+> **Plugin check**: Run `node "../../scripts/check-version.js"` from the plugin root — if it outputs a message, show it to the user before proceeding.
 
 # Add Server Logic
 
 Create and manage one or more Power Pages Server Logic files — server-side JavaScript that runs securely on the Power Pages runtime, hidden from the browser and protected by web roles and table permissions. Server Logic enables secure external API integrations, Dataverse operations, and custom business logic without exposing sensitive code or credentials to the client.
+
+## Codex Notes
+
+- Use `update_plan` for phase tracking wherever this skill mentions `TaskCreate`, `TaskUpdate`, or `TaskList`.
+- Ask the user directly in normal chat wherever this skill mentions `AskUserQuestion`.
+- Do the analysis in the main Codex agent wherever this skill mentions the `Task` tool, an explore agent, or an architect agent.
+- Treat `${CLAUDE_PLUGIN_ROOT}` references as paths rooted at `plugins/power-pages`.
 
 ## Core Principles
 
@@ -24,7 +31,7 @@ Create and manage one or more Power Pages Server Logic files — server-side Jav
 - **No browser APIs, no dependencies**: Server Logic runs in a sandboxed server environment with ECMAScript 2023 support. There is no `fetch`, `XMLHttpRequest`, `setTimeout`, or any DOM API. No npm packages are available.
 - **Five functions only**: A server logic file can only export these top-level functions: `get`, `post`, `put`, `patch`, `del`. The name `delete` is a reserved word in JavaScript and cannot be used.
 - **Always return a string**: Every function must return a string. Use `JSON.stringify()` when returning objects or arrays.
-- **Use TaskCreate/TaskUpdate**: Track all progress throughout all phases — create the todo list upfront with all phases before starting any work.
+- **Use `update_plan`**: Track all progress throughout all phases — create the plan upfront with all phases before starting any work.
 
 > **Prerequisites:**
 > - An existing Power Pages code site created
@@ -56,7 +63,7 @@ Create and manage one or more Power Pages Server Logic files — server-side Jav
 
 **Actions**:
 
-1. Create todo list with all 11 phases (see [Progress Tracking](#progress-tracking) table)
+1. Create a plan with all 11 phases (see [Progress Tracking](#progress-tracking) table)
 
 ### 1.1 Locate Project
 
@@ -70,13 +77,13 @@ Read `powerpages.config.json` to get the site name and configuration:
 
 ### 1.3 Detect Framework
 
-Read `package.json` to determine the frontend framework (React, Vue, Angular, or Astro). This is needed for Phase 8 (client-side integration guidance). See `${CLAUDE_PLUGIN_ROOT}/references/framework-conventions.md` for the full framework detection mapping.
+Read `package.json` to determine the frontend framework (React, Vue, Angular, or Astro). This is needed for Phase 8 (client-side integration guidance). See `../../references/framework-conventions.md` for the full framework detection mapping.
 
 ### 1.4 Explore Existing Server Logic and Frontend Code
 
-Use the **Explore agent** (via `Task` tool with `agent_type: "explore"`) to analyze the site for existing server logic patterns and frontend code that may call or need to call server logic endpoints.
+Analyze the site directly in the main Codex agent for existing server logic patterns and frontend code that may call or need to call server logic endpoints.
 
-**Prompt for the Explore agent:**
+Use this checklist while analyzing:
 
 > "Analyze this Power Pages code site for server logic context. Check:
 > 1. Does `.powerpages-site/server-logic/` exist? If yes, list all subdirectories and their .js files. Summarize what each server logic does (which functions it implements, what SDK features it uses). Also read the corresponding .serverlogic.yml files to check web role assignments.
@@ -89,7 +96,7 @@ Use the **Explore agent** (via `Task` tool with `agent_type: "explore"`) to anal
 > 8. For each existing server logic, assess whether it can be reused or safely extended for the requested capability instead of creating a brand-new server logic file. Call out any strong reuse candidates and explain why.
 > Report all findings so we can avoid duplicating work and match existing patterns."
 
-From the Explore agent's findings, note:
+From your findings, note:
 - **Existing server logic files** — what's already implemented, and which ones are candidates for reuse or extension
 - **Frontend calling patterns** — how the site makes API calls (match this pattern in Phase 9)
 - **Existing service/utility files** — reuse these when adding client-side integration
@@ -104,7 +111,7 @@ Look for the `.powerpages-site` folder:
 
 > "The `.powerpages-site` folder was not found. Server logic files are stored inside this folder, so the site must be deployed at least once before creating server logic. Would you like to deploy now?"
 
-Use `AskUserQuestion`:
+Ask the user directly:
 
 | Question | Options |
 |----------|---------|
@@ -1029,7 +1036,7 @@ Use the reference below for the frontend integration approach, examples, and fra
 
 > Reference: `${CLAUDE_PLUGIN_ROOT}/skills/add-server-logic/references/frontend-integration-reference.md`
 
-Based on the Explore agent's findings from Phase 1.4 and the approved plan, choose the integration approach from that reference and apply it consistently across all server logic endpoints being wired into the frontend.
+Based on the findings from Phase 1.4 and the approved plan, choose the integration approach from that reference and apply it consistently across all server logic endpoints being wired into the frontend.
 
 ### 9.3 Create or Update Frontend Integration
 

--- a/plugins/power-pages/skills/add-server-logic/SKILL.md
+++ b/plugins/power-pages/skills/add-server-logic/SKILL.md
@@ -20,8 +20,8 @@ Create and manage one or more Power Pages Server Logic files — server-side Jav
 
 ## Codex Notes
 
-- Use `update_plan` for phase tracking wherever this skill mentions `TaskCreate`, `TaskUpdate`, or `TaskList`.
-- Ask the user directly in normal chat wherever this skill mentions `AskUserQuestion`.
+- Use `update_plan` for phase tracking throughout this skill.
+- Ask the user directly in normal chat whenever the workflow needs clarification or approval.
 - Do the analysis in the main Codex agent wherever this skill mentions the `Task` tool, an explore agent, or an architect agent.
 - Treat `${CLAUDE_PLUGIN_ROOT}` references as paths rooted at `plugins/power-pages`.
 
@@ -190,7 +190,7 @@ Each entry includes: `name`, `displayName`, `description`, `type` (`action` or `
 
 If custom actions are found (`total > 0`), present a summary to the user grouped by binding type (unbound vs. entity-bound) and ask whether any should be used:
 
-Use `AskUserQuestion`:
+Ask the user directly:
 
 | Question | Options |
 |----------|---------|
@@ -204,7 +204,7 @@ If the user says **No**, skip to Phase 2.2.
 
 If the user says **Yes**, for each server logic item being created, ask which custom action (if any) it should wrap:
 
-Use `AskUserQuestion` for each server logic item:
+Ask the user directly for each server logic item:
 
 | Question | Context |
 |----------|---------|
@@ -256,7 +256,7 @@ These values will be used in Phase 7 to create the environment variables and sit
 
 If secrets were identified in Phase 2.3, ask the user now whether they want to use Azure Key Vault. This decision must happen before Phase 4 so the implementation plan can show the chosen secret management approach.
 
-Use `AskUserQuestion`:
+Ask the user directly:
 
 | Question | Options |
 |----------|---------|
@@ -266,7 +266,7 @@ Record the user's choice — it will be shown in the HTML plan (Phase 4) and exe
 
 ### 2.4 Confirm with User
 
-If the requirements are ambiguous, use `AskUserQuestion` to clarify:
+If the requirements are ambiguous, ask the user directly to clarify:
 
 | Question | Context |
 |----------|---------|
@@ -375,7 +375,7 @@ Do not restate the per-server-logic breakdown, rationale, role assignments, or f
 
 ### 4.4 Confirm with User
 
-Use `AskUserQuestion`:
+Ask the user directly:
 
 | Question | Options |
 |----------|---------|
@@ -828,7 +828,7 @@ The script outputs a JSON array of Key Vaults (`name`, `resourceGroup`, `locatio
 
 If Key Vaults were found, present the list and ask which one to use:
 
-Use `AskUserQuestion`:
+Ask the user directly:
 
 | Question | Context |
 |----------|---------|
@@ -836,7 +836,7 @@ Use `AskUserQuestion`:
 
 If **no Key Vaults are found**, ask the user how to proceed:
 
-Use `AskUserQuestion`:
+Ask the user directly:
 
 | Question | Options |
 |----------|---------|
@@ -844,7 +844,7 @@ Use `AskUserQuestion`:
 
 **If "Create a new Key Vault"**: Ask for a vault name, resource group, and location, then create it:
 
-Use `AskUserQuestion`:
+Ask the user directly:
 
 | Question | Context |
 |----------|---------|
@@ -1022,7 +1022,7 @@ Server logic creates the backend — but without frontend code to call it, the e
 
 ### 9.1 Ask User About Integration Scope
 
-Use `AskUserQuestion`:
+Ask the user directly:
 
 | Question | Options |
 |----------|---------|
@@ -1149,7 +1149,7 @@ Present a summary of everything that was done:
 
 ### 11.3 Ask to Deploy
 
-Use `AskUserQuestion`:
+Ask the user directly:
 
 | Question | Options |
 |----------|---------|
@@ -1157,7 +1157,7 @@ Use `AskUserQuestion`:
 
 **If "Yes, deploy now"**: Invoke the `/deploy-site` skill to deploy the site.
 
-After deployment succeeds, use `AskUserQuestion`:
+After deployment succeeds, ask the user directly:
 
 | Question | Options |
 |----------|---------|
@@ -1192,7 +1192,7 @@ After deployment (or if skipped), remind the user:
 
 ### Throughout All Phases
 
-- **Use TaskCreate/TaskUpdate** to track progress at every phase
+- **Use `update_plan`** to track progress at every phase
 - **Always fetch Microsoft Learn docs** in Phase 3 before writing code — the docs are the source of truth
 - **Ask for user confirmation** at key decision points
 - **Commit at milestones** — after server logic code, table permissions (if any), secrets/environment variables (if any), site settings, and frontend integration (if any)
@@ -1216,7 +1216,7 @@ Do not treat this skill file as the canonical SDK reference. The Phase 3 Microso
 
 ### Progress Tracking
 
-Before starting Phase 1, create a task list with all phases using `TaskCreate`:
+Before starting Phase 1, create a plan with all phases using `update_plan`:
 
 | Task subject | activeForm | Description |
 |-------------|------------|-------------|
@@ -1232,7 +1232,7 @@ Before starting Phase 1, create a task list with all phases using `TaskCreate`:
 | Verify and test guidance | Validating and providing test guidance | Final validation, API URLs, CSRF token instructions, testing guide |
 | Review and deploy | Reviewing summary and deploying | Present summary, ask about deployment, provide post-deploy guidance |
 
-Mark each task `in_progress` when starting it and `completed` when done via `TaskUpdate`. Use `TaskList` between phase transitions and before the final summary to confirm there are no incomplete work items left.
+Mark each phase `in_progress` when starting it and `completed` when done via `update_plan`. Review the current plan between phase transitions and before the final summary to confirm there are no incomplete work items left.
 
 ---
 

--- a/plugins/power-pages/skills/add-server-logic/SKILL.md
+++ b/plugins/power-pages/skills/add-server-logic/SKILL.md
@@ -10,9 +10,6 @@ description: >
   requirements, fetching latest documentation, implementing the server logic code, configuring
   site settings, and deploying. Use this skill whenever the user mentions "server logic",
   "server-side code", or wants to move logic from the browser to the server in their Power Pages site.
-user-invocable: true
-allowed-tools: Read, Write, Edit, Bash, Grep, Glob, AskUserQuestion, Skill, Task, TaskCreate, TaskUpdate, TaskList, mcp__plugin_power-pages_microsoft-learn__microsoft_docs_search, mcp__plugin_power-pages_microsoft-learn__microsoft_code_sample_search, mcp__plugin_power-pages_microsoft-learn__microsoft_docs_fetch
-model: opus
 ---
 
 > **Plugin check**: Run `node "${CLAUDE_PLUGIN_ROOT}/scripts/check-version.js"` — if it outputs a message, show it to the user before proceeding.

--- a/plugins/power-pages/skills/audit-permissions/SKILL.md
+++ b/plugins/power-pages/skills/audit-permissions/SKILL.md
@@ -10,11 +10,17 @@ description: >-
   and suggests fixes for any issues found.
 ---
 
-> **Plugin check**: Run `node "${CLAUDE_PLUGIN_ROOT}/scripts/check-version.js"` — if it outputs a message, show it to the user before proceeding.
+> **Plugin check**: Run `node "../../scripts/check-version.js"` from the plugin root — if it outputs a message, show it to the user before proceeding.
 
 # Audit Permissions
 
 Audit existing table permissions on a Power Pages code site. Analyze permissions against the site code and Dataverse metadata, then generate a visual HTML audit report with findings, reasoning, and suggested fixes.
+
+## Codex Notes
+
+- Use `update_plan` for phase tracking throughout this skill.
+- Ask the user directly in normal chat whenever the workflow needs clarification or approval.
+- Treat `${CLAUDE_PLUGIN_ROOT}` references as paths rooted at `plugins/power-pages`.
 
 ## Workflow
 
@@ -30,7 +36,7 @@ Audit existing table permissions on a Power Pages code site. Analyze permissions
 
 ## Task Tracking
 
-At the start of Step 1, create all tasks upfront using `TaskCreate`. Mark each task `in_progress` when starting and `completed` when done.
+At the start of Step 1, create the full plan in `update_plan`. Mark each phase `in_progress` when starting and `completed` when done.
 
 | Task subject | activeForm | Description |
 |-------------|------------|-------------|
@@ -184,22 +190,22 @@ The union of these two sets is the complete audit scope. Each table will be audi
 For each table in the audit inventory, create a task:
 
 ```
-TaskCreate:
-  subject: "Audit <table_logical_name>"
-  activeForm: "Auditing <table_display_name> permissions"
+update_plan step:
+  step: "Audit <table_logical_name>"
+  status: "in_progress"
   description: "Run all audit checks for <table_logical_name>"
 ```
 
 Also create a summary task:
 
 ```
-TaskCreate:
-  subject: "Compile audit findings"
-  activeForm: "Compiling audit findings"
+update_plan step:
+  step: "Compile audit findings"
+  status: "pending"
   description: "Combine all per-table findings into the final report"
 ```
 
-Use `TaskList` at any point to review progress and see which tables still need auditing.
+Use the current plan at any point to review progress and see which tables still need auditing.
 
 ### 4.3 Per-Table Audit Checklist
 
@@ -381,7 +387,7 @@ Is this table fetched via `$expand` on another table's query?
 
 **K. Record Findings & Complete**
 
-After all checks, mark the table's task as `completed` via `TaskUpdate`.
+After all checks, mark the table's step as `completed` in `update_plan`.
 
 ### 4.4 Cross-Table Validation
 
@@ -392,7 +398,7 @@ After all per-table audits are complete, run these cross-table checks:
 3. **Parent chain completeness:** For every Parent scope permission, verify the parent permission exists and is valid
 4. **Web role consistency:** If two related tables (e.g., parent and child) are accessed by the same feature, verify they share the same web role assignment
 
-Use `TaskList` to review all completed audits, then mark the "Compile audit findings" task as `in_progress` and proceed to Step 5.
+Review the current plan, then mark the "Compile audit findings" step as `in_progress` and proceed to Step 5.
 
 ---
 
@@ -493,7 +499,7 @@ Present a summary to the user:
 1. **Critical findings count** — these need immediate attention
 2. **Warning findings count** — should be addressed
 3. **Report location** — where the HTML file was saved
-4. **Ask the user** using `AskUserQuestion`: "Would you like me to fix any of these issues? I can create or update table permissions to resolve the critical and warning findings."
+4. **Ask the user directly**: "Would you like me to fix any of these issues? I can create or update table permissions to resolve the critical and warning findings."
 
 If the user wants fixes applied:
 

--- a/plugins/power-pages/skills/audit-permissions/SKILL.md
+++ b/plugins/power-pages/skills/audit-permissions/SKILL.md
@@ -8,10 +8,6 @@ description: >-
   This skill analyzes existing table permissions against the site code and Dataverse metadata,
   generates an HTML audit report with findings grouped by severity (critical, warning, info, pass),
   and suggests fixes for any issues found.
-user-invocable: true
-argument-hint: "[optional: specific table or concern]"
-allowed-tools: Read, Write, Bash, Glob, Grep, AskUserQuestion, TaskCreate, TaskUpdate, TaskList, Agent
-model: opus
 ---
 
 > **Plugin check**: Run `node "${CLAUDE_PLUGIN_ROOT}/scripts/check-version.js"` — if it outputs a message, show it to the user before proceeding.

--- a/plugins/power-pages/skills/create-site/SKILL.md
+++ b/plugins/power-pages/skills/create-site/SKILL.md
@@ -3,19 +3,26 @@ name: create-site
 description: This skill should be used when the user asks to "create a power pages site", "build a code site", "scaffold a website", "create a portal", "make a new site", or wants to create a new Power Pages code site (SPA) using React, Angular, Vue, or Astro.
 ---
 
-> **Plugin check**: Run `node "${CLAUDE_PLUGIN_ROOT}/scripts/check-version.js"` — if it outputs a message, show it to the user before proceeding.
+> **Plugin check**: Run `node "../../scripts/check-version.js"` from the plugin root — if it outputs a message, show it to the user before proceeding.
 
 # Create Power Pages Code Site
 
 Guide the user through creating a complete, production-quality Power Pages code site from initial concept to deployed site. Follow a systematic approach: discover requirements, scaffold and launch immediately, plan components and design, implement with design applied, validate, review, and deploy.
 
+## Codex Notes
+
+- Use `update_plan` for phase tracking wherever this skill mentions `TaskCreate`, `TaskUpdate`, or `TaskList`.
+- Ask the user directly in normal chat wherever this skill mentions `AskUserQuestion`.
+- Treat `${CLAUDE_PLUGIN_ROOT}` references as paths rooted at `plugins/power-pages`.
+- Use web search only when you actually need fresh external assets or current documentation.
+
 ## Core Principles
 
 - **Use best judgement for design details**: Once the user picks an aesthetic direction and mood, make confident decisions about specific fonts, colors, page layouts, and component behavior. Do not ask the user to specify every detail — use the design reference and your own taste to make creative, distinctive choices.
-- **Use TaskCreate/TaskUpdate**: Track all progress throughout all phases — create the todo list upfront with all phases before starting any work.
+- **Use `update_plan`**: Track all progress throughout all phases — create the plan upfront with all phases before starting any work.
 - **Scaffold early, design with intention**: Get the dev server running immediately after discovery so the user has something to look at. Then plan the design and features while the scaffold is live — apply the chosen aesthetic during implementation.
 - **Live preview feedback loop**: The dev server MUST be running before any customization begins. Browse the site via Playwright (`browser_navigate` + `browser_snapshot`) to verify every significant change. Do NOT take screenshots — only use accessibility snapshots to check page structure and content.
-- **Use real images**: Source high-quality photos from Unsplash wherever pages need visual content — hero sections, feature cards, about pages, backgrounds, etc. Use `https://images.unsplash.com/photo-{id}?w={width}&h={height}&fit=crop` URLs with specific photo IDs found via `WebSearch`. Never leave image placeholders or broken `<img>` tags pointing to nonexistent files.
+- **Use real images**: Source high-quality photos from Unsplash wherever pages need visual content — hero sections, feature cards, about pages, backgrounds, etc. Use `https://images.unsplash.com/photo-{id}?w={width}&h={height}&fit=crop` URLs with specific photo IDs found via web search. Never leave image placeholders or broken `<img>` tags pointing to nonexistent files.
 - **Git checkpoints**: Commit after every individual page and component — each gets its own commit so breaking changes can be reverted.
 
 **Constraint**: Only static SPA frameworks are supported (React, Vue, Angular, Astro). NOT supported: Next.js, Nuxt.js, Remix, SvelteKit, Liquid.
@@ -34,7 +41,7 @@ Guide the user through creating a complete, production-quality Power Pages code 
 2. If site purpose is clear from arguments:
    - Summarize understanding
    - Identify site type (portal, dashboard, landing page, blog, etc.)
-3. If site purpose is unclear, use `AskUserQuestion`:
+3. If site purpose is unclear, ask the user directly:
 
    | Question | Header | Options |
    |----------|--------|---------|
@@ -74,22 +81,22 @@ Guide the user through creating a complete, production-quality Power Pages code 
 
 > **The scaffold is a temporary branded loading screen** — it shows a Power Pages animated "Building your site" experience with orbiting elements, status messages, and feature cards. Its only purpose is to get the dev server running quickly so the user has something to look at while you plan and build. **During Phase 5 (Implementation), the entire scaffold — including theme.css, Layout, Home page, and all placeholder components — is completely replaced** with the user's actual site: their chosen typography, color palette, pages, components, and navigation. Do NOT try to build on top of the loading screen; replace it entirely.
 
-> See `${CLAUDE_PLUGIN_ROOT}/references/framework-conventions.md` for the full framework → build tool → router → output path mapping.
+> See `../../references/framework-conventions.md` for the full framework → build tool → router → output path mapping.
 
 **Actions**:
 
 ### 2.1 Copy Template
 
-> `${CLAUDE_PLUGIN_ROOT}` is already resolved to the plugin's absolute path at runtime. Use it directly in Glob/Read paths — do NOT search for the plugin directory.
+> Resolve template paths from the `plugins/power-pages` directory. Do not search the filesystem if you already know the plugin root.
 
 Read and copy all files from the matching asset template to the project directory:
 
 | Framework | Asset Directory |
 |-----------|----------------|
-| React | `${CLAUDE_PLUGIN_ROOT}/skills/create-site/assets/react/` |
-| Vue | `${CLAUDE_PLUGIN_ROOT}/skills/create-site/assets/vue/` |
-| Angular | `${CLAUDE_PLUGIN_ROOT}/skills/create-site/assets/angular/` |
-| Astro | `${CLAUDE_PLUGIN_ROOT}/skills/create-site/assets/astro/` |
+| React | `plugins/power-pages/skills/create-site/assets/react/` |
+| Vue | `plugins/power-pages/skills/create-site/assets/vue/` |
+| Angular | `plugins/power-pages/skills/create-site/assets/angular/` |
+| Astro | `plugins/power-pages/skills/create-site/assets/astro/` |
 
 Use `Glob` to discover all files in the asset directory, `Read` each file, then `Write` to the project directory preserving the relative path structure.
 
@@ -167,7 +174,7 @@ Immediately after the dev server starts, verify the scaffold is working:
 
 **Actions**:
 
-1. Use `AskUserQuestion` to collect feature and design requirements:
+1. Ask the user directly to collect feature and design requirements:
 
    | Question | Header | Options |
    |----------|--------|---------|
@@ -182,7 +189,7 @@ Immediately after the dev server starts, verify the scaffold is working:
    >
    > Always generate options that make sense for the specific site — never reuse a fixed list.
 
-2. Read the design aesthetics reference: `${CLAUDE_PLUGIN_ROOT}/skills/create-site/references/design-aesthetics.md`
+2. Read the design aesthetics reference: `./references/design-aesthetics.md`
 3. **Map aesthetic + mood to design choices** using the Aesthetic x Mood Mapping table from the design reference. Record the chosen font direction, color direction, and motion direction.
 4. Analyze requirements and determine needed components. Present component plan to user as a table:
 
@@ -216,7 +223,7 @@ Immediately after the dev server starts, verify the scaffold is working:
 
 **Actions**:
 
-1. Read the design aesthetics reference: `${CLAUDE_PLUGIN_ROOT}/skills/create-site/references/design-aesthetics.md`
+1. Read the design aesthetics reference: `./references/design-aesthetics.md`
 2. Present the implementation plan directly to the user as a formatted message. **The plan MUST have ALL of the following sections:**
 
    **Section A — Design & Pages**

--- a/plugins/power-pages/skills/create-site/SKILL.md
+++ b/plugins/power-pages/skills/create-site/SKILL.md
@@ -11,8 +11,8 @@ Guide the user through creating a complete, production-quality Power Pages code 
 
 ## Codex Notes
 
-- Use `update_plan` for phase tracking wherever this skill mentions `TaskCreate`, `TaskUpdate`, or `TaskList`.
-- Ask the user directly in normal chat wherever this skill mentions `AskUserQuestion`.
+- Use `update_plan` for phase tracking throughout this skill.
+- Ask the user directly in normal chat whenever the workflow needs clarification or approval.
 - Treat `${CLAUDE_PLUGIN_ROOT}` references as paths rooted at `plugins/power-pages`.
 - Use web search only when you actually need fresh external assets or current documentation.
 
@@ -242,7 +242,7 @@ Immediately after the dev server starts, verify the scaffold is working:
 
    > **CRITICAL:** The plan is written for the user — do NOT reference internal phase numbers, tool names, or implementation details. Describe what will be built and what it will look like. The scaffold is already running — this plan covers what will be built on top of it.
 
-3. Use `AskUserQuestion` to get approval:
+3. Ask the user directly for approval:
 
    | Question | Header | Options |
    |----------|--------|---------|
@@ -267,7 +267,7 @@ Immediately after the dev server starts, verify the scaffold is working:
 
 ### 5.1 Create Todos for All Work
 
-**Before writing any code**, use `TaskCreate` to create a todo for every piece of work. This gives the user full visibility into what will be built:
+**Before writing any code**, use `update_plan` to create a plan for every major piece of work. This gives the user full visibility into what will be built:
 
 - **One todo per page** — e.g., "Create Contact page (`/contact`)", "Create Dashboard page (`/dashboard`)"
 - **One todo per shared component** — e.g., "Create ContactForm component", "Create DataTable component"
@@ -449,7 +449,7 @@ Present a summary table to the user:
    ```
 
 3. Share the dev server URL with the user and list all available routes
-4. Ask the user to review using `AskUserQuestion`:
+4. Ask the user to review directly in chat:
    > "The site is ready for review at `<dev server URL>`. Please check it out in your browser. Would you like any changes?"
 5. If the user requests changes, apply them and re-verify by browsing via `browser_snapshot`
 
@@ -471,7 +471,7 @@ Present a summary table to the user:
 
    Follow the skill tracking instructions in the reference to record this skill's usage. Use `--skillName "CreateSite"`. Note: `.powerpages-site` may not exist for first-time sites — the script exits silently.
 
-2. Use `AskUserQuestion` with options: **Deploy now (Recommended)**, **Skip for now**:
+2. Ask the user directly whether to **Deploy now (Recommended)** or **Skip for now**:
    > "Would you like to deploy your site to Power Pages now?"
 3. If the user chooses to deploy, invoke the `/deploy-site` skill.
 4. Mark all todos complete
@@ -494,7 +494,7 @@ Present a summary table to the user:
 
 ### Throughout All Phases
 
-- **Use TaskCreate/TaskUpdate** to track progress at every phase
+- **Use `update_plan`** to track progress at every phase
 - **Ask for user confirmation** at key decision points (see list below)
 - **Use best judgement** for design details — make confident, creative choices based on the user's aesthetic + mood selection without asking for every specific font, color, or layout decision
 - **Apply design from the start** — never build neutral then restyle
@@ -511,7 +511,7 @@ Present a summary table to the user:
 
 ### Progress Tracking
 
-Before starting Phase 1, create a task list with all phases using `TaskCreate`:
+Before starting Phase 1, create a plan with all phases using `update_plan`:
 
 | Task subject | activeForm | Description |
 |-------------|------------|-------------|
@@ -524,7 +524,7 @@ Before starting Phase 1, create a task list with all phases using `TaskCreate`:
 | Review with user | Reviewing site | Navigate all pages, share URL, get user feedback, apply changes |
 | Deploy and wrap up | Deploying site | Ask about deployment, present summary, suggest next steps |
 
-Mark each task `in_progress` when starting it and `completed` when done via `TaskUpdate`. This gives the user visibility into progress and keeps the workflow deterministic.
+Mark each phase `in_progress` when starting it and `completed` when done via `update_plan`. This gives the user visibility into progress and keeps the workflow deterministic.
 
 ### Quality Standards
 
@@ -575,7 +575,7 @@ Every site must meet these standards before completion:
 ### Phase 4: Plan Approval
 
 - Plan presented inline with design & pages + review & deployment sections
-- User approved via AskUserQuestion
+- User approved in chat
 
 ### Phase 5: Implementation
 

--- a/plugins/power-pages/skills/create-site/SKILL.md
+++ b/plugins/power-pages/skills/create-site/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: create-site
 description: This skill should be used when the user asks to "create a power pages site", "build a code site", "scaffold a website", "create a portal", "make a new site", or wants to create a new Power Pages code site (SPA) using React, Angular, Vue, or Astro.
-user-invocable: true
-argument-hint: Optional site description
-allowed-tools: Read, Write, Edit, Grep, Glob, Bash, WebSearch, AskUserQuestion, Task, TaskCreate, TaskUpdate, TaskList, mcp__plugin_power-pages_playwright__browser_navigate, mcp__plugin_power-pages_playwright__browser_snapshot, mcp__plugin_power-pages_playwright__browser_click
-model: opus
 ---
 
 > **Plugin check**: Run `node "${CLAUDE_PLUGIN_ROOT}/scripts/check-version.js"` — if it outputs a message, show it to the user before proceeding.

--- a/plugins/power-pages/skills/create-webroles/SKILL.md
+++ b/plugins/power-pages/skills/create-webroles/SKILL.md
@@ -5,9 +5,6 @@ description: >
   "set up web roles", "add roles", "create roles for my site", "manage web roles",
   "add authenticated role", "add anonymous role", or wants to create web roles for
   their Power Pages code site. Web roles control access and permissions for site users.
-user-invocable: true
-allowed-tools: Read, Write, Bash, Grep, Glob, AskUserQuestion, Task, TaskCreate, TaskUpdate, TaskList
-model: opus
 ---
 
 > **Plugin check**: Run `node "${CLAUDE_PLUGIN_ROOT}/scripts/check-version.js"` — if it outputs a message, show it to the user before proceeding.

--- a/plugins/power-pages/skills/create-webroles/SKILL.md
+++ b/plugins/power-pages/skills/create-webroles/SKILL.md
@@ -7,15 +7,21 @@ description: >
   their Power Pages code site. Web roles control access and permissions for site users.
 ---
 
-> **Plugin check**: Run `node "${CLAUDE_PLUGIN_ROOT}/scripts/check-version.js"` — if it outputs a message, show it to the user before proceeding.
+> **Plugin check**: Run `node "../../scripts/check-version.js"` from the plugin root — if it outputs a message, show it to the user before proceeding.
 
 # Create Web Roles
 
 Create web roles for a Power Pages code site. Web roles define the permissions and access levels for different types of site users.
 
+## Codex Notes
+
+- Use `update_plan` for phase tracking throughout this skill.
+- Ask the user directly in normal chat whenever the workflow needs clarification or approval.
+- Treat `${CLAUDE_PLUGIN_ROOT}` references as paths rooted at `plugins/power-pages`.
+
 ## Core Principles
 
-- **Use TaskCreate/TaskUpdate**: Track all progress throughout all phases — create the todo list upfront with all phases before starting any work.
+- **Use `update_plan`**: Track all progress throughout all phases — create the plan upfront with all phases before starting any work.
 - **Always use the UUID script**: Never generate UUIDs manually — always use `${CLAUDE_PLUGIN_ROOT}/scripts/generate-uuid.js` to produce valid UUID v4 values for each web role.
 - **Preserve uniqueness constraints**: Only one role can have `anonymoususersrole: true` and only one can have `authenticatedusersrole: true`. Always check existing roles before setting these flags.
 
@@ -44,7 +50,7 @@ Create web roles for a Power Pages code site. Web roles define the permissions a
 
 1. Locate the project root (`**/powerpages.config.json`) and check for `.powerpages-site/web-roles/`.
 
-2. **If `.powerpages-site` does NOT exist:** Ask the user to deploy first via `AskUserQuestion` (options: "Yes, deploy now (Recommended)", "No, I'll do it later"). If yes, invoke `/deploy-site` then resume from Phase 2. If no, stop.
+2. **If `.powerpages-site` does NOT exist:** Ask the user directly whether to deploy first (`Yes, deploy now (Recommended)` / `No, I'll do it later`). If yes, invoke `/deploy-site` then resume from Phase 2. If no, stop.
 
 3. **If `.powerpages-site` exists but `web-roles/` does NOT:** Create it:
 
@@ -95,7 +101,7 @@ Create web roles for a Power Pages code site. Web roles define the permissions a
 
 **Actions**:
 
-1. Based on the site's purpose and the existing roles, suggest appropriate web roles. Use `AskUserQuestion` to confirm with the user.
+1. Based on the site's purpose and the existing roles, suggest appropriate web roles. Ask the user directly to confirm.
 
    Common web roles for Power Pages sites include:
    - **Administrators** — Full access to site management
@@ -233,7 +239,7 @@ name: <Role Name>
 
 ### Progress Tracking
 
-Before starting Phase 1, create a task list with all phases using `TaskCreate`:
+Before starting Phase 1, create a plan with all phases using `update_plan`:
 
 | Task subject | activeForm | Description |
 |-------------|------------|-------------|
@@ -244,7 +250,7 @@ Before starting Phase 1, create a task list with all phases using `TaskCreate`:
 | Verify web roles | Verifying web roles | Validate all files exist, have valid UUIDs, and uniqueness constraints are satisfied |
 | Review and deploy | Reviewing and deploying | Present summary of created roles and offer deployment |
 
-Mark each task `in_progress` when starting it and `completed` when done via `TaskUpdate`. This gives the user visibility into progress and keeps the workflow deterministic.
+Mark each phase `in_progress` when starting it and `completed` when done via `update_plan`. This gives the user visibility into progress and keeps the workflow deterministic.
 
 ---
 

--- a/plugins/power-pages/skills/deploy-site/SKILL.md
+++ b/plugins/power-pages/skills/deploy-site/SKILL.md
@@ -11,8 +11,8 @@ Guide the user through deploying an existing Power Pages code site to a Power Pa
 
 ## Codex Notes
 
-- Use `update_plan` for phase tracking wherever this skill mentions `TaskCreate`, `TaskUpdate`, or `TaskList`.
-- Ask the user directly in normal chat wherever this skill mentions `AskUserQuestion`.
+- Use `update_plan` for phase tracking throughout this skill.
+- Ask the user directly in normal chat whenever the workflow needs clarification or approval.
 - Treat sibling slash commands such as `/audit-permissions` or `/activate-site` as references to the corresponding skill folders in `plugins/power-pages/skills/`.
 
 ## Core Principles
@@ -254,7 +254,7 @@ Evaluate the JSON result:
 
 #### 5.5.1 Ask About Activation (only if site is NOT already activated)
 
-Ask the user if they want to activate the site using `AskUserQuestion`:
+Ask the user directly if they want to activate the site:
 
 | Question | Header | Options |
 |----------|--------|---------|
@@ -269,7 +269,7 @@ After confirming the site is activated (either it was already activated in step 
 
 **Prerequisites**: The site must be activated and the project root must be known (from Phase 4.1).
 
-Use `AskUserQuestion` to confirm before proceeding:
+Ask the user directly to confirm before proceeding:
 
 | Question | Header | Options |
 |----------|--------|---------|
@@ -307,7 +307,7 @@ Tell the user:
 
 ### 6.2 Ask for Permission
 
-Use `AskUserQuestion`:
+Ask the user directly:
 
 | Question | Header | Options |
 |----------|--------|---------|
@@ -409,7 +409,7 @@ Always use `pac pages upload-code-site` — **never** use `pac pages upload`. Th
 
 ### Throughout All Phases
 
-- **Use TaskCreate/TaskUpdate** to track progress at every phase
+- **Use `update_plan`** to track progress at every phase
 - **Ask for user confirmation** at key decision points (see list below)
 - **Present errors clearly** — when a command fails, show the user the relevant error output and explain what went wrong before suggesting fixes
 
@@ -424,7 +424,7 @@ Always use `pac pages upload-code-site` — **never** use `pac pages upload`. Th
 
 ### Progress Tracking
 
-Before starting Phase 1, create a task list with all phases using `TaskCreate`:
+Before starting Phase 1, create a plan with all phases using `update_plan`:
 
 | Task subject | activeForm | Description |
 |-------------|------------|-------------|
@@ -435,7 +435,7 @@ Before starting Phase 1, create a task list with all phases using `TaskCreate`:
 | Verify deployment | Verifying deployment | Confirm .powerpages-site folder exists, review upload output, commit changes, offer activation |
 | Handle blocked JavaScript | Resolving JS block | If upload fails due to blocked JS, offer to unblock and retry |
 
-Mark each task `in_progress` when starting it and `completed` when done via `TaskUpdate`. Phase 6 may be marked `completed` immediately if no JavaScript blocking issue is encountered. This gives the user visibility into progress and keeps the workflow deterministic.
+Mark each phase `in_progress` when starting it and `completed` when done via `update_plan`. Phase 6 may be marked `completed` immediately if no JavaScript blocking issue is encountered. This gives the user visibility into progress and keeps the workflow deterministic.
 
 ---
 

--- a/plugins/power-pages/skills/deploy-site/SKILL.md
+++ b/plugins/power-pages/skills/deploy-site/SKILL.md
@@ -3,16 +3,22 @@ name: deploy-site
 description: This skill should be used when the user asks to "deploy to power pages", "upload site", "publish site", "deploy site", "push to power pages", "upload code site", or wants to deploy/upload an existing Power Pages code site to a Power Pages environment using PAC CLI.
 ---
 
-> **Plugin check**: Run `node "${CLAUDE_PLUGIN_ROOT}/scripts/check-version.js"` — if it outputs a message, show it to the user before proceeding.
+> **Plugin check**: Run `node "../../scripts/check-version.js"` from the plugin root — if it outputs a message, show it to the user before proceeding.
 
 # Deploy Power Pages Code Site
 
 Guide the user through deploying an existing Power Pages code site to a Power Pages environment using PAC CLI. Follow a systematic approach: verify tooling, authenticate, confirm the target environment, build and upload the site, and handle any blockers.
 
+## Codex Notes
+
+- Use `update_plan` for phase tracking wherever this skill mentions `TaskCreate`, `TaskUpdate`, or `TaskList`.
+- Ask the user directly in normal chat wherever this skill mentions `AskUserQuestion`.
+- Treat sibling slash commands such as `/audit-permissions` or `/activate-site` as references to the corresponding skill folders in `plugins/power-pages/skills/`.
+
 ## Core Principles
 
 - **Verify before acting**: Always confirm PAC CLI availability, authentication status, and the target environment before attempting any deployment.
-- **Use TaskCreate/TaskUpdate**: Track all progress throughout all phases — create the todo list upfront with all phases before starting any work.
+- **Use `update_plan`**: Track all progress throughout all phases — create the plan upfront with all phases before starting any work.
 - **Never change environment settings without consent**: If deployment requires modifying environment configuration (e.g., unblocking JavaScript attachments), always explain the change and get explicit user permission first.
 
 **Initial request:** $ARGUMENTS
@@ -25,7 +31,7 @@ Guide the user through deploying an existing Power Pages code site to a Power Pa
 
 **Actions**:
 
-1. Create todo list with all 6 phases (see [Progress Tracking](#progress-tracking) table)
+1. Create a plan with all 6 phases (see [Progress Tracking](#progress-tracking) table)
 2. Run `pac help` to check if the PAC CLI is installed and available on the system PATH.
 
    ```powershell
@@ -75,7 +81,7 @@ Guide the user through deploying an existing Power Pages code site to a Power Pa
 3. **If not authenticated**:
 
    1. Inform the user they are not authenticated with PAC CLI.
-   2. Use `AskUserQuestion` to ask for the environment URL:
+   2. Ask the user directly for the environment URL:
 
       | Question | Header | Options |
       |----------|--------|---------|
@@ -109,7 +115,7 @@ Guide the user through deploying an existing Power Pages code site to a Power Pa
 
 1. Present the current environment information to the user and ask them to confirm.
 
-   Use `AskUserQuestion` with the following structure:
+   Ask the user directly with the following structure:
 
    | Question | Header | Options |
    |----------|--------|---------|
@@ -126,7 +132,7 @@ Guide the user through deploying an existing Power Pages code site to a Power Pa
       ```
 
    2. Parse the output to extract environment names and URLs.
-   3. Use `AskUserQuestion` to present the available environments as options (pick up to 4 most relevant, or let user specify).
+   3. Ask the user directly to choose from the available environments (pick up to 4 most relevant, or let the user specify).
    4. Once the user selects an environment, switch to it:
 
       ```powershell
@@ -153,7 +159,7 @@ Determine the project root directory. The project root is the directory containi
 **/powerpages.config.json
 ```
 
-If found in the current working directory or a subdirectory, use that directory as `PROJECT_ROOT`. If multiple are found, ask the user which one to deploy using `AskUserQuestion`.
+If found in the current working directory or a subdirectory, use that directory as `PROJECT_ROOT`. If multiple are found, ask the user directly which one to deploy.
 
 If not found, ask the user to provide the path to the project root.
 
@@ -161,7 +167,7 @@ If not found, ask the user to provide the path to the project root.
 
 If `.powerpages-site` already exists (i.e., this is not the first deployment), table permissions and site settings may have drifted from the code since the last deployment. Offer to audit before deploying.
 
-Use `AskUserQuestion`:
+Ask the user directly:
 
 | Question | Header | Options |
 |----------|--------|---------|
@@ -215,7 +221,7 @@ Confirm `.powerpages-site` exists and list its contents (`web-roles/`, `site-set
 
 ### 5.2 Record Skill Usage
 
-> Reference: `${CLAUDE_PLUGIN_ROOT}/references/skill-tracking-reference.md`
+> Reference: `../../references/skill-tracking-reference.md`
 
 Follow the skill tracking instructions in the reference to record this skill's usage. Use `--skillName "DeploySite"`.
 
@@ -237,7 +243,7 @@ git commit -m "Deploy site to Power Pages"
 Run the activation status check:
 
 ```powershell
-node "${CLAUDE_PLUGIN_ROOT}/scripts/check-activation-status.js" --projectRoot "<PROJECT_ROOT>"
+node "../../scripts/check-activation-status.js" --projectRoot "<PROJECT_ROOT>"
 ```
 
 Evaluate the JSON result:

--- a/plugins/power-pages/skills/deploy-site/SKILL.md
+++ b/plugins/power-pages/skills/deploy-site/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: deploy-site
 description: This skill should be used when the user asks to "deploy to power pages", "upload site", "publish site", "deploy site", "push to power pages", "upload code site", or wants to deploy/upload an existing Power Pages code site to a Power Pages environment using PAC CLI.
-user-invocable: true
-allowed-tools: Read, Bash, AskUserQuestion, Glob, Grep, TaskCreate, TaskUpdate, TaskList
-model: sonnet
 ---
 
 > **Plugin check**: Run `node "${CLAUDE_PLUGIN_ROOT}/scripts/check-version.js"` — if it outputs a message, show it to the user before proceeding.

--- a/plugins/power-pages/skills/integrate-backend/SKILL.md
+++ b/plugins/power-pages/skills/integrate-backend/SKILL.md
@@ -10,10 +10,6 @@ description: >
   problem, identifies the right backend integration approach (or combination), and
   routes to the appropriate skill. Use this instead of jumping directly to a specific
   backend skill when the user's request doesn't clearly map to one approach.
-user-invocable: true
-argument-hint: describe what your backend needs to do
-allowed-tools: Read, Write, Edit, Bash, Grep, Glob, AskUserQuestion, Skill, Task, TaskCreate, TaskUpdate, TaskList
-model: opus
 ---
 
 > **Plugin check**: Run `node "${CLAUDE_PLUGIN_ROOT}/scripts/check-version.js"` — if it outputs a message, show it to the user before proceeding.

--- a/plugins/power-pages/skills/integrate-backend/SKILL.md
+++ b/plugins/power-pages/skills/integrate-backend/SKILL.md
@@ -12,11 +12,17 @@ description: >
   backend skill when the user's request doesn't clearly map to one approach.
 ---
 
-> **Plugin check**: Run `node "${CLAUDE_PLUGIN_ROOT}/scripts/check-version.js"` — if it outputs a message, show it to the user before proceeding.
+> **Plugin check**: Run `node "../../scripts/check-version.js"` from the plugin root — if it outputs a message, show it to the user before proceeding.
 
 # Backend Integration
 
 Analyze the user's business problem and recommend the right backend integration approach — **Web API**, **Server Logic**, **Cloud Flows**, or a combination — then route to the appropriate skill(s) to implement the solution.
+
+## Codex Notes
+
+- Use `update_plan` for phase tracking throughout this skill.
+- Ask the user directly in normal chat whenever the workflow needs clarification or approval.
+- Treat `${CLAUDE_PLUGIN_ROOT}` references as paths rooted at `plugins/power-pages`.
 
 ## Core Principles
 
@@ -102,7 +108,7 @@ From the user's request and the existing site state, determine:
 
 ### 2.2 Clarify if Ambiguous
 
-If the request could map to multiple approaches and the right choice isn't clear, use `AskUserQuestion` to clarify:
+If the request could map to multiple approaches and the right choice isn't clear, ask the user directly to clarify:
 
 | Question | When to ask |
 |----------|-------------|
@@ -297,7 +303,7 @@ In the CLI, give only a brief summary:
 
 ### 3.4 Confirm with User
 
-Use `AskUserQuestion`:
+Ask the user directly:
 
 | Question | Options |
 |----------|---------|
@@ -495,7 +501,7 @@ NOTE: The Web API item must NOT include the status field in its Update
 
 ### Progress Tracking
 
-Before starting Phase 1, create a task list with all phases using `TaskCreate`:
+Before starting Phase 1, create a plan with all phases using `update_plan`:
 
 | Task subject | activeForm | Description |
 |-------------|------------|-------------|
@@ -504,7 +510,7 @@ Before starting Phase 1, create a task list with all phases using `TaskCreate`:
 | Recommend integration approach | Evaluating approaches | Apply decision framework, present recommendation |
 | Route to implementation skill(s) | Implementing backend integration | Invoke the approved skill(s) and summarize results |
 
-Mark each task `in_progress` when starting and `completed` when done via `TaskUpdate`.
+Mark each phase `in_progress` when starting and `completed` when done via `update_plan`.
 
 ---
 

--- a/plugins/power-pages/skills/integrate-webapi/SKILL.md
+++ b/plugins/power-pages/skills/integrate-webapi/SKILL.md
@@ -18,8 +18,8 @@ Integrate Power Pages Web API into a code site's frontend. This skill orchestrat
 
 ## Codex Notes
 
-- Use `update_plan` for phase tracking wherever this skill mentions `TaskCreate`, `TaskUpdate`, or `TaskList`.
-- Ask the user directly in normal chat wherever this skill mentions `AskUserQuestion`.
+- Use `update_plan` for phase tracking throughout this skill.
+- Ask the user directly in normal chat whenever the workflow needs clarification or approval.
 - Do the analysis and implementation in the main Codex agent wherever this skill mentions the `Task` tool, an explore agent, or an architect agent.
 - Treat sibling slash commands such as `/deploy-site` as references to the corresponding skill folders in `plugins/power-pages/skills/`.
 
@@ -294,7 +294,7 @@ Present a table summarizing the verification:
 
 Both agents require the `.powerpages-site` folder. If it doesn't exist:
 
-Use `AskUserQuestion`:
+Ask the user directly:
 
 | Question | Options |
 |----------|---------|
@@ -306,7 +306,7 @@ Use `AskUserQuestion`:
 
 ### 6.2 Choose Permissions Source
 
-Ask the user how they want to define the permissions using the `AskUserQuestion` tool:
+Ask the user directly how they want to define the permissions:
 
 **Question**: "How would you like to define the Web API permissions and settings for your site?"
 
@@ -337,7 +337,7 @@ If the user chooses to upload an existing diagram:
 
 5. Generate a Mermaid flowchart from the parsed data (if the user provided an image or text) for visual confirmation.
 
-6. Present the parsed permissions plan to the user for approval using `AskUserQuestion`:
+6. Present the parsed permissions plan to the user for approval directly in chat:
 
    | Question | Options |
    |----------|---------|
@@ -493,7 +493,7 @@ Present a summary of everything that was done:
 
 ### 7.3 Ask to Deploy
 
-Use `AskUserQuestion`:
+Ask the user directly:
 
 | Question | Options |
 |----------|---------|
@@ -522,7 +522,7 @@ After deployment (or if skipped), remind the user:
 
 ### Throughout All Phases
 
-- **Use TaskCreate/TaskUpdate** to track progress at every phase
+- **Use `update_plan`** to track progress at every phase
 - **Ask for user confirmation** at key decision points (see list below)
 - **First table sequential, then parallel** — the first table creates the shared API client; after that, remaining tables can be processed in parallel since each creates independent files
 - **Commit at milestones** — after integration code and after permission files
@@ -539,7 +539,7 @@ After deployment (or if skipped), remind the user:
 
 ### Progress Tracking
 
-Before starting Phase 1, create a task list with all phases using `TaskCreate`:
+Before starting Phase 1, create a plan with all phases using `update_plan`:
 
 | Task subject | activeForm | Description |
 |-------------|------------|-------------|
@@ -551,7 +551,7 @@ Before starting Phase 1, create a task list with all phases using `TaskCreate`:
 | Setup permissions and settings | Configuring permissions and site settings | Choose permissions source (upload diagram or architects), invoke table-permissions-architect and webapi-settings-architect agents in parallel, create YAML files with case-sensitive validated column names, git commit |
 | Review and deploy | Reviewing summary and deploying | Present summary, ask about deployment, provide post-deploy guidance |
 
-Mark each task `in_progress` when starting it and `completed` when done via `TaskUpdate`. This gives the user visibility into progress and keeps the workflow deterministic.
+Mark each phase `in_progress` when starting it and `completed` when done via `update_plan`. This gives the user visibility into progress and keeps the workflow deterministic.
 
 ---
 

--- a/plugins/power-pages/skills/integrate-webapi/SKILL.md
+++ b/plugins/power-pages/skills/integrate-webapi/SKILL.md
@@ -10,18 +10,25 @@ description: >
   code integration, permissions setup, and deployment.
 ---
 
-> **Plugin check**: Run `node "${CLAUDE_PLUGIN_ROOT}/scripts/check-version.js"` — if it outputs a message, show it to the user before proceeding.
+> **Plugin check**: Run `node "../../scripts/check-version.js"` from the plugin root — if it outputs a message, show it to the user before proceeding.
 
 # Integrate Web API
 
 Integrate Power Pages Web API into a code site's frontend. This skill orchestrates the full lifecycle: analyzing where integrations are needed, implementing API client code for each table, configuring permissions and site settings, and deploying the site.
 
+## Codex Notes
+
+- Use `update_plan` for phase tracking wherever this skill mentions `TaskCreate`, `TaskUpdate`, or `TaskList`.
+- Ask the user directly in normal chat wherever this skill mentions `AskUserQuestion`.
+- Do the analysis and implementation in the main Codex agent wherever this skill mentions the `Task` tool, an explore agent, or an architect agent.
+- Treat sibling slash commands such as `/deploy-site` as references to the corresponding skill folders in `plugins/power-pages/skills/`.
+
 ## Core Principles
 
 - **First table sequential, then parallel**: The first table must be processed alone because it creates the shared `powerPagesApi.ts` client. Once that exists, remaining tables can be processed in parallel since each creates independent files (types, service, hooks).
-- **Parallelize independent agents**: The `table-permissions-architect` and `webapi-settings-architect` agents are independent — invoke them in parallel rather than sequentially.
+- **Parallelize independent work conceptually**: permissions analysis and site-setting analysis are independent, but in Codex they should normally be done directly in the main agent unless the user explicitly asks for delegation.
 - **Permissions require deployment**: The `.powerpages-site` folder must exist before table permissions and site settings can be configured. Integration code can be written without it, but permissions cannot.
-- **Use TaskCreate/TaskUpdate**: Track all progress throughout all phases — create the todo list upfront with all phases before starting any work.
+- **Use `update_plan`**: Track all progress throughout all phases — create the plan upfront with all phases before starting any work.
 
 > **Prerequisites:**
 >
@@ -38,9 +45,9 @@ Integrate Power Pages Web API into a code site's frontend. This skill orchestrat
 1. **Verify Site Exists** — Locate the Power Pages project and verify prerequisites
 2. **Explore Integration Points** — Analyze site code and data model to identify tables needing Web API integration
 3. **Review Integration Plan** — Present findings to the user and confirm which tables to integrate
-4. **Implement Integrations** — Use the `webapi-integration` agent for each table
+4. **Implement Integrations** — Implement the integration for each table directly in Codex
 5. **Verify Integrations** — Validate all expected files exist and the project builds successfully
-6. **Setup Permissions & Settings** — Choose permissions source (upload diagram or let the architects analyze), then configure table permissions and Web API site settings with case-sensitive validated column names
+6. **Setup Permissions & Settings** — Choose permissions source (upload diagram or let Codex analyze), then configure table permissions and Web API site settings with case-sensitive validated column names
 7. **Review & Deploy** — Ask the user to deploy the site and invoke `/deploy-site` if confirmed
 
 ---
@@ -71,7 +78,7 @@ Get-Content "<PROJECT_ROOT>/powerpages.config.json" | ConvertFrom-Json
 
 ### 1.3 Detect Framework
 
-Read `package.json` to determine the framework (React, Vue, Angular, or Astro). See `${CLAUDE_PLUGIN_ROOT}/references/framework-conventions.md` for the full framework detection mapping.
+Read `package.json` to determine the framework (React, Vue, Angular, or Astro). See `../../references/framework-conventions.md` for the full framework detection mapping.
 
 ### 1.4 Check for Data Model
 
@@ -103,11 +110,11 @@ Look for the `.powerpages-site` folder:
 
 **Actions**:
 
-Use the **Explore agent** (via `Task` tool with `agent_type: "explore"`) to analyze the site code and data model. The Explore agent should answer these questions:
+Analyze the site code and data model directly in the main Codex agent. Answer these questions:
 
 ### 2.1 Discover Tables
 
-Ask the Explore agent to identify all Dataverse tables that need Web API integration by examining:
+Identify all Dataverse tables that need Web API integration by examining:
 
 - `.datamodel-manifest.json` — List of tables and their columns
 - `src/**/*.{ts,tsx,js,jsx,vue,astro}` — Source code files that reference table data, mock data, or placeholder API calls
@@ -117,13 +124,13 @@ Ask the Explore agent to identify all Dataverse tables that need Web API integra
 - Mock data files or hardcoded arrays that should be replaced with API calls
 - `TODO` or `FIXME` comments mentioning API integration
 
-**Prompt for the Explore agent:**
+Use this checklist while analyzing:
 
 > "Analyze this Power Pages code site and identify all Dataverse tables that need Web API integration. Check `.datamodel-manifest.json` for the data model, then search the source code for: mock data arrays, hardcoded data, placeholder fetch calls to `/_api/`, TypeScript interfaces matching Dataverse column patterns (publisher prefix like `cr*_`), TODO/FIXME comments about API integration, and components that display table data. For each table found, report: the table logical name, the entity set name (plural), which source files reference it, what operations are needed (read/create/update/delete), and whether an existing API client or service already exists in `src/shared/` or `src/services/`. Also check if `src/shared/powerPagesApi.ts` already exists."
 
 ### 2.2 Identify Existing Integration Code
 
-The Explore agent should also report:
+Also capture:
 
 - Whether `src/shared/powerPagesApi.ts` (or equivalent API client) already exists
 - Which tables already have service files in `src/shared/services/` or `src/services/`
@@ -134,7 +141,7 @@ This avoids duplicating work that was already done.
 
 ### 2.3 Compile Integration Manifest
 
-From the Explore agent's findings, compile a list of tables needing integration:
+From your findings, compile a list of tables needing integration:
 
 | Table | Logical Name | Entity Set | Operations | Files Referencing | Existing Service |
 |-------|-------------|-----------|------------|-------------------|-----------------|
@@ -162,7 +169,7 @@ Show the user:
 
 ### 3.2 Confirm Tables
 
-Use `AskUserQuestion` to confirm:
+Ask the user directly to confirm:
 
 | Question | Options |
 |----------|---------|
@@ -176,15 +183,15 @@ If the user selects specific tables or adds more, update the integration manifes
 
 ## Phase 4: Implement Integrations
 
-**Goal**: Create Web API integration code for each confirmed table using the `webapi-integration` agent
+**Goal**: Create Web API integration code for each confirmed table directly in the main Codex agent
 
 **Actions**:
 
-### 4.1 Invoke Agent Per Table
+### 4.1 Implement Per Table
 
-For each table, use the `Task` tool to invoke the `webapi-integration` agent at `${CLAUDE_PLUGIN_ROOT}/agents/webapi-integration.md`:
+For each table, follow the guidance in `plugins/power-pages/agents/webapi-integration.md` but do the implementation directly in the main Codex agent.
 
-**Prompt template for the agent:**
+Use this table checklist:
 
 > "Integrate Power Pages Web API for the **[Table Display Name]** table.
 >
@@ -198,18 +205,18 @@ For each table, use the `Task` tool to invoke the `webapi-integration` agent at 
 >
 > Create the TypeScript types, CRUD service layer, and framework-specific hooks/composables. Replace any mock data or placeholder API calls in the referencing source files with the new service."
 
-### 4.2 Process First Table, Then Parallelize Remaining
+### 4.2 Process First Table, Then Continue Remaining
 
 The **first table** must be processed alone — it creates the shared `powerPagesApi.ts` client that all other tables depend on. After the first table completes and the shared client exists:
 
 - **Verify** the shared API client was created at `src/shared/powerPagesApi.ts`
-- **Then invoke all remaining tables in parallel** using multiple `Task` calls — each table creates independent files (its own types in `src/types/`, service in `src/shared/services/`, and hook/composable), so there are no conflicts
+- **Then implement all remaining tables** — each table creates independent files (its own types in `src/types/`, service in `src/shared/services/`, and hook/composable), so they can be handled in any order
 
 If there is only one table, this step is simply sequential.
 
 ### 4.3 Verify Each Integration
 
-After each agent completes (or after all parallel agents complete), verify the output:
+After each table integration is complete, verify the output:
 
 - Check that the expected files were created (types, service, hook/composable)
 - Confirm the shared API client exists after the first table is processed
@@ -537,9 +544,9 @@ Before starting Phase 1, create a task list with all phases using `TaskCreate`:
 | Task subject | activeForm | Description |
 |-------------|------------|-------------|
 | Verify site exists | Verifying site prerequisites | Locate project root, detect framework, check data model and deployment status |
-| Explore integration points | Analyzing code for integration points | Use Explore agent to discover tables, existing services, and compile integration manifest |
+| Explore integration points | Analyzing code for integration points | Discover tables, existing services, and compile the integration manifest directly in Codex |
 | Review integration plan | Reviewing integration plan with user | Present findings and confirm which tables to integrate |
-| Implement integrations | Implementing Web API integrations | Invoke webapi-integration agent for first table (creates shared client), then remaining tables in parallel, verify output, git commit |
+| Implement integrations | Implementing Web API integrations | Implement the first table to create the shared client, then finish the remaining tables and verify output before committing |
 | Verify integrations | Verifying integrations | Validate all expected files exist, check imports and API references, run project build |
 | Setup permissions and settings | Configuring permissions and site settings | Choose permissions source (upload diagram or architects), invoke table-permissions-architect and webapi-settings-architect agents in parallel, create YAML files with case-sensitive validated column names, git commit |
 | Review and deploy | Reviewing summary and deploying | Present summary, ask about deployment, provide post-deploy guidance |

--- a/plugins/power-pages/skills/integrate-webapi/SKILL.md
+++ b/plugins/power-pages/skills/integrate-webapi/SKILL.md
@@ -8,9 +8,6 @@ description: >
   Power Pages Web API into their site's frontend code with proper permissions
   and deployment. This skill orchestrates the full integration lifecycle:
   code integration, permissions setup, and deployment.
-user-invocable: true
-allowed-tools: Read, Write, Edit, Bash, Grep, Glob, AskUserQuestion, Task, TaskCreate, TaskUpdate, TaskList
-model: opus
 ---
 
 > **Plugin check**: Run `node "${CLAUDE_PLUGIN_ROOT}/scripts/check-version.js"` — if it outputs a message, show it to the user before proceeding.

--- a/plugins/power-pages/skills/setup-auth/SKILL.md
+++ b/plugins/power-pages/skills/setup-auth/SKILL.md
@@ -8,9 +8,6 @@ description: >
   "add auth to my site", "configure identity provider", or wants to set up
   authentication (login/logout via Microsoft Entra ID) and role-based
   authorization for their Power Pages code site.
-user-invocable: true
-allowed-tools: Read, Write, Edit, Bash, Grep, Glob, AskUserQuestion, Task, TaskCreate, TaskUpdate, TaskList, Skill
-model: opus
 ---
 
 > **Plugin check**: Run `node "${CLAUDE_PLUGIN_ROOT}/scripts/check-version.js"` — if it outputs a message, show it to the user before proceeding.

--- a/plugins/power-pages/skills/setup-auth/SKILL.md
+++ b/plugins/power-pages/skills/setup-auth/SKILL.md
@@ -10,11 +10,17 @@ description: >
   authorization for their Power Pages code site.
 ---
 
-> **Plugin check**: Run `node "${CLAUDE_PLUGIN_ROOT}/scripts/check-version.js"` — if it outputs a message, show it to the user before proceeding.
+> **Plugin check**: Run `node "../../scripts/check-version.js"` from the plugin root — if it outputs a message, show it to the user before proceeding.
 
 # Set Up Authentication & Authorization
 
 Configure authentication (login/logout via Microsoft Entra ID) and role-based authorization for a Power Pages code site. This skill creates an auth service, type declarations, authorization utilities, auth UI components, and role-based access control patterns appropriate to the site's framework.
+
+## Codex Notes
+
+- Use `update_plan` for phase tracking throughout this skill.
+- Ask the user directly in normal chat whenever the workflow needs clarification or approval.
+- Treat `${CLAUDE_PLUGIN_ROOT}` references as paths rooted at `plugins/power-pages`.
 
 ## Core Principles
 
@@ -75,7 +81,7 @@ Look for the `.powerpages-site` folder:
 
 > "The `.powerpages-site` folder was not found. The site needs to be deployed at least once before authentication can be configured."
 
-Use `AskUserQuestion`:
+Ask the user directly:
 
 | Question | Options |
 |----------|---------|
@@ -134,7 +140,7 @@ If auth files already exist, present them to the user and ask whether to overwri
 
 #### 2.1 Gather Requirements
 
-Use `AskUserQuestion` to determine the scope:
+Ask the user directly to determine the scope:
 
 | Question | Options |
 |----------|---------|
@@ -155,7 +161,7 @@ Present the implementation plan inline:
 - Which routes/components will be protected and with which roles
 - The site setting that needs to be configured (`Authentication/Registration/ProfileRedirectEnabled = false`)
 
-Use `AskUserQuestion` to get approval:
+Ask the user directly for approval:
 
 | Question | Options |
 |----------|---------|
@@ -514,7 +520,7 @@ Present a summary of everything created:
 
 #### 8.4 Ask to Deploy
 
-Use `AskUserQuestion`:
+Ask the user directly:
 
 | Question | Options |
 |----------|---------|
@@ -549,7 +555,7 @@ After deployment (or if skipped), remind the user:
 
 ### Progress Tracking
 
-Use `TaskCreate` at the start to track each phase:
+Use `update_plan` at the start to track each phase:
 
 | Task | Description |
 |------|-------------|
@@ -562,7 +568,7 @@ Use `TaskCreate` at the start to track each phase:
 | Phase 7 | Verify Auth Setup — validate files exist, build succeeds, auth UI renders |
 | Phase 8 | Review & Deploy — site setting, summary, deployment prompt |
 
-Update each task with `TaskUpdate` as phases are completed.
+Update each phase in `update_plan` as phases are completed.
 
 ### Key Decision Points
 

--- a/plugins/power-pages/skills/setup-datamodel/SKILL.md
+++ b/plugins/power-pages/skills/setup-datamodel/SKILL.md
@@ -8,16 +8,23 @@ description: >
   Power Pages site based on a data model proposal.
 ---
 
-> **Plugin check**: Run `node "${CLAUDE_PLUGIN_ROOT}/scripts/check-version.js"` — if it outputs a message, show it to the user before proceeding.
+> **Plugin check**: Run `node "../../scripts/check-version.js"` from the plugin root — if it outputs a message, show it to the user before proceeding.
 
 # Set Up Dataverse Data Model
 
 Guide the user through creating Dataverse tables, columns, and relationships for their Power Pages site. Follow a systematic approach: verify prerequisites, obtain a data model (via AI analysis or user-provided diagram), review and approve, then create all schema objects via OData API.
 
+## Codex Notes
+
+- Use `update_plan` for phase tracking wherever this skill mentions `TaskCreate`, `TaskUpdate`, or `TaskList`.
+- Ask the user directly in normal chat wherever this skill mentions `AskUserQuestion`.
+- Do the analysis in the main Codex agent wherever this skill mentions the `Task` tool or a specialist architect agent.
+- Treat `${CLAUDE_PLUGIN_ROOT}` references as paths rooted at `plugins/power-pages`.
+
 ## Core Principles
 
 - **Never create without approval**: Always present the full data model proposal and get explicit user confirmation before making any Dataverse changes.
-- **Use TaskCreate/TaskUpdate**: Track all progress throughout all phases — create the todo list upfront with all phases before starting any work.
+- **Use `update_plan`**: Track all progress throughout all phases — create the plan upfront with all phases before starting any work.
 - **Resilient execution**: Refresh tokens proactively, check for existing tables before creating, and report failures without automated rollback.
 
 **Initial request:** $ARGUMENTS
@@ -30,8 +37,8 @@ Guide the user through creating Dataverse tables, columns, and relationships for
 
 **Actions**:
 
-1. Create todo list with all 8 phases (see [Progress Tracking](#progress-tracking) table)
-2. Follow the prerequisite steps in `${CLAUDE_PLUGIN_ROOT}/references/dataverse-prerequisites.md` to verify PAC CLI auth, acquire an Azure CLI token, and confirm API access. Store the environment URL as `$envUrl`.
+1. Create a plan with all 8 phases (see [Progress Tracking](#progress-tracking) table)
+2. Follow the prerequisite steps in `../../references/dataverse-prerequisites.md` to verify PAC CLI auth, acquire an Azure CLI token, and confirm API access. Store the environment URL as `$envUrl`.
 
 **Output**: Verified PAC CLI auth, valid Azure CLI token, confirmed API access, `$envUrl` stored
 
@@ -43,7 +50,7 @@ Guide the user through creating Dataverse tables, columns, and relationships for
 
 **Actions**:
 
-1. Ask the user how they want to define the data model using the `AskUserQuestion` tool:
+1. Ask the user directly how they want to define the data model:
 
    **Question**: "How would you like to define the data model for your site?"
 
@@ -63,7 +70,7 @@ If the user chooses to upload an existing diagram:
    - **Mermaid syntax** — The user can paste Mermaid ER diagram text directly in chat
    - **Text description** — A structured list of tables, columns, and relationships
 
-2. Parse the diagram into the same structured format used by the data-model-architect agent:
+2. Parse the diagram into the same structured format used by the legacy data-model-architect workflow:
    - Publisher prefix (ask the user, or retrieve from the environment via `pac env who`)
    - Table definitions: `logicalName`, `displayName`, `status` (new/modified/reused), `columns`, `relationships`
    - Column definitions: `logicalName`, `displayName`, `type`, `required`
@@ -75,46 +82,32 @@ If the user chooses to upload an existing diagram:
 
 5. Proceed directly to **Phase 4: Review Proposal** with the parsed data model.
 
-### Path B: Let the Data Model Architect Figure It Out
+### Path B: Let Codex Analyze The Site
 
-If the user chooses to let the Data Model Architect figure it out, proceed to **Phase 3: Invoke Data Model Architect** (the existing automated flow).
+If the user chooses to let Codex infer the model, proceed to **Phase 3: Analyze Site And Propose Data Model**.
 
 **Output**: Data model source chosen and, for Path A, parsed data model ready for review
 
 ---
 
-## Phase 3: Invoke Data Model Architect
+## Phase 3: Analyze Site And Propose Data Model
 
-**Goal**: Spawn the data-model-architect agent to autonomously analyze the site and propose a data model
+**Goal**: Analyze the site in the main Codex agent and propose a complete data model
 
 **Actions**:
 
-1. Use the `Task` tool to spawn the `data-model-architect` agent. This agent autonomously:
-   - Analyzes the site's source code to infer data requirements
-   - Queries existing Dataverse tables via OData GET requests
-   - Identifies reuse opportunities (reuse, extend, or create new)
-   - Proposes a complete data model with an ER diagram
+1. Read `plugins/power-pages/agents/data-model-architect.md` as a reference for the expected proposal shape and checks.
+2. Analyze the current project and Dataverse environment directly:
+   - inspect the site's source code to infer data requirements
+   - query existing Dataverse tables via OData `GET` requests
+   - identify reuse opportunities (reuse, extend, or create new)
+   - propose a complete data model with an ER diagram
+3. Produce the same structured output the old architect agent would have returned:
+   - publisher prefix
+   - table definitions (`logicalName`, `displayName`, `status`, `columns`, `relationships`)
+   - Mermaid ER diagram
 
-2. Spawn the agent:
-
-   ```
-   Task tool:
-     subagent_type: general-purpose
-     prompt: |
-       You are the data-model-architect agent. Follow the instructions in
-       the agent definition file at:
-       ${CLAUDE_PLUGIN_ROOT}/agents/data-model-architect.md
-
-       Analyze the current project and Dataverse environment, then propose
-       a complete data model. Return:
-       1. Publisher prefix
-       2. Table definitions (logicalName, displayName, status, columns, relationships)
-       3. Mermaid ER diagram
-   ```
-
-3. Wait for the agent to return its structured proposal before proceeding.
-
-**Output**: Structured data model proposal from the agent (publisher prefix, table definitions, ER diagram)
+**Output**: Structured data model proposal (publisher prefix, table definitions, ER diagram)
 
 ---
 
@@ -136,7 +129,7 @@ Present the data model proposal directly to the user as a formatted message, inc
 
 ### 4.2 Get User Approval
 
-Use `AskUserQuestion` to get approval:
+Ask the user directly to get approval:
 
 | Question | Header | Options |
 |----------|--------|---------|
@@ -371,7 +364,7 @@ Before starting Phase 1, create a task list with all phases using `TaskCreate`:
 |-------------|------------|-------------|
 | Verify prerequisites | Verifying prerequisites | Confirm PAC CLI auth, acquire Azure CLI token, verify API access |
 | Choose data model source | Choosing data model source | Ask user to upload ER diagram or let AI analyze the site |
-| Invoke data model architect | Invoking data model architect | Spawn agent to analyze site and propose data model |
+| Analyze site and propose data model | Analyzing site and proposing data model | Inspect the project and Dataverse environment directly, then propose a data model |
 | Review and approve proposal | Reviewing proposal | Present data model proposal to user, get explicit approval |
 | Pre-creation checks | Running pre-creation checks | Refresh token, query existing tables, build creation plan |
 | Create tables and columns | Creating tables and columns | POST to OData API to create tables and columns |

--- a/plugins/power-pages/skills/setup-datamodel/SKILL.md
+++ b/plugins/power-pages/skills/setup-datamodel/SKILL.md
@@ -6,9 +6,6 @@ description: >
   "setup dataverse schema", "create the database", "build my data model",
   or wants to create Dataverse tables, columns, and relationships for their
   Power Pages site based on a data model proposal.
-user-invocable: true
-allowed-tools: Read, Write, Bash, Grep, Glob, AskUserQuestion, Task, TaskCreate, TaskUpdate, TaskList, mcp__plugin_power-pages_microsoft-learn__microsoft_docs_search, mcp__plugin_power-pages_microsoft-learn__microsoft_code_sample_search, mcp__plugin_power-pages_microsoft-learn__microsoft_docs_fetch
-model: opus
 ---
 
 > **Plugin check**: Run `node "${CLAUDE_PLUGIN_ROOT}/scripts/check-version.js"` — if it outputs a message, show it to the user before proceeding.

--- a/plugins/power-pages/skills/setup-datamodel/SKILL.md
+++ b/plugins/power-pages/skills/setup-datamodel/SKILL.md
@@ -16,8 +16,8 @@ Guide the user through creating Dataverse tables, columns, and relationships for
 
 ## Codex Notes
 
-- Use `update_plan` for phase tracking wherever this skill mentions `TaskCreate`, `TaskUpdate`, or `TaskList`.
-- Ask the user directly in normal chat wherever this skill mentions `AskUserQuestion`.
+- Use `update_plan` for phase tracking throughout this skill.
+- Ask the user directly in normal chat whenever the workflow needs clarification or approval.
 - Do the analysis in the main Codex agent wherever this skill mentions the `Task` tool or a specialist architect agent.
 - Treat `${CLAUDE_PLUGIN_ROOT}` references as paths rooted at `plugins/power-pages`.
 
@@ -344,7 +344,7 @@ After the summary, suggest:
 
 ### Throughout All Phases
 
-- **Use TaskCreate/TaskUpdate** to track progress at every phase
+- **Use `update_plan`** to track progress at every phase
 - **Ask for user confirmation** at key decision points (see list below)
 - **Token refresh is automatic** — the `dataverse-request.js` script handles 401 token refresh and 429/5xx retry internally
 - **Report failures without rollback** — track each creation attempt and continue with remaining items on failure
@@ -358,7 +358,7 @@ After the summary, suggest:
 
 ### Progress Tracking
 
-Before starting Phase 1, create a task list with all phases using `TaskCreate`:
+Before starting Phase 1, create a plan with all phases using `update_plan`:
 
 | Task subject | activeForm | Description |
 |-------------|------------|-------------|
@@ -371,7 +371,7 @@ Before starting Phase 1, create a task list with all phases using `TaskCreate`:
 | Create relationships | Creating relationships | POST to OData API to create 1:N and M:N relationships |
 | Publish and verify | Publishing and verifying | Publish customizations, verify tables, write manifest, present summary |
 
-Mark each task `in_progress` when starting it and `completed` when done via `TaskUpdate`. This gives the user visibility into progress and keeps the workflow deterministic.
+Mark each phase `in_progress` when starting it and `completed` when done via `update_plan`. This gives the user visibility into progress and keeps the workflow deterministic.
 
 ---
 

--- a/plugins/power-pages/skills/test-site/SKILL.md
+++ b/plugins/power-pages/skills/test-site/SKILL.md
@@ -8,13 +8,19 @@ description: >
   browser-based navigation, page crawling, and API request verification.
 ---
 
-> **Plugin check**: Run `node "${CLAUDE_PLUGIN_ROOT}/scripts/check-version.js"` — if it outputs a message, show it to the user before proceeding.
+> **Plugin check**: Run `node "../../scripts/check-version.js"` from the plugin root — if it outputs a message, show it to the user before proceeding.
 
 # Test Power Pages Site
 
 Test a deployed, activated Power Pages site at runtime. Navigate the site in a browser, crawl all discoverable links, verify pages load correctly, capture network traffic to test API requests, and generate a comprehensive test report.
 
 > **Prerequisite:** This skill expects a deployed and activated Power Pages site. Run `/deploy-site` and `/activate-site` first if the site is not yet live.
+
+## Codex Notes
+
+- Use `update_plan` for phase tracking throughout this skill.
+- Ask the user directly in normal chat whenever the workflow needs clarification or approval.
+- Treat `${CLAUDE_PLUGIN_ROOT}` references as paths rooted at `plugins/power-pages`.
 
 ## Core Principles
 
@@ -67,7 +73,7 @@ If no URL was provided, attempt auto-detection:
 
 #### 1.4 Ask the User
 
-If auto-detection failed or was inconclusive, use `AskUserQuestion`:
+If auto-detection failed or was inconclusive, ask the user directly:
 
 | Question | Header | Options |
 |----------|--------|---------|
@@ -148,7 +154,7 @@ Review the browser snapshot from Phase 2.4 and the current browser URL for signs
 
 #### 3.2 Handle Private Site Gate
 
-If a private site gate is detected, use `AskUserQuestion`:
+If a private site gate is detected, ask the user directly:
 
 | Question | Header | Options |
 |----------|--------|---------|
@@ -158,7 +164,7 @@ If a private site gate is detected, use `AskUserQuestion`:
 
 1. Use `browser_snapshot` to verify the user is now on the actual site (site content visible, navigation present, URL is back on the `SITE_URL` domain).
 2. If still on the identity provider login page:
-   - Use `AskUserQuestion` again: "It looks like the login hasn't completed yet. The browser should still be open — please complete the login and try again."
+   - Ask the user directly again: "It looks like the login hasn't completed yet. The browser should still be open — please complete the login and try again."
    - Repeat until login is confirmed or user cancels.
 3. Once confirmed, re-run Phase 2.5 and 2.6 (capture console errors and network requests on the now-loaded homepage).
 4. Continue to step 3.3 to check for site-level authentication.
@@ -184,7 +190,7 @@ If neither a private site gate nor site-level authentication indicators are foun
 
 #### 3.5 Handle Site-Level Authentication
 
-If site-level authentication indicators are detected (login links in navigation, etc.), use `AskUserQuestion`:
+If site-level authentication indicators are detected (login links in navigation, etc.), ask the user directly:
 
 | Question | Header | Options |
 |----------|--------|---------|
@@ -194,9 +200,9 @@ If site-level authentication indicators are detected (login links in navigation,
 
 1. Use `browser_snapshot` to verify the user is now logged in (login link replaced with user name/profile, or authenticated content is visible).
 2. If the login form is still showing:
-   - Use `AskUserQuestion` again: "It looks like the login hasn't completed yet. The browser should still be open — please complete the login and try again."
+   - Ask the user directly again: "It looks like the login hasn't completed yet. The browser should still be open — please complete the login and try again."
    - Repeat until login is confirmed or user cancels.
-3. Create an additional task for testing authenticated scenarios using `TaskCreate`:
+3. Add an additional `update_plan` step for testing authenticated scenarios:
 
    | Task subject | activeForm | Description |
    |-------------|------------|-------------|
@@ -533,7 +539,7 @@ Based on the test results, suggest relevant skills:
 
 ### Throughout All Phases
 
-- **Use TaskCreate/TaskUpdate** to track progress at every phase
+- **Use `update_plan`** to track progress at every phase
 - **This skill is read-only** — it does not modify any files or data
 - **Never attempt to log in** on behalf of the user — always ask them to log in via the browser window
 - **Present errors clearly** — when a page or API fails, include the specific URL and error details
@@ -549,7 +555,7 @@ Based on the test results, suggest relevant skills:
 
 ### Progress Tracking
 
-Before starting Phase 1, create a task list with all phases using `TaskCreate`:
+Before starting Phase 1, create a plan with all phases using `update_plan`:
 
 | Task subject | activeForm | Description |
 |-------------|------------|-------------|
@@ -560,7 +566,7 @@ Before starting Phase 1, create a task list with all phases using `TaskCreate`:
 | Test API requests | Testing API endpoints | Capture network requests, verify API responses, analyze errors |
 | Generate test report | Generating test report | Present summary of all pages and APIs tested, suggest next steps |
 
-Mark each task `in_progress` when starting it and `completed` when done via `TaskUpdate`.
+Mark each phase `in_progress` when starting it and `completed` when done via `update_plan`.
 
 ---
 

--- a/plugins/power-pages/skills/test-site/SKILL.md
+++ b/plugins/power-pages/skills/test-site/SKILL.md
@@ -6,10 +6,6 @@ description: >
   "test pages", "check api calls", "test web api", "verify deployment works",
   or wants to test a deployed, activated Power Pages site at runtime using
   browser-based navigation, page crawling, and API request verification.
-user-invocable: true
-argument-hint: "<site-url>"
-allowed-tools: Read, Bash, Glob, Grep, AskUserQuestion, TaskCreate, TaskUpdate, TaskList, mcp__plugin_power-pages_playwright__browser_navigate, mcp__plugin_power-pages_playwright__browser_snapshot, mcp__plugin_power-pages_playwright__browser_click, mcp__plugin_power-pages_playwright__browser_close, mcp__plugin_power-pages_playwright__browser_network_requests, mcp__plugin_power-pages_playwright__browser_console_messages, mcp__plugin_power-pages_playwright__browser_wait_for, mcp__plugin_power-pages_playwright__browser_take_screenshot, mcp__plugin_power-pages_playwright__browser_resize, mcp__plugin_power-pages_playwright__browser_evaluate
-model: opus
 ---
 
 > **Plugin check**: Run `node "${CLAUDE_PLUGIN_ROOT}/scripts/check-version.js"` — if it outputs a message, show it to the user before proceeding.


### PR DESCRIPTION
## Summary
- adapt repository and plugin guidance so Codex can consume plugin skills as standalone skill folders
- simplify all SKILL.md frontmatter to Codex-friendly metadata with only `name` and `description`
- rewrite canvas-apps workflows to run in a single Codex agent instead of relying on Claude task orchestration
- update key skill references in code-apps to use relative paths that Codex can follow directly

## Validation
- ran `git diff --check`
- verified all `SKILL.md` frontmatters contain only `name` and `description`