### PR TITLE
[Pages] Bump astro to ^6.1.6 to fix XSS in define:vars

### DIFF
--- a/plugins/power-pages/skills/create-site/assets/astro/package.json
+++ b/plugins/power-pages/skills/create-site/assets/astro/package.json
@@ -9,6 +9,6 @@
     "preview": "astro preview"
   },
   "dependencies": {
-    "astro": "^5.2.0"
+    "astro": "^6.1.6"
   }
 }

--- a/plugins/power-pages/skills/create-site/assets/astro/src/layouts/Layout.astro
+++ b/plugins/power-pages/skills/create-site/assets/astro/src/layouts/Layout.astro
@@ -1,5 +1,5 @@
 ---
-import { ViewTransitions } from 'astro:transitions'
+import { ClientRouter } from 'astro:transitions'
 import '../styles/theme.css'
 
 interface Props {
@@ -20,7 +20,7 @@ const pageTitle = title === 'Home' ? '__SITE_NAME__' : `${title} | __SITE_NAME__
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;1,9..40,300&family=Outfit:wght@200;300;400;500;600;700&display=swap" rel="stylesheet" />
-    <ViewTransitions />
+    <ClientRouter />
   </head>
   <body>
     <slot />


### PR DESCRIPTION
- Resolves Dependabot alert GHSA-j687-52p2-xcff (CVE-2026-41067): case-insensitive </script> bypass in Astro's define:vars sanitization.
- Updates create-site scaffold package.json from ^5.2.0 to ^6.1.6.
- Migrates Layout.astro from <ViewTransitions /> to <ClientRouter />, which is required by Astro v6 (ViewTransitions was removed).