### PR TITLE
Add OpenCode installer support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ ENV/
 
 # Local settings
 .claude/settings.local.json
+.opencode/
 
 # OS
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Official agent skills/plugins for Power Platform development by Microsoft.
 
 ## Overview
 
-This repository is a **plugin marketplace** containing Claude Code/GitHub Copilot plugins for Power Platform services. Each plugin provides skills, agents, and commands to help developers build on the Power Platform.
+This repository is a plugin marketplace for Claude Code and GitHub Copilot, plus a filesystem-based skill and agent distribution for OpenCode. Each plugin provides skills, agents, and commands to help developers build on the Power Platform.
 
 ## Installation
 
@@ -27,13 +27,18 @@ curl -fsSL https://raw.githubusercontent.com/microsoft/power-platform-skills/mai
 The installer automatically:
 
 - Installs `pac` CLI if not already installed
-- Detects available tools (Claude Code, GitHub Copilot CLI)
-- Registers the plugin marketplace and installs all listed plugins
-- Enables auto-update so plugins stay current
+- Detects available tools (Claude Code, GitHub Copilot CLI, OpenCode)
+- Registers the marketplace and installs all listed plugins for Claude Code and GitHub Copilot
+- Generates namespaced OpenCode skill and agent wrappers under `~/.config/opencode`
+- Enables auto-update where the host supports it
 
 ### Manual Installation
 
-If you prefer to install manually, run these commands inside a Claude Code or GitHub Copilot CLI session:
+If you prefer to install manually, use the host-specific flow below.
+
+### Claude Code / GitHub Copilot CLI
+
+Run these commands inside a Claude Code or GitHub Copilot CLI session:
 
 1. Add the marketplace
 
@@ -46,9 +51,31 @@ If you prefer to install manually, run these commands inside a Claude Code or Gi
     ```bash
     /plugin install power-pages@power-platform-skills
     /plugin install model-apps@power-platform-skills
-    /plugin install code-apps@power-platform-skills
+    /plugin install mcp-apps@power-platform-skills
+    /plugin install code-apps-preview@power-platform-skills
     /plugin install canvas-apps@power-platform-skills
     ```
+
+### OpenCode
+
+OpenCode does not support the Claude/Copilot marketplace flow for this repository. Run the installer instead:
+
+```bash
+node scripts/install.js
+```
+
+The installer syncs a managed copy of this repository to `~/.config/opencode/power-platform-skills`, then generates global wrappers in:
+
+- `~/.config/opencode/skills/*/SKILL.md`
+- `~/.config/opencode/agents/*.md`
+
+OpenCode skill names are prefixed by plugin to avoid collisions. Common entry points:
+
+- `/power-pages-create-site`
+- `/model-apps-genpage`
+- `/mcp-apps-generate-mcp-app-ui`
+- `/code-apps-create-code-app`
+- `/canvas-apps-generate-canvas-app`
 
 ## Available Plugins
 
@@ -64,13 +91,19 @@ Build and deploy Power Apps generative pages for model-driven apps.
 
 **Stack**: React + TypeScript + Fluent, deployed via PAC CLI
 
-### [Code Apps](plugins/code-apps/AGENTS.md) (`plugins/code-apps`)
+### [Code Apps](plugins/code-apps/README.md) (`plugins/code-apps`)
 
 Build and deploy Power Apps code apps connected to Power Platform via connectors.
 
 **Stack**: React + Vite + TypeScript, deployed via PAC CLI
 
-### [Canvas Apps](plugins/canvas-apps/AGENTS.md) (`plugins/canvas-apps`)
+### [MCP Apps](plugins/mcp-apps/README.md) (`plugins/mcp-apps`)
+
+Generate self-contained MCP App widgets from tool output.
+
+**Stack**: HTML + MCP Apps protocol + Fluent UI via CDN
+
+### [Canvas Apps](plugins/canvas-apps/README.md) (`plugins/canvas-apps`)
 
 Author Power Apps Canvas Apps using the Canvas Authoring MCP server.
 
@@ -81,11 +114,18 @@ Author Power Apps Canvas Apps using the Canvas Authoring MCP server.
 To develop and test plugins locally, follow these steps:
 
 1. Clone this repository
-1. Launch Claude Code with plugin path:
+2. Refresh the OpenCode wrappers from the repo root when testing OpenCode locally:
+
+    ```bash
+    node scripts/install.js
+    ```
+
+3. Launch Claude Code with a plugin path when testing the native marketplace plugins directly:
 
     ```bash
     claude --plugin-dir /path/to/power-platform-skills/plugins/power-pages
     claude --plugin-dir /path/to/power-platform-skills/plugins/model-apps
+    claude --plugin-dir /path/to/power-platform-skills/plugins/mcp-apps
     claude --plugin-dir /path/to/power-platform-skills/plugins/code-apps
     claude --plugin-dir /path/to/power-platform-skills/plugins/canvas-apps
     ```

--- a/plugins/canvas-apps/README.md
+++ b/plugins/canvas-apps/README.md
@@ -17,6 +17,14 @@ Build Power Apps Canvas Apps with your coding agent as coauthor. This plugin con
 /plugin install canvas-apps@power-platform-skills
 ```
 
+### OpenCode
+
+```bash
+node scripts/install.js
+```
+
+The installer generates namespaced OpenCode skills such as `/canvas-apps-configure-canvas-mcp` and `/canvas-apps-generate-canvas-app`.
+
 ### From a local clone
 
 ```bash
@@ -27,9 +35,11 @@ claude --plugin-dir /path/to/power-platform-skills/plugins/canvas-apps
 
 ### `/configure-canvas-mcp`
 
-Register the Canvas Authoring MCP server with Claude Code or GitHub Copilot.
+Register the Canvas Authoring MCP server with Claude Code, GitHub Copilot, or OpenCode.
 
 **Usage:** Invoke directly with `/configure-canvas-mcp`, or use any of the keywords below to trigger the skill automatically:
+
+In OpenCode, use `/canvas-apps-configure-canvas-mcp`.
 
 - `Configure MCP for Canvas Apps`
 - `Set up the Canvas Authoring MCP server`
@@ -41,6 +51,8 @@ Generate a complete Canvas App from a natural language description.
 
 **Usage:** Invoke directly with `/generate-canvas-app`, or use any of the keywords below to trigger the skill automatically:
 
+In OpenCode, use `/canvas-apps-generate-canvas-app`.
+
 - `Create a Canvas App for managing inventory`
 - `I need a Canvas App for tracking employee time off`
 
@@ -49,6 +61,8 @@ Generate a complete Canvas App from a natural language description.
 Edit an existing Canvas App from a natural language description of changes.
 
 **Usage:** Invoke directly with `/edit-canvas-app`, or use any of the keywords below to trigger the skill automatically:
+
+In OpenCode, use `/canvas-apps-edit-canvas-app`.
 
 - `Modify the form in my existing Canvas App to include validation`
 - `Edit my Canvas App to add a new screen for reports`

--- a/plugins/code-apps/README.md
+++ b/plugins/code-apps/README.md
@@ -1,17 +1,17 @@
 # Code Apps Plugin
 
-Copilot plugin for building Power Apps code apps with React and Vite. Works with both Claude Code and GitHub Copilot.
+Plugin for building Power Apps code apps with React and Vite. Works with Claude Code, GitHub Copilot, and OpenCode.
 
 > **Preview:** This plugin is currently in preview and may change before general availability.
 
 ## Prerequisites
 
 - [Node.js v22+](https://nodejs.org/)
-- [Claude Code](https://docs.anthropic.com/en/docs/claude-code/getting-started) or [GitHub Copilot](https://github.com/features/copilot)
+- [Claude Code](https://docs.anthropic.com/en/docs/claude-code/getting-started), [GitHub Copilot](https://github.com/features/copilot), or [OpenCode](https://opencode.ai)
 
 ## Install
 
-The plugin marketplace is hosted in the `plugin` folder of the [microsoft/PowerAppsCodeApps](https://github.com/microsoft/PowerAppsCodeApps) repository.
+For Claude Code and GitHub Copilot, install from the `microsoft/power-platform-skills` marketplace.
 
 Open Claude Code or GitHub Copilot in any folder and run the following commands:
 
@@ -21,9 +21,19 @@ Open Claude Code or GitHub Copilot in any folder and run the following commands:
    ```
 
 2. Install the plugin:
-   ```
-   "/plugin install code-apps@power-platform-skills"
-   ```
+    ```
+    /plugin install code-apps-preview@power-platform-skills
+    ```
+
+### OpenCode
+
+Run the repository installer:
+
+```bash
+node scripts/install.js
+```
+
+The installer generates namespaced OpenCode skills under `~/.config/opencode/skills`. Start with `/code-apps-create-code-app`.
 
 ## Available Commands
 
@@ -42,10 +52,12 @@ Open Claude Code or GitHub Copilot in any folder and run the following commands:
 
 Start with `/create-code-app` — it walks you through everything.
 
+In OpenCode, the same commands are installed with a `code-apps-` prefix, for example `/code-apps-create-code-app` and `/code-apps-add-dataverse`.
+
 ## Uninstall
 
 ```
-/plugin uninstall code-apps
+/plugin uninstall code-apps-preview
 ```
 
 ## Documentation

--- a/plugins/code-apps/shared/version-check.md
+++ b/plugins/code-apps/shared/version-check.md
@@ -6,10 +6,10 @@
 
 ### Step 1: Check if a version check is needed
 
-Look for the file `~/.claude/.power-apps-last-version-check`. Use Bash to read it if it exists:
+Look for the file `~/.config/power-platform-skills/.code-apps-last-version-check`. Use Bash to read it if it exists:
 
 ```bash
-cat ~/.claude/.power-apps-last-version-check 2>/dev/null
+cat ~/.config/power-platform-skills/.code-apps-last-version-check 2>/dev/null
 ```
 
 - If the file exists and contains today's date (YYYY-MM-DD format), **skip the entire check** and continue with the skill silently.
@@ -27,7 +27,7 @@ Fetch the remote marketplace manifest using Bash:
 curl -fsSL https://raw.githubusercontent.com/microsoft/power-platform-skills/main/.claude-plugin/marketplace.json 2>/dev/null
 ```
 
-Parse the `version` field from the first plugin in the `plugins` array.
+Find the plugin in the `plugins` array whose `name` matches the local plugin name, then parse its `version` field.
 
 ### Step 4: Compare versions
 
@@ -40,7 +40,7 @@ Compare the local version against the remote version using semver rules — spli
 ```
 ╔══════════════════════════════════════════════════════════════╗
 ║  UPDATE AVAILABLE: v{local} → v{remote}                    ║
-║  Run: claude plugin update power-apps                       ║
+║  Re-run the Power Platform Skills installer                 ║
 ╚══════════════════════════════════════════════════════════════╝
 ```
 
@@ -48,13 +48,13 @@ Compare the local version against the remote version using semver rules — spli
 
 ### Step 6: Update the timestamp
 
-Write today's date (YYYY-MM-DD) to `~/.claude/.power-apps-last-version-check` using Bash:
+Write today's date (YYYY-MM-DD) to `~/.config/power-platform-skills/.code-apps-last-version-check` using Bash:
 
 ```bash
-mkdir -p ~/.claude && echo "YYYY-MM-DD" > ~/.claude/.power-apps-last-version-check
+mkdir -p ~/.config/power-platform-skills && echo "YYYY-MM-DD" > ~/.config/power-platform-skills/.code-apps-last-version-check
 ```
 
-> **Note:** Writing to `~/.claude/` is a pre-approved exception to the "confirm before writing outside project root" guardrail. This file is a shared cache and does not affect the user's project.
+> **Note:** Writing to `~/.config/power-platform-skills/` is a pre-approved exception to the "confirm before writing outside project root" guardrail. This file is a shared cache and does not affect the user's project.
 
 ## Error Handling
 

--- a/plugins/mcp-apps/README.md
+++ b/plugins/mcp-apps/README.md
@@ -11,6 +11,14 @@ Generate interactive MCP App widgets for MCP tools using Claude Code or Visual S
 /plugin install mcp-apps@power-platform-skills
 ```
 
+### OpenCode
+
+```bash
+node scripts/install.js
+```
+
+The installer generates the OpenCode wrapper command `/mcp-apps-generate-mcp-app-ui` under `~/.config/opencode/skills`.
+
 ### From a local clone
 
 ```bash
@@ -25,6 +33,8 @@ Describe the visual you want, paste your tool's JSON output, and get a self-cont
 
 1. Test your custom tool and copy the JSON output (make sure your tool's output is set to JSON)
 2. Run `/generate-mcp-app-ui` and describe the visual you want, pasting your tool's test output
+
+In OpenCode, use `/mcp-apps-generate-mcp-app-ui`.
 
 ### Example
 

--- a/plugins/model-apps/README.md
+++ b/plugins/model-apps/README.md
@@ -11,6 +11,14 @@ Build and deploy generative pages (genux) for Power Apps model-driven apps. This
 /plugin install model-apps@power-platform-skills
 ```
 
+### OpenCode
+
+```bash
+node scripts/install.js
+```
+
+The installer generates the OpenCode wrapper command `/model-apps-genpage` under `~/.config/opencode/skills`.
+
 ### From a local clone
 
 ```bash
@@ -27,6 +35,8 @@ claude --plugin-dir /path/to/power-platform-skills/plugins/model-apps
 ## Skills
 
 The plugin provides a single skill that covers the full lifecycle of a generative page.
+
+In OpenCode, `/genpage` is installed as `/model-apps-genpage` to keep skill names unique.
 
 ### `/genpage`
 

--- a/plugins/power-pages/README.md
+++ b/plugins/power-pages/README.md
@@ -13,6 +13,14 @@ Create and deploy Power Pages code sites using modern frontend frameworks. This 
 /plugin install power-pages@power-platform-skills
 ```
 
+### OpenCode
+
+```bash
+node scripts/install.js
+```
+
+The installer generates the OpenCode wrapper command `/power-pages-create-site` and the rest of the Power Pages skills under `~/.config/opencode/skills`.
+
 ### From a local clone
 
 ```bash
@@ -39,6 +47,8 @@ This keeps hook behavior in one place and avoids relying on skill-frontmatter ho
 ## Skills
 
 The plugin provides 9 skills that cover the full lifecycle of a Power Pages code site. Each skill is invoked conversationally — just describe what you want to do.
+
+In OpenCode, these same skills are installed with a `power-pages-` prefix. For example, `/create-site` becomes `/power-pages-create-site`.
 
 ### `/create-site`
 

--- a/plugins/power-pages/scripts/check-version.js
+++ b/plugins/power-pages/scripts/check-version.js
@@ -29,15 +29,17 @@ function compareSemver(a, b) {
 
 /**
  * Format the update notification as plain text.
- * Includes marketplace update (first) and plugin update (second).
+ * Keeps Claude-specific commands for users on that host, but also points
+ * other hosts such as OpenCode back to the shared installer.
  */
 function formatUpdateMessage(pluginName, localVersion, remoteVersion, marketplaceName) {
   const qualifiedName = marketplaceName ? `${pluginName}@${marketplaceName}` : pluginName;
   let msg = `\nPlugin update available: ${pluginName} ${localVersion} → ${remoteVersion}.\n`;
+  msg += 'Re-run the Power Platform Skills installer to refresh your host configuration.';
   if (marketplaceName) {
-    msg += `Run:\n  claude plugin marketplace update ${marketplaceName}\n  claude plugin update ${qualifiedName}`;
+    msg += `\nClaude Code users can also run:\n  claude plugin marketplace update ${marketplaceName}\n  claude plugin update ${qualifiedName}`;
   } else {
-    msg += `Run: claude plugin update ${qualifiedName}`;
+    msg += `\nClaude Code users can also run:\n  claude plugin update ${qualifiedName}`;
   }
   return msg;
 }

--- a/plugins/power-pages/scripts/tests/check-version.test.js
+++ b/plugins/power-pages/scripts/tests/check-version.test.js
@@ -40,10 +40,12 @@ test('formatUpdateMessage includes plugin name and both versions', () => {
   assert.ok(msg.includes('power-pages'));
   assert.ok(msg.includes('1.2.0'));
   assert.ok(msg.includes('1.3.0'));
+  assert.ok(msg.includes('Re-run the Power Platform Skills installer'));
 });
 
-test('formatUpdateMessage includes marketplace update then plugin update when marketplace is provided', () => {
+test('formatUpdateMessage includes installer guidance and Claude update commands when marketplace is provided', () => {
   const msg = formatUpdateMessage('power-pages', '1.2.0', '1.3.0', 'power-platform-skills');
+  assert.ok(msg.includes('Re-run the Power Platform Skills installer'));
   assert.ok(msg.includes('claude plugin marketplace update power-platform-skills'));
   assert.ok(msg.includes('claude plugin update power-pages@power-platform-skills'));
   const marketplaceIdx = msg.indexOf('marketplace update');
@@ -54,6 +56,7 @@ test('formatUpdateMessage includes marketplace update then plugin update when ma
 
 test('formatUpdateMessage uses plain name when marketplace is not provided', () => {
   const msg = formatUpdateMessage('power-pages', '1.2.0', '1.3.0');
+  assert.ok(msg.includes('Re-run the Power Platform Skills installer'));
   assert.ok(msg.includes('claude plugin update power-pages'));
   assert.ok(!msg.includes('@'));
   assert.ok(!msg.includes('marketplace update'));

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -2,8 +2,9 @@
 /**
  * Power Platform Skills — Installation Script
  *
- * Clones the marketplace repository and uses CLI commands to register
- * the marketplace and install plugins for Claude Code and GitHub Copilot.
+ * Registers the marketplace and installs plugins for Claude Code and
+ * GitHub Copilot, and generates filesystem-based skill/agent wrappers
+ * for OpenCode.
  *
  * Usage:
  *   node scripts/install.js                                              (from local clone)
@@ -18,9 +19,16 @@ const https = require("https");
 
 // ── Config ────────────────────────────────────────────────────
 const REPO = "microsoft/power-platform-skills";
+const REPO_URL = `https://github.com/${REPO}.git`;
 const MARKETPLACE_NAME = "power-platform-skills";
 const GITHUB_RAW = `https://raw.githubusercontent.com/${REPO}/main`;
 const HOME = os.homedir();
+const OPENCODE_CONFIG_ROOT = path.join(HOME, ".config", "opencode");
+const OPENCODE_INSTALL_ROOT = path.join(OPENCODE_CONFIG_ROOT, MARKETPLACE_NAME);
+const OPENCODE_INSTALL_MANIFEST = path.join(
+  OPENCODE_CONFIG_ROOT,
+  `${MARKETPLACE_NAME}-install-manifest.json`
+);
 
 // ── Colors (disabled when output is piped) ────────────────────
 const tty = process.stdout.isTTY;
@@ -82,6 +90,368 @@ function httpsGet(url) {
   });
 }
 
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function exists(filePath) {
+  return fs.existsSync(filePath);
+}
+
+function ensureDir(dirPath) {
+  fs.mkdirSync(dirPath, { recursive: true });
+}
+
+function removePath(targetPath) {
+  fs.rmSync(targetPath, { recursive: true, force: true });
+}
+
+function toPortablePath(filePath) {
+  return filePath.replace(/\\/g, "/");
+}
+
+function copyDir(source, target) {
+  ensureDir(target);
+  for (const entry of fs.readdirSync(source, { withFileTypes: true })) {
+    if (entry.name === ".git") continue;
+    const sourcePath = path.join(source, entry.name);
+    const targetPath = path.join(target, entry.name);
+    if (entry.isDirectory()) {
+      copyDir(sourcePath, targetPath);
+    } else {
+      ensureDir(path.dirname(targetPath));
+      fs.copyFileSync(sourcePath, targetPath);
+    }
+  }
+}
+
+function replaceFrontmatterName(content, nextName) {
+  const frontmatterMatch = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!frontmatterMatch) return content;
+
+  const frontmatter = frontmatterMatch[1];
+  const updatedFrontmatter = frontmatter.match(/^name:\s*.+$/m)
+    ? frontmatter.replace(/^name:\s*.+$/m, `name: ${nextName}`)
+    : `name: ${nextName}\n${frontmatter}`;
+
+  return `${content.slice(0, frontmatterMatch.index)}---\n${updatedFrontmatter}\n---${content.slice(
+    frontmatterMatch.index + frontmatterMatch[0].length
+  )}`;
+}
+
+function readFrontmatterName(content) {
+  const frontmatterMatch = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!frontmatterMatch) return null;
+  const nameMatch = frontmatterMatch[1].match(/^name:\s*(.+)$/m);
+  return nameMatch ? nameMatch[1].trim() : null;
+}
+
+function mapOpenCodeAgentColor(color) {
+  const normalized = color.trim().toLowerCase();
+  const supported = new Set([
+    "primary",
+    "secondary",
+    "accent",
+    "success",
+    "warning",
+    "error",
+    "info",
+  ]);
+
+  if (supported.has(normalized) || /^#[0-9a-f]{6}$/i.test(color.trim())) {
+    return color.trim();
+  }
+
+  const aliases = {
+    blue: "info",
+    cyan: "info",
+    green: "success",
+    yellow: "warning",
+    orange: "warning",
+    red: "error",
+    purple: "accent",
+  };
+
+  return aliases[normalized] || null;
+}
+
+function sanitizeOpenCodeAgentFrontmatter(content) {
+  const frontmatterMatch = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!frontmatterMatch) {
+    return `---\ndescription: Generated Power Platform Skills agent for OpenCode\nmode: subagent\n---\n\n${content}`;
+  }
+
+  const lines = frontmatterMatch[1].split(/\r?\n/);
+  const sanitized = [];
+  let skippingTools = false;
+  let hasMode = false;
+
+  for (const line of lines) {
+    if (skippingTools) {
+      if (/^\s+-\s+/.test(line)) {
+        continue;
+      }
+      skippingTools = false;
+    }
+
+    if (/^tools:\s*$/.test(line)) {
+      skippingTools = true;
+      continue;
+    }
+
+    if (/^name:\s*/.test(line) || /^model:\s*/.test(line)) {
+      continue;
+    }
+
+    const colorMatch = line.match(/^color:\s*(.+)$/);
+    if (colorMatch) {
+      const mapped = mapOpenCodeAgentColor(colorMatch[1]);
+      if (mapped) {
+        sanitized.push(`color: ${mapped}`);
+      }
+      continue;
+    }
+
+    if (/^mode:\s*/.test(line)) {
+      hasMode = true;
+    }
+
+    sanitized.push(line);
+  }
+
+  if (!hasMode) {
+    sanitized.push("mode: subagent");
+  }
+
+  const body = content.slice(frontmatterMatch.index + frontmatterMatch[0].length).replace(/^\r?\n/, "");
+  return `---\n${sanitized.join("\n")}\n---\n\n${body}`;
+}
+
+function resolveScriptRepoRoot() {
+  const candidates = [];
+  if (process.argv[1]) {
+    const scriptDir = path.dirname(path.resolve(process.argv[1]));
+    candidates.push(path.resolve(scriptDir, ".."));
+  }
+  candidates.push(process.cwd());
+
+  for (const candidate of candidates) {
+    if (exists(path.join(candidate, ".claude-plugin", "marketplace.json"))) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+function resolveMarketplaceSource(source) {
+  return source.replace(/^\.\//, "");
+}
+
+function getOpenCodePrefix(pluginName) {
+  return pluginName === "code-apps-preview" ? "code-apps" : pluginName;
+}
+
+function cleanupOpenCodeInstall() {
+  if (!exists(OPENCODE_INSTALL_MANIFEST)) return;
+
+  try {
+    const manifest = JSON.parse(fs.readFileSync(OPENCODE_INSTALL_MANIFEST, "utf8"));
+    for (const skillDir of manifest.skills || []) {
+      removePath(path.join(OPENCODE_CONFIG_ROOT, "skills", skillDir));
+    }
+    for (const agentFile of manifest.agents || []) {
+      removePath(path.join(OPENCODE_CONFIG_ROOT, "agents", agentFile));
+    }
+  } catch {
+    warn("Could not clean up previous OpenCode wrappers");
+  }
+}
+
+function writeOpenCodeInstallManifest(manifest) {
+  ensureDir(path.dirname(OPENCODE_INSTALL_MANIFEST));
+  fs.writeFileSync(OPENCODE_INSTALL_MANIFEST, JSON.stringify(manifest, null, 2) + "\n");
+}
+
+function syncLocalRepoForOpenCode(sourceRoot, plugins) {
+  removePath(OPENCODE_INSTALL_ROOT);
+  ensureDir(path.join(OPENCODE_INSTALL_ROOT, "plugins"));
+
+  for (const entry of [".claude-plugin", "shared"]) {
+    const sourcePath = path.join(sourceRoot, entry);
+    if (exists(sourcePath)) {
+      copyDir(sourcePath, path.join(OPENCODE_INSTALL_ROOT, entry));
+    }
+  }
+
+  for (const plugin of plugins) {
+    const relativeSource = resolveMarketplaceSource(plugin.source);
+    copyDir(path.join(sourceRoot, relativeSource), path.join(OPENCODE_INSTALL_ROOT, relativeSource));
+  }
+}
+
+function prepareOpenCodeSource(plugins) {
+  ensureDir(OPENCODE_CONFIG_ROOT);
+  const localRepoRoot = resolveScriptRepoRoot();
+
+  if (localRepoRoot) {
+    info("Syncing repository files for OpenCode...");
+    syncLocalRepoForOpenCode(localRepoRoot, plugins);
+    ok(`Repository synced to ${OPENCODE_INSTALL_ROOT}`);
+    return OPENCODE_INSTALL_ROOT;
+  }
+
+  if (!hasCommand("git")) {
+    fail("git not found — cannot fetch repository sources for OpenCode");
+    info(`Install git, or run this script from a local clone of ${REPO}`);
+    return null;
+  }
+
+  if (exists(path.join(OPENCODE_INSTALL_ROOT, ".git"))) {
+    info("Updating cached repository for OpenCode...");
+    const pullResult = run(`git -C "${OPENCODE_INSTALL_ROOT}" pull --ff-only`);
+    if (pullResult.ok) {
+      ok("Cached repository updated");
+      return OPENCODE_INSTALL_ROOT;
+    }
+
+    warn(`Could not update cached repository: ${pullResult.output}`);
+    removePath(OPENCODE_INSTALL_ROOT);
+  } else if (exists(OPENCODE_INSTALL_ROOT)) {
+    removePath(OPENCODE_INSTALL_ROOT);
+  }
+
+  info("Cloning repository for OpenCode...");
+  const cloneResult = run(`git clone --depth 1 "${REPO_URL}" "${OPENCODE_INSTALL_ROOT}"`);
+  if (cloneResult.ok) {
+    ok("Repository cloned for OpenCode");
+    return OPENCODE_INSTALL_ROOT;
+  }
+
+  fail(`Failed to clone repository: ${cloneResult.output}`);
+  return null;
+}
+
+function collectOpenCodeEntries(repoRoot, plugins) {
+  const entries = [];
+
+  for (const plugin of plugins) {
+    const pluginName = plugin.name;
+    const pluginRoot = path.join(repoRoot, resolveMarketplaceSource(plugin.source));
+    const prefix = getOpenCodePrefix(pluginName);
+    const skillMap = {};
+
+    const skillsRoot = path.join(pluginRoot, "skills");
+    if (exists(skillsRoot)) {
+      for (const entry of fs.readdirSync(skillsRoot, { withFileTypes: true })) {
+        if (!entry.isDirectory()) continue;
+        const sourcePath = path.join(skillsRoot, entry.name, "SKILL.md");
+        if (!exists(sourcePath)) continue;
+        const content = fs.readFileSync(sourcePath, "utf8");
+        const originalName = readFrontmatterName(content) || entry.name;
+        skillMap[originalName] = `${prefix}-${originalName}`;
+      }
+    }
+
+    entries.push({ pluginName, pluginRoot, prefix, skillMap });
+  }
+
+  return entries;
+}
+
+function rewriteOpenCodeContent(content, pluginRoot, skillMap) {
+  let updated = content.replace(/\$\{CLAUDE_PLUGIN_ROOT\}/g, toPortablePath(pluginRoot));
+
+  for (const [originalName, installedName] of Object.entries(skillMap)) {
+    const pattern = new RegExp(`/${escapeRegex(originalName)}(?=[^A-Za-z0-9-]|$)`, "g");
+    updated = updated.replace(pattern, `/${installedName}`);
+  }
+
+  return updated;
+}
+
+function installOpenCode(plugins) {
+  header("OpenCode");
+  const repoRoot = prepareOpenCodeSource(plugins);
+  if (!repoRoot) return;
+
+  const descriptors = collectOpenCodeEntries(repoRoot, plugins);
+  const installedSkills = [];
+  const installedAgents = [];
+
+  cleanupOpenCodeInstall();
+  ensureDir(path.join(OPENCODE_CONFIG_ROOT, "skills"));
+  ensureDir(path.join(OPENCODE_CONFIG_ROOT, "agents"));
+
+  info("Generating OpenCode skill wrappers...");
+  for (const descriptor of descriptors) {
+    const skillsRoot = path.join(descriptor.pluginRoot, "skills");
+    if (!exists(skillsRoot)) continue;
+
+    for (const entry of fs.readdirSync(skillsRoot, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      const sourcePath = path.join(skillsRoot, entry.name, "SKILL.md");
+      if (!exists(sourcePath)) continue;
+
+      const content = fs.readFileSync(sourcePath, "utf8");
+      const originalName = readFrontmatterName(content) || entry.name;
+      const installedName = descriptor.skillMap[originalName];
+      const targetDir = path.join(OPENCODE_CONFIG_ROOT, "skills", installedName);
+      const targetPath = path.join(targetDir, "SKILL.md");
+
+      let updated = rewriteOpenCodeContent(content, descriptor.pluginRoot, descriptor.skillMap);
+      updated = replaceFrontmatterName(updated, installedName);
+
+      ensureDir(targetDir);
+      fs.writeFileSync(targetPath, updated);
+      installedSkills.push(installedName);
+    }
+  }
+  ok(`Installed ${installedSkills.length} OpenCode skills`);
+
+  info("Generating OpenCode agent wrappers...");
+  for (const descriptor of descriptors) {
+    const agentsRoot = path.join(descriptor.pluginRoot, "agents");
+    if (!exists(agentsRoot)) continue;
+
+    for (const entry of fs.readdirSync(agentsRoot, { withFileTypes: true })) {
+      if (!entry.isFile() || !entry.name.endsWith(".md")) continue;
+
+      const sourcePath = path.join(agentsRoot, entry.name);
+      const content = fs.readFileSync(sourcePath, "utf8");
+      const originalName = readFrontmatterName(content) || path.basename(entry.name, ".md");
+      const installedName = `${descriptor.prefix}-${originalName}`;
+      const targetFile = `${installedName}.md`;
+      const targetPath = path.join(OPENCODE_CONFIG_ROOT, "agents", targetFile);
+
+      let updated = rewriteOpenCodeContent(content, descriptor.pluginRoot, descriptor.skillMap);
+      updated = sanitizeOpenCodeAgentFrontmatter(updated);
+
+      fs.writeFileSync(targetPath, updated);
+      installedAgents.push(targetFile);
+    }
+  }
+  ok(`Installed ${installedAgents.length} OpenCode agents`);
+
+  writeOpenCodeInstallManifest({
+    installedAt: new Date().toISOString(),
+    repoRoot: OPENCODE_INSTALL_ROOT,
+    skills: installedSkills,
+    agents: installedAgents,
+  });
+
+  const verifiedSkills = installedSkills.filter((skill) =>
+    exists(path.join(OPENCODE_CONFIG_ROOT, "skills", skill, "SKILL.md"))
+  );
+  const verifiedAgents = installedAgents.filter((agent) =>
+    exists(path.join(OPENCODE_CONFIG_ROOT, "agents", agent))
+  );
+
+  ok(`Verified: ${verifiedSkills.length} skills, ${verifiedAgents.length} agents`);
+  info(`Config root: ${OPENCODE_CONFIG_ROOT}`);
+  info(`Repository cache: ${OPENCODE_INSTALL_ROOT}`);
+}
+
 // ── Auto-update ──────────────────────────────────────────────
 // The CLI's `marketplace add` does not set autoUpdate — patch it manually.
 // `getMarketplaces` extracts the marketplaces object from the config root.
@@ -107,19 +477,11 @@ function enableAutoUpdate(configFile, getMarketplaces) {
 
 // ── Marketplace loader ────────────────────────────────────────
 async function loadMarketplace() {
-  const scriptDir = process.argv[1] ? path.dirname(path.resolve(process.argv[1])) : process.cwd();
-  // Script lives in scripts/, so the repo root is one level up
-  const repoRoot = path.resolve(scriptDir, "..");
-  const localFile = path.join(repoRoot, ".claude-plugin", "marketplace.json");
-
-  if (fs.existsSync(localFile)) {
-    return JSON.parse(fs.readFileSync(localFile, "utf8"));
-  }
-
-  // Also check cwd (handles running from repo root or piped download)
-  const cwdFile = path.join(process.cwd(), ".claude-plugin", "marketplace.json");
-  if (fs.existsSync(cwdFile)) {
-    return JSON.parse(fs.readFileSync(cwdFile, "utf8"));
+  const localRepoRoot = resolveScriptRepoRoot();
+  if (localRepoRoot) {
+    return JSON.parse(
+      fs.readFileSync(path.join(localRepoRoot, ".claude-plugin", "marketplace.json"), "utf8")
+    );
   }
 
   info("Fetching marketplace manifest from GitHub...");
@@ -131,7 +493,6 @@ async function loadMarketplace() {
 function installClaude(plugins) {
   header("Claude Code");
 
-  // 1. Register marketplace via CLI (CLI clones the repo automatically)
   info("Registering marketplace...");
   const addResult = run(`claude plugin marketplace add "${REPO}"`);
   if (addResult.ok) {
@@ -143,7 +504,6 @@ function installClaude(plugins) {
     return;
   }
 
-  // 2. Update marketplace
   info("Updating marketplace...");
   const updateResult = run(`claude plugin marketplace update "${MARKETPLACE_NAME}"`);
   if (updateResult.ok) {
@@ -152,11 +512,9 @@ function installClaude(plugins) {
     warn(`Marketplace update: ${updateResult.output}`);
   }
 
-  // 3. Enable auto-update (CLI does not set this)
   const knownPath = path.join(HOME, ".claude", "plugins", "known_marketplaces.json");
   enableAutoUpdate(knownPath, (data) => data);
 
-  // 4. Install each plugin via CLI
   for (const plugin of plugins) {
     info(`Installing ${plugin}...`);
     const installResult = run(
@@ -171,11 +529,10 @@ function installClaude(plugins) {
     }
   }
 
-  // 5. Verify installation
   info("Verifying installation...");
   const listResult = run("claude plugin list");
   if (listResult.ok) {
-    const installed = plugins.filter((p) => listResult.output.includes(p));
+    const installed = plugins.filter((plugin) => listResult.output.includes(plugin));
     if (installed.length > 0) {
       ok(`Verified: ${installed.join(", ")}`);
     } else {
@@ -188,7 +545,6 @@ function installClaude(plugins) {
 function installCopilot(plugins) {
   header("GitHub Copilot");
 
-  // 1. Register marketplace via CLI (CLI clones the repo automatically)
   info("Registering marketplace...");
   const addResult = run(`copilot plugin marketplace add "${REPO}"`);
   if (addResult.ok) {
@@ -200,11 +556,9 @@ function installCopilot(plugins) {
     return;
   }
 
-  // 2. Enable auto-update (CLI does not set this)
   const configPath = path.join(HOME, ".copilot", "config.json");
   enableAutoUpdate(configPath, (data) => data.marketplaces);
 
-  // 3. Install each plugin via CLI
   for (const plugin of plugins) {
     info(`Installing ${plugin}...`);
     const installResult = run(`copilot plugin install "${plugin}@${MARKETPLACE_NAME}"`);
@@ -217,11 +571,10 @@ function installCopilot(plugins) {
     }
   }
 
-  // 4. Verify installation
   info("Verifying installation...");
   const listResult = run("copilot plugin list");
   if (listResult.ok) {
-    const installed = plugins.filter((p) => listResult.output.includes(p));
+    const installed = plugins.filter((plugin) => listResult.output.includes(plugin));
     if (installed.length > 0) {
       ok(`Verified: ${installed.join(", ")}`);
     } else {
@@ -230,40 +583,56 @@ function installCopilot(plugins) {
   }
 }
 
+function printGetStarted(tool) {
+  if (tool === "opencode") {
+    console.log("    opencode session -> /power-pages-create-site");
+    console.log("    opencode session -> /model-apps-genpage");
+    console.log("    opencode session -> /mcp-apps-generate-mcp-app-ui");
+    console.log("    opencode session -> /code-apps-create-code-app");
+    console.log("    opencode session -> /canvas-apps-generate-canvas-app");
+    return;
+  }
+
+  console.log(`    ${tool} session  ->  /power-pages:create-site`);
+}
+
 // ── Main ──────────────────────────────────────────────────────
 async function main() {
   console.log("");
   console.log(bold("Power Platform Skills — Installer"));
   console.log("──────────────────────────────────");
 
-  // ── Prerequisites ──────────────────────────────────────────
   header("Checking prerequisites");
   ok(`Node.js ${process.version}`);
 
-  // Detect tools — require CLI in PATH (CLI commands need the binary)
   const tools = [];
 
   if (hasCommand("claude")) {
-    const ver = run("claude --version");
+    const version = run("claude --version");
     tools.push("claude");
-    ok(`Claude Code ${ver.ok ? ver.output : "(version unknown)"}`);
+    ok(`Claude Code ${version.ok ? version.output : "(version unknown)"}`);
   }
   if (hasCommand("copilot")) {
-    const ver = run("copilot --version");
+    const version = run("copilot --version");
     tools.push("copilot");
-    ok(`GitHub Copilot CLI ${ver.ok ? ver.output : "(version unknown)"}`);
+    ok(`GitHub Copilot CLI ${version.ok ? version.output : "(version unknown)"}`);
+  }
+  if (hasCommand("opencode")) {
+    const version = run("opencode --version");
+    tools.push("opencode");
+    ok(`OpenCode ${version.ok ? version.output : "(version unknown)"}`);
   }
 
   if (tools.length === 0) {
-    fail("Neither Claude Code nor GitHub Copilot CLI found in PATH.");
+    fail("No supported host CLI found in PATH.");
     console.log("");
     console.log("  Install at least one and ensure it is on your PATH:");
     console.log("    Claude Code     https://docs.anthropic.com/en/docs/claude-code");
     console.log("    GitHub Copilot  https://docs.github.com/en/copilot");
+    console.log("    OpenCode        https://opencode.ai");
     process.exit(1);
   }
 
-  // ── PAC CLI ──────────────────────────────────────────────────
   header("Power Platform CLI (pac)");
 
   if (hasCommand("pac")) {
@@ -271,7 +640,6 @@ async function main() {
     const versionMatch = ver.ok && ver.output.match(/Version:\s*(.+)/i);
     ok(`PAC CLI ${versionMatch ? versionMatch[1].trim() : "(installed)"}`);
 
-    // Check NuGet for a newer version and update if available
     if (hasCommand("dotnet")) {
       const localVersion = versionMatch ? versionMatch[1].trim().split("+")[0] : null;
       let latestVersion = null;
@@ -290,9 +658,7 @@ async function main() {
       } else if (latestVersion) {
         info(`Newer version available: ${latestVersion} (installed: ${localVersion || "unknown"})`);
         info("Updating PAC CLI...");
-        const updateResult = run(
-          "dotnet tool update --global Microsoft.PowerApps.CLI.Tool"
-        );
+        const updateResult = run("dotnet tool update --global Microsoft.PowerApps.CLI.Tool");
         if (updateResult.ok) {
           ok(`Updated to ${latestVersion}`);
         } else {
@@ -305,9 +671,7 @@ async function main() {
 
     if (hasCommand("dotnet")) {
       info("Installing PAC CLI via dotnet tool...");
-      const installResult = run(
-        "dotnet tool install --global Microsoft.PowerApps.CLI.Tool"
-      );
+      const installResult = run("dotnet tool install --global Microsoft.PowerApps.CLI.Tool");
       if (installResult.ok) {
         ok("PAC CLI installed");
         info("You may need to restart your terminal for the 'pac' command to be available.");
@@ -327,7 +691,6 @@ async function main() {
     }
   }
 
-  // ── Azure CLI ───────────────────────────────────────────────
   header("Azure CLI (az)");
 
   if (hasCommand("az")) {
@@ -373,39 +736,55 @@ async function main() {
     }
   }
 
-  // ── Marketplace ────────────────────────────────────────────
   header("Reading marketplace");
 
   const manifest = await loadMarketplace();
-  const plugins = manifest.plugins.map((p) => p.name);
+  const plugins = manifest.plugins.map((plugin) => plugin.name);
+  const openCodePlugins = manifest.plugins.map((plugin) => ({
+    name: plugin.name,
+    source: plugin.source,
+  }));
 
   console.log(`  Marketplace : ${manifest.name}`);
   console.log("  Plugins     :");
-  for (const p of plugins) console.log(`    - ${p}`);
+  for (const plugin of plugins) console.log(`    - ${plugin}`);
 
   if (plugins.length === 0) {
     warn("No plugins found in the marketplace.");
     process.exit(0);
   }
 
-  // ── Install ────────────────────────────────────────────────
   if (tools.includes("claude")) installClaude(plugins);
   if (tools.includes("copilot")) installCopilot(plugins);
+  if (tools.includes("opencode")) installOpenCode(openCodePlugins);
 
-  // ── Summary ────────────────────────────────────────────────
   header("Done!");
   console.log("");
-  console.log("  Plugins will stay current via the marketplace auto-update mechanism.");
   console.log("  Run this script again anytime to re-install or update.");
+  console.log("  Claude Code and GitHub Copilot stay current via marketplace auto-update.");
+  console.log("  OpenCode is refreshed by re-running this installer.");
   console.log("");
   console.log("  Get started:");
   for (const tool of tools) {
-    console.log(`    ${tool} session  ->  /power-pages:create-site`);
+    printGetStarted(tool);
   }
   console.log("");
 }
 
-main().catch((err) => {
-  fail(`Installation failed: ${err.message}`);
-  process.exit(1);
-});
+module.exports = {
+  collectOpenCodeEntries,
+  installOpenCode,
+  loadMarketplace,
+  prepareOpenCodeSource,
+  replaceFrontmatterName,
+  resolveScriptRepoRoot,
+  rewriteOpenCodeContent,
+  sanitizeOpenCodeAgentFrontmatter,
+};
+
+if (require.main === module) {
+  main().catch((err) => {
+    fail(`Installation failed: ${err.message}`);
+    process.exit(1);
+  });
+}

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -248,6 +248,37 @@ function resolveMarketplaceSource(source) {
   return source.replace(/^\.\//, "");
 }
 
+function getOpenCodeCompatibilitySkillRoots() {
+  return [
+    path.join(HOME, ".claude", "skills"),
+    path.join(HOME, ".agents", "skills"),
+    path.join(OPENCODE_CONFIG_ROOT, "skills"),
+  ];
+}
+
+function collectSkillNamesFromRoots(roots) {
+  const skills = new Map();
+
+  for (const root of roots) {
+    if (!exists(root)) continue;
+
+    for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+
+      const skillPath = path.join(root, entry.name, "SKILL.md");
+      if (!exists(skillPath)) continue;
+
+      const content = fs.readFileSync(skillPath, "utf8");
+      const skillName = readFrontmatterName(content) || entry.name;
+      if (!skills.has(skillName)) {
+        skills.set(skillName, skillPath);
+      }
+    }
+  }
+
+  return skills;
+}
+
 function getOpenCodePrefix(pluginName) {
   return pluginName === "code-apps-preview" ? "code-apps" : pluginName;
 }
@@ -378,10 +409,13 @@ function installOpenCode(plugins) {
   const descriptors = collectOpenCodeEntries(repoRoot, plugins);
   const installedSkills = [];
   const installedAgents = [];
+  const skippedSkills = [];
 
   cleanupOpenCodeInstall();
   ensureDir(path.join(OPENCODE_CONFIG_ROOT, "skills"));
   ensureDir(path.join(OPENCODE_CONFIG_ROOT, "agents"));
+
+  const existingSkills = collectSkillNamesFromRoots(getOpenCodeCompatibilitySkillRoots());
 
   info("Generating OpenCode skill wrappers...");
   for (const descriptor of descriptors) {
@@ -399,15 +433,29 @@ function installOpenCode(plugins) {
       const targetDir = path.join(OPENCODE_CONFIG_ROOT, "skills", installedName);
       const targetPath = path.join(targetDir, "SKILL.md");
 
+      if (existingSkills.has(installedName)) {
+        skippedSkills.push({
+          name: installedName,
+          existingPath: existingSkills.get(installedName),
+        });
+        continue;
+      }
+
       let updated = rewriteOpenCodeContent(content, descriptor.pluginRoot, descriptor.skillMap);
       updated = replaceFrontmatterName(updated, installedName);
 
       ensureDir(targetDir);
       fs.writeFileSync(targetPath, updated);
       installedSkills.push(installedName);
+      existingSkills.set(installedName, targetPath);
     }
   }
   ok(`Installed ${installedSkills.length} OpenCode skills`);
+  if (skippedSkills.length > 0) {
+    info(
+      `Skipped ${skippedSkills.length} duplicate OpenCode skills already available via compatibility paths`
+    );
+  }
 
   info("Generating OpenCode agent wrappers...");
   for (const descriptor of descriptors) {
@@ -772,7 +820,9 @@ async function main() {
 }
 
 module.exports = {
+  collectSkillNamesFromRoots,
   collectOpenCodeEntries,
+  getOpenCodeCompatibilitySkillRoots,
   installOpenCode,
   loadMarketplace,
   prepareOpenCodeSource,


### PR DESCRIPTION
## Summary
- add OpenCode support to the installer by generating namespaced filesystem-based skill and agent wrappers alongside the existing Claude Code and GitHub Copilot marketplace flow
- update README and plugin docs, plus version-check guidance, so OpenCode users get the right install, update, and command names
- normalize generated OpenCode agent frontmatter and ignore project-local .opencode/ files so local state does not break the CLI or leak into git

## Testing
- node --check scripts/install.js
- node --test plugins/power-pages/scripts/tests/check-version.test.js
- opencode --help