### PR TITLE
ALM validation run: 11 fixes + integration tests + live-verified end-to-end

### DIFF
--- a/plugins/power-pages/scripts/lib/compute-split-plan.js
+++ b/plugins/power-pages/scripts/lib/compute-split-plan.js
@@ -386,6 +386,39 @@ function sanitizeDomainName(name) {
   return String(name).replace(/[^A-Za-z0-9]/g, '');
 }
 
+/**
+ * Appends an empty "Future Growth" solution to a multi-solution split so there
+ * is an obvious default target for any new components the team adds later. Without
+ * this buffer, every new server-logic / flow / env var tends to end up crammed
+ * into the wrong layer solution and forces a re-plan.
+ *
+ * Rules:
+ *   - Only appended when the split already has ≥ 2 solutions (splits, not `single`).
+ *   - Sized at 0 MB / 0 components — it's a reserved slot, not a prediction.
+ *   - Marked with `isFutureBuffer: true` so renderers and setup-solution can
+ *     style/describe it distinctly from partition-owned solutions.
+ *   - Tagged with `componentTypes: ['Any']` to signal "open to any type."
+ */
+function appendFutureBuffer(solutions, meta) {
+  if (!Array.isArray(solutions) || solutions.length < 2) return solutions;
+  const nextOrder = (solutions[solutions.length - 1].order || solutions.length) + 1;
+  return [
+    ...solutions,
+    {
+      uniqueName: `${meta.baseName}_Future`,
+      displayName: `${meta.siteName} — Future Growth`,
+      order: nextOrder,
+      componentTypes: ['Any'],
+      description:
+        'Reserved empty solution. New components added to the site after this plan (server logic, cloud flows, env vars, pages, etc.) should be added here by default so the partition-owned solutions above stay stable. Rename it or fold it into an existing solution if site growth plateaus.',
+      sizeMB: 0,
+      componentCount: 0,
+      components: [],
+      isFutureBuffer: true,
+    },
+  ];
+}
+
 function round(n) {
   return Math.round((Number(n) || 0) * 10) / 10;
 }
@@ -483,6 +516,11 @@ function computeSplitPlan({ estimate, config, meta }) {
     proposedSolutions = applyConfigIsolation(proposedSolutions, estimate, meta);
   }
 
+  // Add a reserved `{Prefix}_Future` solution when the site is actually being
+  // split so new components have a defined home. Single-solution plans skip
+  // this — there's no split to protect.
+  proposedSolutions = appendFutureBuffer(proposedSolutions, meta);
+
   const splitWarnings = validateSplits(proposedSolutions, config.thresholds);
   const recommendations = buildRecommendations(estimate, strategy, config).concat(splitWarnings);
 
@@ -538,6 +576,7 @@ module.exports = {
   partitionByChangeFrequency,
   partitionBySchema,
   applyConfigIsolation,
+  appendFutureBuffer,
   validateSplits,
   buildRecommendations,
 };

--- a/plugins/power-pages/scripts/lib/compute-split-plan.js
+++ b/plugins/power-pages/scripts/lib/compute-split-plan.js
@@ -47,9 +47,9 @@ function buildSizeAnalysis(estimate, thresholds) {
       tier: classifyTier(estimate.totalSizeMB, 60, thresholds.maxSolutionSizeMB),
     },
     componentCount: {
-      value: estimate.componentCount,
+      value: estimate.componentCountSiteTotal,
       tier: classifyTier(
-        estimate.componentCount,
+        estimate.componentCountSiteTotal,
         thresholds.warnComponentCount,
         thresholds.maxComponentCount,
       ),
@@ -174,7 +174,7 @@ function selectStrategy(estimate, config) {
   // Hard-flag counts still route to Strategy 2 — a split is the best option we have. The
   // hard-flag warning is added separately in buildRecommendations.
   const isComponentHeavy =
-    estimate.componentCount > t.maxComponentCount ||
+    estimate.componentCountSiteTotal > t.maxComponentCount ||
     (estimate.cloudFlowCount > t.changeFreqMinFlows && estimate.totalSizeMB > t.changeFreqMinSizeMB);
   const hasManyEnvVars = estimate.envVarCount > t.maxEnvVarCount;
 
@@ -201,7 +201,7 @@ function partitionBySingle(estimate, meta) {
       description:
         'All components packaged in a single managed solution. Estimated size is within recommended thresholds.',
       sizeMB: estimate.totalSizeMB,
-      componentCount: estimate.componentCount,
+      componentCount: estimate.componentCountSiteTotal,
       components: [],
     },
   ];
@@ -209,7 +209,7 @@ function partitionBySingle(estimate, meta) {
 
 function partitionByLayer(estimate, meta) {
   const coreSize = Math.max(estimate.totalSizeMB - estimate.webFilesAggregateMB, 0);
-  const coreCount = Math.max(estimate.componentCount - (estimate.webFileCount || 0), 0);
+  const coreCount = Math.max(estimate.componentCountSiteTotal - (estimate.webFileCount || 0), 0);
   return [
     {
       uniqueName: `${meta.baseName}_Core`,
@@ -237,11 +237,11 @@ function partitionByLayer(estimate, meta) {
 }
 
 function partitionByChangeFrequency(estimate, meta) {
-  const foundationCount = Math.ceil(estimate.componentCount * 0.15);
+  const foundationCount = Math.ceil(estimate.componentCountSiteTotal * 0.15);
   const integrationCount = estimate.cloudFlowCount + estimate.botCount;
-  const configCount = Math.ceil(estimate.componentCount * 0.1);
+  const configCount = Math.ceil(estimate.componentCountSiteTotal * 0.1);
   const contentCount = Math.max(
-    estimate.componentCount - foundationCount - integrationCount - configCount,
+    estimate.componentCountSiteTotal - foundationCount - integrationCount - configCount,
     0,
   );
 
@@ -336,7 +336,7 @@ function partitionBySchema(estimate, meta, config) {
       'Site artifacts — web roles, permissions, settings, flows, pages. Imports after all domain solutions.',
     sizeMB: round(siteSizeMB),
     componentCount: Math.max(
-      estimate.componentCount - domainSolutions.reduce((s, d) => s + d.componentCount, 0),
+      estimate.componentCountSiteTotal - domainSolutions.reduce((s, d) => s + d.componentCount, 0),
       0,
     ),
     components: [],
@@ -453,11 +453,11 @@ function buildRecommendations(estimate, strategy, config) {
         'Schema-heavy solution detected. Expected import time per stage: 2–10+ hours. Test in staging first and do not schedule production deploys during peak hours.',
     });
   }
-  if (estimate.componentCount > t.hardFlagComponentCount) {
+  if (estimate.componentCountSiteTotal > t.hardFlagComponentCount) {
     recs.push({
       type: 'error',
       message:
-        `Component count (${estimate.componentCount.toLocaleString()}) exceeds the hard-flag threshold of ${t.hardFlagComponentCount.toLocaleString()}. Splitting alone is unlikely to be sufficient — archive historical data, remove unused components, or consolidate before proceeding.`,
+        `Component count (${estimate.componentCountSiteTotal.toLocaleString()}) exceeds the hard-flag threshold of ${t.hardFlagComponentCount.toLocaleString()}. Splitting alone is unlikely to be sufficient — archive historical data, remove unused components, or consolidate before proceeding.`,
     });
   }
   if (estimate.totalSizeMB > t.maxSolutionSizeMB) {

--- a/plugins/power-pages/scripts/lib/estimate-solution-size.js
+++ b/plugins/power-pages/scripts/lib/estimate-solution-size.js
@@ -104,6 +104,10 @@ async function collectPaginated(envUrl, path, token, maxPages = 20) {
 }
 
 async function discoverPowerPageComponents(envUrl, websiteRecordId, token) {
+  // Verified 2026-04-21 against org1e98cc97 (v9.2 endpoint): both quoted and
+  // unquoted GUID forms return identical results. Keeping quoted because it's
+  // the historically safer form and tests against this codebase assume it.
+  // See memory/project_pr107_deferred_validation.md (Check 1) for evidence.
   const path =
     `powerpagecomponents` +
     `?$filter=_powerpagesiteid_value eq '${websiteRecordId}'` +

--- a/plugins/power-pages/scripts/lib/estimate-solution-size.js
+++ b/plugins/power-pages/scripts/lib/estimate-solution-size.js
@@ -116,7 +116,9 @@ async function collectPaginated(envUrl, path, token, maxPages = 20) {
  *
  * Each bot has child `botcomponent` rows (topics, entities, gpt defs). Both
  * bots and bot components become separate `solutioncomponents` rows when added
- * to a solution (types 10137 and 10193). Counting them here closes the
+ * to a solution — componenttype 10192 for Bot and 10193 for Bot Component.
+ * (componenttype 10137 is Connection Reference, NOT a bot type — earlier
+ * comments in this module had those swapped.) Counting them here closes the
  * siteTotal gap that previously made orphansOnSite look artificially small.
  *
  * Pagination ceilings (from collectPaginated below): bots up to 1,500 records
@@ -525,39 +527,36 @@ async function estimateSolutionSize({ envUrl, websiteRecordId, token, publisherP
   });
 
   // Optional: when caller passes --solutionId, also report what's actually
-  // in the solution vs. site-total. Fixes the 908-on-site / 361-in-solution
-  // ambiguity that previously caused plan docs to overstate solution size.
-  //
-  // Also provides the site's ppc id set as a cross-site safety check — if any
-  // type-10373 rows in the solution aren't on this site, we surface that as
-  // a warning in the output rather than silently miscounting.
+  // in the solution vs. site-total. Reported raw — every solutioncomponents
+  // row counts, including bundle-chunk ppcs that were explicitly added to the
+  // solution. Matches the Power Platform Maker UI's solution breakdown
+  // (e.g. 311 site components + 11 tables + 1 site record + 1 site language
+  // + 4 connection references + 2 cloud flows + 2 agents + 30 agent
+  // components = 362). An earlier revision subtracted bundle chunks from
+  // inSolution.total on the theory they were "noise", but bundle chunks that
+  // made it into the solution ship as managed components — they're real
+  // members, not noise. Noise-filtering belongs only to the on-site orphan
+  // heuristic below, not the in-solution count.
   const sitePpcIdSet = new Set(
     ppcs.map((p) => (p.powerpagecomponentid || '').toLowerCase()).filter(Boolean),
   );
-  const inSolutionRaw = solutionId
+  const inSolution = solutionId
     ? await countSolutionMembership(envUrl, solutionId, resolved, sitePpcIdSet)
     : null;
 
-  // Exclude bundle chunks from inSolution too so the comparison stays
-  // apples-to-apples with siteTotal. Without this, solutions that shipped
-  // last week's bundle chunks (still living in Dataverse even though
-  // superseded on-site) make inSolution look artificially larger.
-  let inSolution = inSolutionRaw;
+  // Tag how many of the solution's ppc rows are bundle-chunk files, purely as
+  // metadata — we do NOT subtract this from inSolution.total. Useful for
+  // downstream cleanup tooling and for the plan banner that says "your
+  // solution contains N superseded bundle chunks — consider a cleanup pass".
   let bundleChunksInSolution = 0;
-  if (inSolutionRaw && classified.bundleChunks.length > 0) {
+  if (inSolution && classified.bundleChunks.length > 0) {
     const chunkIdSet = new Set(
       classified.bundleChunks.map((c) => (c.powerpagecomponentid || '').toLowerCase()),
     );
-    const inSolIds = new Set(inSolutionRaw.objectIds || []);
+    const inSolIds = new Set(inSolution.objectIds || []);
     for (const id of chunkIdSet) {
       if (inSolIds.has(id)) bundleChunksInSolution += 1;
     }
-    inSolution = {
-      ...inSolutionRaw,
-      total: Math.max(inSolutionRaw.total - bundleChunksInSolution, 0),
-      totalRawIncludingBundleChunks: inSolutionRaw.total,
-      bundleChunksInSolution,
-    };
   }
 
   // Component count must match what Dataverse `solutioncomponents` counts —
@@ -566,75 +565,81 @@ async function estimateSolutionSize({ envUrl, websiteRecordId, token, publisherP
   // on schema-heavy sites (e.g. 503 attrs pushed the count from 405 → 908).
   //
   // Each term maps to a distinct `solutioncomponents` row that would be added
-  // when the site is solutionized:
+  // when the site is solutionized. Solutioncomponents componenttype values are:
   //
-  //   ppcs.length                               → type 10373 rows (includes
-  //                                                type-27 bot consumers and
-  //                                                type-33 cloud flow bindings,
-  //                                                which themselves import as
-  //                                                type 10373 sub-components)
-  //   tables.length                             → type 1 rows (Entity). Columns
-  //                                                ride along — do NOT add
-  //                                                schemaAttrCount here.
-  //   envVarCount                               → type 380 rows
-  //   classified.cloudFlowLinks.length          → type 29 rows (the workflow
-  //                                                entity itself). Each cloud
-  //                                                flow contributes TWO distinct
-  //                                                solutioncomponents rows: one
-  //                                                type-10373 (the ppc binding,
-  //                                                already in ppcs.length) and
-  //                                                one type-29 (added here).
-  //                                                Since type-33 ppc bindings
-  //                                                pair 1:1 with workflows,
-  //                                                cloudFlowLinks.length is the
-  //                                                workflow count. NOT a double-
-  //                                                count despite the name.
-  //   botsAndComponents.bots.length             → type 10137 rows
-  //   botsAndComponents.botComponents.length    → type 10193 rows
+  //   1       Entity (table) — columns ride along, never counted separately
+  //   29      Workflow (cloud flow — the workflow entity itself)
+  //   10137   Connection Reference
+  //   10192   Bot (Power Virtual Agent / Copilot Studio agent)
+  //   10193   Bot Component (agent topics, entities, gpt defs)
+  //   10373   Power Page Component (unified site-component type — pages, files,
+  //           templates, roles, settings, permissions, bot consumers,
+  //           cloud flow bindings, server logic all share this type)
+  //   10374   Website (the site record)
+  //   380     Environment Variable Definition
   //
-  // Before adding bot queries on 2026-04-22, bots + bot components were a known
-  // undercount. Live SIP site had 4 bots + 30 components missing from siteTotal,
-  // making orphansOnSite (46) misleadingly small. With bot queries enabled,
-  // siteTotal now includes them and orphansOnSite reflects reality.
+  // ppcs.length already includes type-27 bot consumers and type-33 cloud flow
+  // bindings under the umbrella of type-10373. cloudFlowLinks.length below
+  // refers to the 1:1 paired type-29 workflow record, not a double-count.
   //
-  // Subtract bundle chunks (Vite/Rollup hashed .js/.css). Those accumulate as
-  // dead orphans with every `pac pages upload-code-site` rebuild and don't
-  // represent real site inventory — they're noise, not content.
+  // Raw site inventory — every ppc and related artifact, no filtering. Matches
+  // the Dataverse view of the site. Bundle-chunk noise is surfaced separately
+  // (bundleChunkCount) so consumers can reason about it without us silently
+  // subtracting it here. Earlier revisions subtracted chunks to get an
+  // "actionable" count, but that made the siteTotal non-comparable to the
+  // solution count in Dataverse (which does include chunk members).
   const bundleChunkCount = classified.bundleChunks.length;
   const siteTotalComponents =
-    ppcs.length -
-    bundleChunkCount +
+    ppcs.length +
     tables.length +
     envVarCount +
     classified.cloudFlowLinks.length +
     (botsAndComponents.bots.length || 0) +
     (botsAndComponents.botComponents.length || 0);
 
+  // "Actionable" site inventory — excludes bundle-chunk ppcs that are stale
+  // leftovers from prior `pac pages upload-code-site` runs. Useful when the
+  // user wants to know "how many real components do I have" vs. "how many
+  // rows exist in Dataverse".
+  const siteActionableComponents = siteTotalComponents - bundleChunkCount;
+
   return {
     siteName: siteName || null,
     publisherPrefix: publisherPrefix || null,
     solutionId: solutionId || null,
     totalSizeMB: round1(totalSizeMB),
-    // Canonical field for "components the site would export as solutioncomponents
-    // rows." Earlier revisions exposed a duplicate `componentCount` alias; it was
-    // dropped on 2026-04-22 since ALM skills are still in feature-branch development
-    // and don't need the legacy alias. Consumers (compute-split-plan, render-alm-plan)
-    // read `componentCountSiteTotal` directly.
+    // componentCountSiteTotal is the RAW site inventory — one count per
+    // Dataverse row. Matches what the Power Platform Maker UI would show
+    // if the whole site were added to a solution. Bundle chunks are included
+    // here because they're real rows in the site's `powerpagecomponents`.
     componentCountSiteTotal: siteTotalComponents,
+    // Sub-count that strips bundle-chunk noise (stale .js/.css from prior
+    // `pac pages upload-code-site` runs) for people who want the
+    // "actionable content" view.
+    componentCountSiteActionable: siteActionableComponents,
+    // componentCountInSolution matches the raw solutioncomponents row count
+    // for the target solution — i.e. what the Maker UI "Objects" page shows.
+    // Bundle chunks that were added to the solution count as members here;
+    // they ship with the managed solution when exported.
     componentCountInSolution: inSolution ? inSolution.total : null,
-    orphansOnSite: inSolution ? Math.max(siteTotalComponents - inSolution.total, 0) : null,
+    // Orphans = ppcs on the site that the solution does not own. Bundle
+    // chunks are excluded from orphans since they're stale upload artifacts,
+    // not content gaps. If you want the strict diff, compare
+    // componentCountSiteTotal - componentCountInSolution yourself.
+    orphansOnSite: inSolution
+      ? Math.max(siteActionableComponents - inSolution.total, 0)
+      : null,
     botCountScoped: botsAndComponents.bots.length || 0,
     botComponentCountScoped: botsAndComponents.botComponents.length || 0,
     bundleChunkCount,
     bundleChunkNote: bundleChunkCount > 0
-      ? `${bundleChunkCount} hashed bundle chunks (Vite/Rollup) excluded from siteTotal — they're stale orphans from prior pac pages upload-code-site runs. Cleanable via dedicated cleanup pass (not yet implemented).`
+      ? `${bundleChunkCount} hashed bundle chunks (Vite/Rollup) on the site — ${bundleChunksInSolution} are in the solution, ${bundleChunkCount - bundleChunksInSolution} are orphans from prior pac pages upload-code-site runs. Cleanable via dedicated cleanup pass.`
       : null,
     inSolution: inSolution
       ? {
           total: inSolution.total,
           byComponentType: inSolution.byComponentType,
-          totalRawIncludingBundleChunks: inSolution.totalRawIncludingBundleChunks,
-          bundleChunksInSolution: inSolution.bundleChunksInSolution,
+          bundleChunksInSolution,
           crossSitePpcCount: (inSolution.crossSitePpcs || []).length,
           crossSitePpcWarning:
             inSolution.crossSitePpcs && inSolution.crossSitePpcs.length > 0

--- a/plugins/power-pages/scripts/lib/estimate-solution-size.js
+++ b/plugins/power-pages/scripts/lib/estimate-solution-size.js
@@ -409,8 +409,14 @@ function estimateTotalSize({ classified, tables, schemaAttrCount, webFilesAggreg
  * componenttype so the caller can distinguish "site-total" from "in-solution"
  * numbers. Used to fix the common confusion where the site has 908 ppcs but
  * only 361 are actually owned by the solution being planned.
+ *
+ * When `sitePpcIdSet` is provided (the set of powerpagecomponent ids actually
+ * linked to the target site), the returned object also includes a
+ * `crossSitePpcs` warning — type-10373 rows in the solution that do NOT belong
+ * to the expected site. Safety check for solutions that accidentally contain
+ * ppcs from multiple sites.
  */
-async function countSolutionMembership(envUrl, solutionId, token) {
+async function countSolutionMembership(envUrl, solutionId, token, sitePpcIdSet = null) {
   const url = `${envUrl}/api/data/v9.2/solutioncomponents?$filter=_solutionid_value eq ${solutionId}&$select=objectid,componenttype&$top=5000`;
   const res = await makeRequest({
     url,
@@ -433,10 +439,25 @@ async function countSolutionMembership(envUrl, solutionId, token) {
   for (const r of rows) {
     byType[r.componenttype] = (byType[r.componenttype] || 0) + 1;
   }
+
+  // Cross-site safety check: if the caller gave us the set of ppc ids on the
+  // target site, flag any type-10373 row in the solution whose objectid isn't
+  // in that set. 100% overlap is the healthy case; any miss means this
+  // solution contains ppcs from a different site (rare, but possible when a
+  // user manually adds components across sites).
+  let crossSitePpcs = [];
+  if (sitePpcIdSet && sitePpcIdSet.size > 0) {
+    const solPpcs = rows
+      .filter((r) => r.componenttype === 10373)
+      .map((r) => (r.objectid || '').toLowerCase());
+    crossSitePpcs = solPpcs.filter((id) => id && !sitePpcIdSet.has(id));
+  }
+
   return {
     total: rows.length,
     byComponentType: byType,
     objectIds: rows.map((r) => (r.objectid || '').toLowerCase()),
+    crossSitePpcs,
   };
 }
 
@@ -486,8 +507,15 @@ async function estimateSolutionSize({ envUrl, websiteRecordId, token, publisherP
   // Optional: when caller passes --solutionId, also report what's actually
   // in the solution vs. site-total. Fixes the 908-on-site / 361-in-solution
   // ambiguity that previously caused plan docs to overstate solution size.
+  //
+  // Also provides the site's ppc id set as a cross-site safety check — if any
+  // type-10373 rows in the solution aren't on this site, we surface that as
+  // a warning in the output rather than silently miscounting.
+  const sitePpcIdSet = new Set(
+    ppcs.map((p) => (p.powerpagecomponentid || '').toLowerCase()).filter(Boolean),
+  );
   const inSolutionRaw = solutionId
-    ? await countSolutionMembership(envUrl, solutionId, resolved)
+    ? await countSolutionMembership(envUrl, solutionId, resolved, sitePpcIdSet)
     : null;
 
   // Exclude bundle chunks from inSolution too so the comparison stays
@@ -566,6 +594,11 @@ async function estimateSolutionSize({ envUrl, websiteRecordId, token, publisherP
           byComponentType: inSolution.byComponentType,
           totalRawIncludingBundleChunks: inSolution.totalRawIncludingBundleChunks,
           bundleChunksInSolution: inSolution.bundleChunksInSolution,
+          crossSitePpcCount: (inSolution.crossSitePpcs || []).length,
+          crossSitePpcWarning:
+            inSolution.crossSitePpcs && inSolution.crossSitePpcs.length > 0
+              ? `⚠ ${inSolution.crossSitePpcs.length} powerpagecomponent row(s) in this solution do not belong to site ${websiteRecordId}. The solution may contain components from a different site. Re-check the site scope before exporting.`
+              : null,
           // objectIds intentionally omitted from JSON output to keep it small;
           // callers that need diffing should use discover-site-components.js.
         }
@@ -626,5 +659,7 @@ module.exports = {
   estimateSolutionSize,
   estimateTotalSize,
   classifyPPCs,
+  countSolutionMembership,
+  isProbablyBundleChunk,
   BYTES_PER,
 };

--- a/plugins/power-pages/scripts/lib/estimate-solution-size.js
+++ b/plugins/power-pages/scripts/lib/estimate-solution-size.js
@@ -284,7 +284,7 @@ async function countEnvVarDefinitions(envUrl, publisherPrefix, token) {
 // [A-Za-z0-9_-] followed by a `.js`/`.mjs`/`.cjs`/`.css`/`.map` extension.
 // Includes sourcemaps since those also accumulate. Keeps static assets like
 // `logo.svg`, `favicon.ico`, `hero.jpg` — no hash suffix.
-const BUNDLE_CHUNK_NAME = /[-.][A-Za-z0-9_-]{7,14}\.(?:js|mjs|cjs|css|map)$/;
+const BUNDLE_CHUNK_NAME = /[-.][A-Za-z0-9_-]{7,14}\.(?:js|mjs|cjs|css)(?:\.map)?$/;
 function isProbablyBundleChunk(name) {
   if (!name) return false;
   return BUNDLE_CHUNK_NAME.test(String(name));

--- a/plugins/power-pages/scripts/lib/estimate-solution-size.js
+++ b/plugins/power-pages/scripts/lib/estimate-solution-size.js
@@ -56,6 +56,7 @@ function parseArgs(argv) {
     publisherPrefix: null,
     siteName: null,
     datamodelManifest: null,
+    solutionId: null,
   };
   for (let i = 0; i < args.length; i++) {
     if (args[i] === '--envUrl' && args[i + 1]) out.envUrl = args[++i];
@@ -64,6 +65,7 @@ function parseArgs(argv) {
     else if (args[i] === '--publisherPrefix' && args[i + 1]) out.publisherPrefix = args[++i];
     else if (args[i] === '--siteName' && args[i + 1]) out.siteName = args[++i];
     else if (args[i] === '--datamodelManifest' && args[i + 1]) out.datamodelManifest = args[++i];
+    else if (args[i] === '--solutionId' && args[i + 1]) out.solutionId = args[++i];
   }
   return out;
 }
@@ -273,7 +275,43 @@ function estimateTotalSize({ classified, tables, schemaAttrCount, webFilesAggreg
   return total / (1024 * 1024);
 }
 
-async function estimateSolutionSize({ envUrl, websiteRecordId, token, publisherPrefix, siteName, datamodelManifest }) {
+/**
+ * Queries solutioncomponents for a specific solution and aggregates counts by
+ * componenttype so the caller can distinguish "site-total" from "in-solution"
+ * numbers. Used to fix the common confusion where the site has 908 ppcs but
+ * only 361 are actually owned by the solution being planned.
+ */
+async function countSolutionMembership(envUrl, solutionId, token) {
+  const url = `${envUrl}/api/data/v9.2/solutioncomponents?$filter=_solutionid_value eq ${solutionId}&$select=objectid,componenttype&$top=5000`;
+  const res = await makeRequest({
+    url,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/json',
+      'OData-MaxVersion': '4.0',
+      'OData-Version': '4.0',
+      Prefer: 'odata.maxpagesize=5000',
+    },
+    timeout: 30000,
+  });
+  if (res.error || res.statusCode < 200 || res.statusCode >= 300) {
+    // Don't fail the whole estimate — just omit the inSolution block.
+    return null;
+  }
+  const parsed = JSON.parse(res.body);
+  const rows = parsed.value || [];
+  const byType = {};
+  for (const r of rows) {
+    byType[r.componenttype] = (byType[r.componenttype] || 0) + 1;
+  }
+  return {
+    total: rows.length,
+    byComponentType: byType,
+    objectIds: rows.map((r) => (r.objectid || '').toLowerCase()),
+  };
+}
+
+async function estimateSolutionSize({ envUrl, websiteRecordId, token, publisherPrefix, siteName, datamodelManifest, solutionId }) {
   if (!envUrl || !websiteRecordId) {
     throw new Error('--envUrl and --websiteRecordId are required');
   }
@@ -308,15 +346,33 @@ async function estimateSolutionSize({ envUrl, websiteRecordId, token, publisherP
     envVarCount,
   });
 
+  // Optional: when caller passes --solutionId, also report what's actually
+  // in the solution vs. site-total. Fixes the 908-on-site / 361-in-solution
+  // ambiguity that previously caused plan docs to overstate solution size.
+  const inSolution = solutionId
+    ? await countSolutionMembership(envUrl, solutionId, resolved)
+    : null;
+
+  const siteTotalComponents =
+    ppcs.length + tables.length + schemaAttrCount + envVarCount;
+
   return {
     siteName: siteName || null,
     publisherPrefix: publisherPrefix || null,
+    solutionId: solutionId || null,
     totalSizeMB: round1(totalSizeMB),
-    componentCount:
-      ppcs.length +
-      tables.length +
-      schemaAttrCount +
-      envVarCount,
+    componentCount: siteTotalComponents,
+    componentCountSiteTotal: siteTotalComponents,
+    componentCountInSolution: inSolution ? inSolution.total : null,
+    orphansOnSite: inSolution ? Math.max(siteTotalComponents - inSolution.total, 0) : null,
+    inSolution: inSolution
+      ? {
+          total: inSolution.total,
+          byComponentType: inSolution.byComponentType,
+          // objectIds intentionally omitted from JSON output to keep it small;
+          // callers that need diffing should use discover-site-components.js.
+        }
+      : null,
     tableCount: tables.length,
     schemaAttrCount,
     webFilesAggregateMB: round1(webFilesAggregateBytes / (1024 * 1024)),

--- a/plugins/power-pages/scripts/lib/estimate-solution-size.js
+++ b/plugins/power-pages/scripts/lib/estimate-solution-size.js
@@ -353,8 +353,28 @@ async function estimateSolutionSize({ envUrl, websiteRecordId, token, publisherP
     ? await countSolutionMembership(envUrl, solutionId, resolved)
     : null;
 
+  // Component count must match what Dataverse `solutioncomponents` counts —
+  // each table is ONE component (attributes ride along, not counted separately).
+  // Earlier versions added `schemaAttrCount` which inflated the total by 3–5×
+  // on schema-heavy sites (e.g. 503 attrs pushed the count from 405 → 908).
+  //
+  // Each constant here maps directly to a `componenttype`:
+  //   ppcs.length          → componenttype 10373 (site sub-components)
+  //   tables.length        → componenttype 1 (Entity) — attributes NOT added
+  //   envVarCount          → componenttype 380 (env var definition)
+  //   classified.cloudFlowLinks.length → componenttype 29 via the workflow
+  //                            (the type-33 ppc binding is already in ppcs.length)
+  //   classified.botConsumers.length → counted once (as ppc type 27 in ppcs.length)
+  //
+  // Bots (type 10137) and bot topics (type 10193) are separate entity rows not
+  // reachable from ppcs; they're captured under inSolution when --solutionId is
+  // passed but can't be discovered site-wide without a bot-specific query.
+  // That's a known undercount bound; it does not affect the solution-owned count.
   const siteTotalComponents =
-    ppcs.length + tables.length + schemaAttrCount + envVarCount;
+    ppcs.length +
+    tables.length +
+    envVarCount +
+    classified.cloudFlowLinks.length;
 
   return {
     siteName: siteName || null,

--- a/plugins/power-pages/scripts/lib/estimate-solution-size.js
+++ b/plugins/power-pages/scripts/lib/estimate-solution-size.js
@@ -131,11 +131,15 @@ async function discoverTables(envUrl, publisherPrefix, token, manifestPath) {
     } catch {}
   }
 
-  // Query EntityDefinitions for custom unmanaged tables
+  // Query EntityDefinitions for custom unmanaged tables.
+  // Verified 2026-04-22 against org1e98cc97 (v9.2): EntityDefinitions does NOT
+  // support `$top` (returns 400 "The query parameter $top is not supported").
+  // We filter server-side to IsCustomEntity=true to keep the payload bounded —
+  // there's still no client-side pagination needed for typical tenants.
   const path =
     `EntityDefinitions` +
-    `?$select=LogicalName,MetadataId,IsManaged,IsCustomEntity` +
-    `&$top=500`;
+    `?$filter=IsCustomEntity eq true` +
+    `&$select=LogicalName,MetadataId,IsManaged,IsCustomEntity`;
   const all = await collectPaginated(envUrl, path, token, 10);
   const custom = all.filter((e) => e.IsCustomEntity === true && e.IsManaged === false);
   const matchingPrefix = publisherPrefix

--- a/plugins/power-pages/scripts/lib/estimate-solution-size.js
+++ b/plugins/power-pages/scripts/lib/estimate-solution-size.js
@@ -115,11 +115,14 @@ async function collectPaginated(envUrl, path, token, maxPages = 20) {
  * don't inflate this site's count.
  *
  * Each bot has child `botcomponent` rows (topics, entities, gpt defs). Both
- * bots and bot components become separate `solutioncomponents` rows when added
- * to a solution — componenttype 10192 for Bot and 10193 for Bot Component.
- * (componenttype 10137 is Connection Reference, NOT a bot type — earlier
- * comments in this module had those swapped.) Counting them here closes the
- * siteTotal gap that previously made orphansOnSite look artificially small.
+ * bots and bot components become separate `solutioncomponents` rows when
+ * added to a solution (the Bot and BotComponent types; integer values are
+ * dynamic per tenant — resolve via `discover-component-types.js` before any
+ * mutation). Observed values in current tenants are 10192 for Bot and 10193
+ * for BotComponent; 10137 is Connection Reference (not a bot type), which
+ * earlier comments here had swapped. Counting bots + bot components here
+ * closes the siteTotal gap that previously made orphansOnSite look
+ * artificially small.
  *
  * Pagination ceilings (from collectPaginated below): bots up to 1,500 records
  * (3 pages × $top=500), botcomponents up to 25,000 (5 × 5,000). Hitting either
@@ -564,23 +567,42 @@ async function estimateSolutionSize({ envUrl, websiteRecordId, token, publisherP
   // Earlier versions added `schemaAttrCount` which inflated the total by 3–5×
   // on schema-heavy sites (e.g. 503 attrs pushed the count from 405 → 908).
   //
-  // Each term maps to a distinct `solutioncomponents` row that would be added
-  // when the site is solutionized. Solutioncomponents componenttype values are:
+  // Each term in the sum below maps to a category of `solutioncomponents` row
+  // that would be created if the site's artifacts were added to a solution.
   //
-  //   1       Entity (table) — columns ride along, never counted separately
-  //   29      Workflow (cloud flow — the workflow entity itself)
-  //   10137   Connection Reference
-  //   10192   Bot (Power Virtual Agent / Copilot Studio agent)
-  //   10193   Bot Component (agent topics, entities, gpt defs)
-  //   10373   Power Page Component (unified site-component type — pages, files,
-  //           templates, roles, settings, permissions, bot consumers,
-  //           cloud flow bindings, server logic all share this type)
-  //   10374   Website (the site record)
-  //   380     Environment Variable Definition
+  // On componenttype integers: the Dataverse `solutioncomponent.componenttype`
+  // picklist is officially **dynamic per tenant** — AddSolutionComponent
+  // expects the caller to resolve values at runtime, which is what
+  // `scripts/lib/discover-component-types.js` does. `countSolutionMembership`
+  // in this file is deliberately resolver-free: it tallies whatever values
+  // Dataverse returns in `byComponentType`, no hardcoded integers. Observed
+  // values in current tenants (2026-04-22) are
+  //   1=Entity, 29=Workflow, 380=EnvVarDef, 10137=ConnectionReference,
+  //   10192=Bot, 10193=BotComponent, 10373=PowerPageComponent, 10374=Website
+  // but callers MUST NOT rely on those in mutation paths — use the resolver.
   //
-  // ppcs.length already includes type-27 bot consumers and type-33 cloud flow
-  // bindings under the umbrella of type-10373. cloudFlowLinks.length below
-  // refers to the 1:1 paired type-29 workflow record, not a double-count.
+  // Site-inventory terms:
+  //   ppcs.length          — rows in powerpagecomponents for this website.
+  //                          Already contains type-27 bot consumers and
+  //                          type-33 cloud flow bindings (they're all ppcs).
+  //                          When exported to a solution they become the
+  //                          umbrella PowerPageComponent solutioncomponents
+  //                          type — one row each.
+  //   tables.length        — custom tables matching publisherPrefix.
+  //   envVarCount          — envvar definitions matching publisherPrefix.
+  //   cloudFlowLinks       — classified.cloudFlowLinks is type-33 ppcs but
+  //                          we're using its length as a 1:1 proxy for the
+  //                          Workflow entity count. Not a double-count with
+  //                          ppcs.length: that sum covers the ppc binding,
+  //                          this term covers the distinct Workflow record.
+  //   bots / botComponents — resolved by schema-name match through the
+  //                          site's type-27 ppcs; adds the env-level Bot +
+  //                          BotComponent entity rows.
+  //
+  // For the live SIP reference site in dev (org1e98cc97), this sum evaluates
+  // to 393 + 11 + 1 + 2 + 2 + 30 = 439. Connection references (4) and the
+  // website record itself (1) are NOT included — they're env-/site-level
+  // artifacts and not derivable without separate queries.
   //
   // Raw site inventory — every ppc and related artifact, no filtering. Matches
   // the Dataverse view of the site. Bundle-chunk noise is surfaced separately

--- a/plugins/power-pages/scripts/lib/estimate-solution-size.js
+++ b/plugins/power-pages/scripts/lib/estimate-solution-size.js
@@ -105,6 +105,86 @@ async function collectPaginated(envUrl, path, token, maxPages = 20) {
   return items;
 }
 
+/**
+ * Discovers bots + bot components linked to the site.
+ *
+ * Power Pages bot linkage: each site has `powerpagecomponent` rows of type 27
+ * (Bot Consumer). Each consumer references a bot by its schemaname stored in
+ * the ppc `name` field. We use those names to scope the bot query so we only
+ * count bots actually attached to this site, not every bot in the env.
+ *
+ * Each bot has child `botcomponent` rows (topics, entities, gpt defs). Both
+ * bots and bot components become separate `solutioncomponents` rows when added
+ * to a solution (types 10137 and 10193). Counting them here closes the
+ * siteTotal gap that previously made orphansOnSite look artificially small.
+ */
+async function discoverBotsAndComponents(envUrl, botConsumerPpcs, token) {
+  if (!botConsumerPpcs || botConsumerPpcs.length === 0) {
+    return { bots: [], botComponents: [] };
+  }
+
+  // Bot schemaname lives in the ppc `content` JSON (the `name` field is the
+  // literal string "Bot Consumer" — not useful). We re-query the consumers
+  // with content included, parse, and collect unique schema names.
+  const consumerIds = botConsumerPpcs
+    .map((c) => c.powerpagecomponentid)
+    .filter(Boolean);
+  if (consumerIds.length === 0) return { bots: [], botComponents: [] };
+
+  const idFilter = consumerIds.map((id) => `powerpagecomponentid eq ${id}`).join(' or ');
+  const withContentPath =
+    `powerpagecomponents?$filter=${idFilter}&$select=powerpagecomponentid,content&$top=500`;
+  let enriched;
+  try {
+    enriched = await collectPaginated(envUrl, withContentPath, token, 2);
+  } catch {
+    return { bots: [], botComponents: [] };
+  }
+
+  const consumerNames = [];
+  for (const row of enriched) {
+    let schema = null;
+    try {
+      const parsed = JSON.parse(row.content || '{}');
+      schema = parsed.botschemaname || parsed.botSchemaName || null;
+    } catch {
+      // Malformed content — skip this consumer.
+    }
+    if (schema) consumerNames.push(schema);
+  }
+
+  const unique = [...new Set(consumerNames)];
+  if (unique.length === 0) return { bots: [], botComponents: [] };
+
+  // Fetch bots by schema-name match. OR-chaining several equality predicates
+  // stays well inside URL-length limits for realistic consumer counts (<50).
+  const safeNames = unique.map((n) => n.replace(/'/g, "''"));
+  const botFilter = safeNames.map((n) => `schemaname eq '${n}'`).join(' or ');
+  const botsPath =
+    `bots?$filter=${botFilter}&$select=botid,name,schemaname&$top=500`;
+  let bots = [];
+  try {
+    bots = await collectPaginated(envUrl, botsPath, token, 3);
+  } catch {
+    // Bots may be unavailable in some tenants (privilege / feature gating).
+    // Don't fail the whole estimate — surface as zero and move on.
+    return { bots: [], botComponents: [] };
+  }
+  if (bots.length === 0) return { bots: [], botComponents: [] };
+
+  const botIds = bots.map((b) => b.botid).filter(Boolean);
+  const compFilter = botIds.map((id) => `_parentbotid_value eq ${id}`).join(' or ');
+  const compsPath =
+    `botcomponents?$filter=${compFilter}&$select=botcomponentid&$top=5000`;
+  let botComponents = [];
+  try {
+    botComponents = await collectPaginated(envUrl, compsPath, token, 5);
+  } catch {
+    botComponents = [];
+  }
+  return { bots, botComponents };
+}
+
 async function discoverPowerPageComponents(envUrl, websiteRecordId, token) {
   // Verified 2026-04-21 against org1e98cc97 (v9.2 endpoint): both quoted and
   // unquoted GUID forms return identical results. Keeping quoted because it's
@@ -328,6 +408,14 @@ async function estimateSolutionSize({ envUrl, websiteRecordId, token, publisherP
 
   const envVarCount = await countEnvVarDefinitions(envUrl, publisherPrefix, resolved);
 
+  // Bot + bot components — scoped to bots referenced by this site's
+  // type-27 bot consumer ppcs so env-wide bots don't inflate the count.
+  const botsAndComponents = await discoverBotsAndComponents(
+    envUrl,
+    classified.botConsumers,
+    resolved,
+  );
+
   const webFileSample = classified.webFiles.slice(0, 80); // sample up to 80 web files for sizing
   const webMeasure = await measureWebFiles(envUrl, webFileSample, resolved);
 
@@ -365,16 +453,20 @@ async function estimateSolutionSize({ envUrl, websiteRecordId, token, publisherP
   //   classified.cloudFlowLinks.length → componenttype 29 via the workflow
   //                            (the type-33 ppc binding is already in ppcs.length)
   //   classified.botConsumers.length → counted once (as ppc type 27 in ppcs.length)
+  //   botsAndComponents.bots.length → componenttype 10137 (Bot)
+  //   botsAndComponents.botComponents.length → componenttype 10193 (Bot Component)
   //
-  // Bots (type 10137) and bot topics (type 10193) are separate entity rows not
-  // reachable from ppcs; they're captured under inSolution when --solutionId is
-  // passed but can't be discovered site-wide without a bot-specific query.
-  // That's a known undercount bound; it does not affect the solution-owned count.
+  // Before adding bot queries on 2026-04-22, bots + bot components were a known
+  // undercount. Live SIP site had 4 bots + 30 components missing from siteTotal,
+  // making orphansOnSite (46) misleadingly small. With bot queries enabled,
+  // siteTotal now includes them and orphansOnSite reflects reality.
   const siteTotalComponents =
     ppcs.length +
     tables.length +
     envVarCount +
-    classified.cloudFlowLinks.length;
+    classified.cloudFlowLinks.length +
+    (botsAndComponents.bots.length || 0) +
+    (botsAndComponents.botComponents.length || 0);
 
   return {
     siteName: siteName || null,
@@ -385,6 +477,8 @@ async function estimateSolutionSize({ envUrl, websiteRecordId, token, publisherP
     componentCountSiteTotal: siteTotalComponents,
     componentCountInSolution: inSolution ? inSolution.total : null,
     orphansOnSite: inSolution ? Math.max(siteTotalComponents - inSolution.total, 0) : null,
+    botCountScoped: botsAndComponents.bots.length || 0,
+    botComponentCountScoped: botsAndComponents.botComponents.length || 0,
     inSolution: inSolution
       ? {
           total: inSolution.total,

--- a/plugins/power-pages/scripts/lib/estimate-solution-size.js
+++ b/plugins/power-pages/scripts/lib/estimate-solution-size.js
@@ -267,6 +267,29 @@ async function countEnvVarDefinitions(envUrl, publisherPrefix, token) {
   return items.length;
 }
 
+// Detects Vite/Rollup/Webpack code-bundle chunks emitted by
+// `pac pages upload-code-site`. Each rebuild uploads new hash-suffixed files
+// and leaves the prior batch behind — so the total accumulates even though
+// only the latest batch is referenced by index.html. For plan-alm purposes,
+// these dead entries are noise, not real site inventory.
+//
+// Patterns matched:
+//   Home-BPuZZDcA.js        (Vite dynamic chunks)
+//   index-DyzztwOp.js       (main entry)
+//   chunk-RxR9EgHz.js       (generic chunk)
+//   vendor.a1b2c3d4.js      (older Webpack pattern)
+//   style.Z0qHD57j.css
+//
+// Heuristic: name contains `-` or `.` separator followed by 7–14 chars of
+// [A-Za-z0-9_-] followed by a `.js`/`.mjs`/`.cjs`/`.css`/`.map` extension.
+// Includes sourcemaps since those also accumulate. Keeps static assets like
+// `logo.svg`, `favicon.ico`, `hero.jpg` — no hash suffix.
+const BUNDLE_CHUNK_NAME = /[-.][A-Za-z0-9_-]{7,14}\.(?:js|mjs|cjs|css|map)$/;
+function isProbablyBundleChunk(name) {
+  if (!name) return false;
+  return BUNDLE_CHUNK_NAME.test(String(name));
+}
+
 function classifyPPCs(ppcs) {
   const byType = new Map();
   for (const c of ppcs) {
@@ -275,15 +298,30 @@ function classifyPPCs(ppcs) {
     byType.get(t).push(c);
   }
 
-  // Canonical type numbers for known Power Pages components
+  // Canonical `powerpagecomponenttype` picklist values (authoritative: MS Learn,
+  // cross-checked against the PPC_TYPE_LABELS enum in discover-site-components.js).
+  // Earlier versions of this file had swapped constants (WEB_FILE=2, WEB_PAGE=4,
+  // WEB_TEMPLATE=11) which actually pointed at Web Page, Web Link Set, and Web
+  // Role respectively — making webFileCount / webFilesAggregateMB catastrophically
+  // wrong on any site. Fixed 2026-04-22.
+  const PUBLISHING_STATE = 1;
+  const WEB_PAGE = 2;
+  const WEB_FILE = 3;
+  const WEB_LINK_SET = 4;
+  const WEB_LINK = 5;
+  const PAGE_TEMPLATE = 6;
+  const CONTENT_SNIPPET = 7;
+  const WEB_TEMPLATE = 8;
   const SITE_SETTING = 9;
-  const WEB_ROLE = 16;
-  const TABLE_PERMISSION = 18;
+  const WEB_ROLE = 11;
+  const SITE_MARKER = 13;
   const BOT_CONSUMER = 27;
   const CLOUD_FLOW_LINK = 33;
-  const WEB_FILE = 2;
-  const WEB_PAGE = 4;
-  const WEB_TEMPLATE = 11;
+  const TABLE_PERMISSION = 18; // note: 18 is Table Permission per the docs
+
+  const rawWebFiles = byType.get(WEB_FILE) || [];
+  const bundleChunks = rawWebFiles.filter((f) => isProbablyBundleChunk(f.name));
+  const liveWebFiles = rawWebFiles.filter((f) => !isProbablyBundleChunk(f.name));
 
   return {
     siteSettings: byType.get(SITE_SETTING) || [],
@@ -291,9 +329,20 @@ function classifyPPCs(ppcs) {
     tablePermissions: byType.get(TABLE_PERMISSION) || [],
     botConsumers: byType.get(BOT_CONSUMER) || [],
     cloudFlowLinks: byType.get(CLOUD_FLOW_LINK) || [],
-    webFiles: byType.get(WEB_FILE) || [],
+    // webFiles now excludes bundle chunks — the real "content" web files only
+    // (images, fonts, static assets). Bundle chunks are surfaced separately so
+    // they can be reported (and optionally cleaned up) but not counted as
+    // meaningful site inventory for planning purposes.
+    webFiles: liveWebFiles,
+    bundleChunks,
     webPages: byType.get(WEB_PAGE) || [],
     webTemplates: byType.get(WEB_TEMPLATE) || [],
+    publishingStates: byType.get(PUBLISHING_STATE) || [],
+    webLinks: byType.get(WEB_LINK) || [],
+    webLinkSets: byType.get(WEB_LINK_SET) || [],
+    pageTemplates: byType.get(PAGE_TEMPLATE) || [],
+    contentSnippets: byType.get(CONTENT_SNIPPET) || [],
+    siteMarkers: byType.get(SITE_MARKER) || [],
     all: ppcs,
     byType,
   };
@@ -437,9 +486,31 @@ async function estimateSolutionSize({ envUrl, websiteRecordId, token, publisherP
   // Optional: when caller passes --solutionId, also report what's actually
   // in the solution vs. site-total. Fixes the 908-on-site / 361-in-solution
   // ambiguity that previously caused plan docs to overstate solution size.
-  const inSolution = solutionId
+  const inSolutionRaw = solutionId
     ? await countSolutionMembership(envUrl, solutionId, resolved)
     : null;
+
+  // Exclude bundle chunks from inSolution too so the comparison stays
+  // apples-to-apples with siteTotal. Without this, solutions that shipped
+  // last week's bundle chunks (still living in Dataverse even though
+  // superseded on-site) make inSolution look artificially larger.
+  let inSolution = inSolutionRaw;
+  let bundleChunksInSolution = 0;
+  if (inSolutionRaw && classified.bundleChunks.length > 0) {
+    const chunkIdSet = new Set(
+      classified.bundleChunks.map((c) => (c.powerpagecomponentid || '').toLowerCase()),
+    );
+    const inSolIds = new Set(inSolutionRaw.objectIds || []);
+    for (const id of chunkIdSet) {
+      if (inSolIds.has(id)) bundleChunksInSolution += 1;
+    }
+    inSolution = {
+      ...inSolutionRaw,
+      total: Math.max(inSolutionRaw.total - bundleChunksInSolution, 0),
+      totalRawIncludingBundleChunks: inSolutionRaw.total,
+      bundleChunksInSolution,
+    };
+  }
 
   // Component count must match what Dataverse `solutioncomponents` counts —
   // each table is ONE component (attributes ride along, not counted separately).
@@ -460,8 +531,14 @@ async function estimateSolutionSize({ envUrl, websiteRecordId, token, publisherP
   // undercount. Live SIP site had 4 bots + 30 components missing from siteTotal,
   // making orphansOnSite (46) misleadingly small. With bot queries enabled,
   // siteTotal now includes them and orphansOnSite reflects reality.
+  //
+  // Subtract bundle chunks (Vite/Rollup hashed .js/.css). Those accumulate as
+  // dead orphans with every `pac pages upload-code-site` rebuild and don't
+  // represent real site inventory — they're noise, not content.
+  const bundleChunkCount = classified.bundleChunks.length;
   const siteTotalComponents =
-    ppcs.length +
+    ppcs.length -
+    bundleChunkCount +
     tables.length +
     envVarCount +
     classified.cloudFlowLinks.length +
@@ -479,10 +556,16 @@ async function estimateSolutionSize({ envUrl, websiteRecordId, token, publisherP
     orphansOnSite: inSolution ? Math.max(siteTotalComponents - inSolution.total, 0) : null,
     botCountScoped: botsAndComponents.bots.length || 0,
     botComponentCountScoped: botsAndComponents.botComponents.length || 0,
+    bundleChunkCount,
+    bundleChunkNote: bundleChunkCount > 0
+      ? `${bundleChunkCount} hashed bundle chunks (Vite/Rollup) excluded from siteTotal — they're stale orphans from prior pac pages upload-code-site runs. Cleanable via dedicated cleanup pass (not yet implemented).`
+      : null,
     inSolution: inSolution
       ? {
           total: inSolution.total,
           byComponentType: inSolution.byComponentType,
+          totalRawIncludingBundleChunks: inSolution.totalRawIncludingBundleChunks,
+          bundleChunksInSolution: inSolution.bundleChunksInSolution,
           // objectIds intentionally omitted from JSON output to keep it small;
           // callers that need diffing should use discover-site-components.js.
         }

--- a/plugins/power-pages/scripts/lib/estimate-solution-size.js
+++ b/plugins/power-pages/scripts/lib/estimate-solution-size.js
@@ -109,14 +109,20 @@ async function collectPaginated(envUrl, path, token, maxPages = 20) {
  * Discovers bots + bot components linked to the site.
  *
  * Power Pages bot linkage: each site has `powerpagecomponent` rows of type 27
- * (Bot Consumer). Each consumer references a bot by its schemaname stored in
- * the ppc `name` field. We use those names to scope the bot query so we only
- * count bots actually attached to this site, not every bot in the env.
+ * (Bot Consumer). Each consumer carries the bot schemaname in its `content`
+ * JSON (the `name` column is literally the string "Bot Consumer"). We scope
+ * the bot query by those schemanames so env-wide bots from other projects
+ * don't inflate this site's count.
  *
  * Each bot has child `botcomponent` rows (topics, entities, gpt defs). Both
  * bots and bot components become separate `solutioncomponents` rows when added
  * to a solution (types 10137 and 10193). Counting them here closes the
  * siteTotal gap that previously made orphansOnSite look artificially small.
+ *
+ * Pagination ceilings (from collectPaginated below): bots up to 1,500 records
+ * (3 pages × $top=500), botcomponents up to 25,000 (5 × 5,000). Hitting either
+ * is so unusual in real tenants that we log a WARN rather than paginating
+ * forever; caller can see the warning in stderr and bump the limits if needed.
  */
 async function discoverBotsAndComponents(envUrl, botConsumerPpcs, token) {
   if (!botConsumerPpcs || botConsumerPpcs.length === 0) {
@@ -160,27 +166,41 @@ async function discoverBotsAndComponents(envUrl, botConsumerPpcs, token) {
   // stays well inside URL-length limits for realistic consumer counts (<50).
   const safeNames = unique.map((n) => n.replace(/'/g, "''"));
   const botFilter = safeNames.map((n) => `schemaname eq '${n}'`).join(' or ');
+  const BOTS_TOP = 500;
+  const BOTS_MAX_PAGES = 3;
   const botsPath =
-    `bots?$filter=${botFilter}&$select=botid,name,schemaname&$top=500`;
+    `bots?$filter=${botFilter}&$select=botid,name,schemaname&$top=${BOTS_TOP}`;
   let bots = [];
   try {
-    bots = await collectPaginated(envUrl, botsPath, token, 3);
+    bots = await collectPaginated(envUrl, botsPath, token, BOTS_MAX_PAGES);
   } catch {
     // Bots may be unavailable in some tenants (privilege / feature gating).
     // Don't fail the whole estimate — surface as zero and move on.
     return { bots: [], botComponents: [] };
   }
+  if (bots.length >= BOTS_TOP * BOTS_MAX_PAGES) {
+    process.stderr.write(
+      `estimate-solution-size: WARN — bot query returned ${bots.length} rows, at pagination cap (${BOTS_TOP * BOTS_MAX_PAGES}). Counts may be undercounted; raise BOTS_MAX_PAGES if your tenant has more bots referenced by this site.\n`,
+    );
+  }
   if (bots.length === 0) return { bots: [], botComponents: [] };
 
   const botIds = bots.map((b) => b.botid).filter(Boolean);
   const compFilter = botIds.map((id) => `_parentbotid_value eq ${id}`).join(' or ');
+  const COMPS_TOP = 5000;
+  const COMPS_MAX_PAGES = 5;
   const compsPath =
-    `botcomponents?$filter=${compFilter}&$select=botcomponentid&$top=5000`;
+    `botcomponents?$filter=${compFilter}&$select=botcomponentid&$top=${COMPS_TOP}`;
   let botComponents = [];
   try {
-    botComponents = await collectPaginated(envUrl, compsPath, token, 5);
+    botComponents = await collectPaginated(envUrl, compsPath, token, COMPS_MAX_PAGES);
   } catch {
     botComponents = [];
+  }
+  if (botComponents.length >= COMPS_TOP * COMPS_MAX_PAGES) {
+    process.stderr.write(
+      `estimate-solution-size: WARN — bot component query returned ${botComponents.length} rows, at pagination cap (${COMPS_TOP * COMPS_MAX_PAGES}). Counts may be undercounted; raise COMPS_MAX_PAGES if your tenant's bots have more topics.\n`,
+    );
   }
   return { bots, botComponents };
 }
@@ -545,15 +565,32 @@ async function estimateSolutionSize({ envUrl, websiteRecordId, token, publisherP
   // Earlier versions added `schemaAttrCount` which inflated the total by 3–5×
   // on schema-heavy sites (e.g. 503 attrs pushed the count from 405 → 908).
   //
-  // Each constant here maps directly to a `componenttype`:
-  //   ppcs.length          → componenttype 10373 (site sub-components)
-  //   tables.length        → componenttype 1 (Entity) — attributes NOT added
-  //   envVarCount          → componenttype 380 (env var definition)
-  //   classified.cloudFlowLinks.length → componenttype 29 via the workflow
-  //                            (the type-33 ppc binding is already in ppcs.length)
-  //   classified.botConsumers.length → counted once (as ppc type 27 in ppcs.length)
-  //   botsAndComponents.bots.length → componenttype 10137 (Bot)
-  //   botsAndComponents.botComponents.length → componenttype 10193 (Bot Component)
+  // Each term maps to a distinct `solutioncomponents` row that would be added
+  // when the site is solutionized:
+  //
+  //   ppcs.length                               → type 10373 rows (includes
+  //                                                type-27 bot consumers and
+  //                                                type-33 cloud flow bindings,
+  //                                                which themselves import as
+  //                                                type 10373 sub-components)
+  //   tables.length                             → type 1 rows (Entity). Columns
+  //                                                ride along — do NOT add
+  //                                                schemaAttrCount here.
+  //   envVarCount                               → type 380 rows
+  //   classified.cloudFlowLinks.length          → type 29 rows (the workflow
+  //                                                entity itself). Each cloud
+  //                                                flow contributes TWO distinct
+  //                                                solutioncomponents rows: one
+  //                                                type-10373 (the ppc binding,
+  //                                                already in ppcs.length) and
+  //                                                one type-29 (added here).
+  //                                                Since type-33 ppc bindings
+  //                                                pair 1:1 with workflows,
+  //                                                cloudFlowLinks.length is the
+  //                                                workflow count. NOT a double-
+  //                                                count despite the name.
+  //   botsAndComponents.bots.length             → type 10137 rows
+  //   botsAndComponents.botComponents.length    → type 10193 rows
   //
   // Before adding bot queries on 2026-04-22, bots + bot components were a known
   // undercount. Live SIP site had 4 bots + 30 components missing from siteTotal,
@@ -578,7 +615,11 @@ async function estimateSolutionSize({ envUrl, websiteRecordId, token, publisherP
     publisherPrefix: publisherPrefix || null,
     solutionId: solutionId || null,
     totalSizeMB: round1(totalSizeMB),
-    componentCount: siteTotalComponents,
+    // Canonical field for "components the site would export as solutioncomponents
+    // rows." Earlier revisions exposed a duplicate `componentCount` alias; it was
+    // dropped on 2026-04-22 since ALM skills are still in feature-branch development
+    // and don't need the legacy alias. Consumers (compute-split-plan, render-alm-plan)
+    // read `componentCountSiteTotal` directly.
     componentCountSiteTotal: siteTotalComponents,
     componentCountInSolution: inSolution ? inSolution.total : null,
     orphansOnSite: inSolution ? Math.max(siteTotalComponents - inSolution.total, 0) : null,

--- a/plugins/power-pages/scripts/tests/compute-split-plan.test.js
+++ b/plugins/power-pages/scripts/tests/compute-split-plan.test.js
@@ -123,29 +123,40 @@ test('computeSplitPlan produces 1 proposed solution for single', () => {
   assert.equal(result.proposedSolutions[0].uniqueName, 'Test');
 });
 
-test('computeSplitPlan produces 2 solutions for Layer split', () => {
+test('computeSplitPlan produces 2 partition solutions + 1 Future buffer for Layer split', () => {
   const result = computeSplitPlan({
     estimate: baseEstimate({ totalSizeMB: 142, webFilesAggregateMB: 110 }),
     config: baseConfig(),
     meta: { baseName: 'Test', siteName: 'Test Site' },
   });
   assert.equal(result.splitStrategy, 'strategy-1-layer');
-  assert.equal(result.proposedSolutions.length, 2);
+  // 2 partition solutions (Core, WebAssets) + 1 Future buffer reserved for new additions
+  assert.equal(result.proposedSolutions.length, 3);
   assert.match(result.proposedSolutions[0].uniqueName, /Core$/);
   assert.match(result.proposedSolutions[1].uniqueName, /WebAssets$/);
+  assert.equal(result.proposedSolutions[2].uniqueName, 'Test_Future');
+  assert.equal(result.proposedSolutions[2].isFutureBuffer, true);
   assert.equal(result.proposedSolutions[0].order, 1);
   assert.equal(result.proposedSolutions[1].order, 2);
+  assert.equal(result.proposedSolutions[2].order, 3);
 });
 
-test('computeSplitPlan produces 4 solutions for Change-Frequency split', () => {
+test('computeSplitPlan produces 4 partition solutions + 1 Future buffer for Change-Frequency split', () => {
   const result = computeSplitPlan({
     estimate: baseEstimate({ totalSizeMB: 74, componentCount: 7200, cloudFlowCount: 12 }),
     config: baseConfig(),
     meta: { baseName: 'Test', siteName: 'Test Site' },
   });
-  assert.equal(result.proposedSolutions.length, 4);
+  assert.equal(result.proposedSolutions.length, 5);
   const names = result.proposedSolutions.map((s) => s.uniqueName);
-  assert.deepEqual(names, ['Test_Foundation', 'Test_Integration', 'Test_Config', 'Test_Content']);
+  assert.deepEqual(names, [
+    'Test_Foundation',
+    'Test_Integration',
+    'Test_Config',
+    'Test_Content',
+    'Test_Future',
+  ]);
+  assert.equal(result.proposedSolutions[4].isFutureBuffer, true);
 });
 
 test('computeSplitPlan Strategy 3 uses explicit config.domains when present', () => {
@@ -161,11 +172,13 @@ test('computeSplitPlan Strategy 3 uses explicit config.domains when present', ()
     meta: { baseName: 'Test', siteName: 'Test Site' },
   });
   assert.equal(result.splitStrategy, 'strategy-3-schema-segmentation');
-  // 2 explicit domains + 1 Site solution
-  assert.equal(result.proposedSolutions.length, 3);
+  // 2 explicit domains + 1 Site solution + 1 Future buffer
+  assert.equal(result.proposedSolutions.length, 4);
   assert.equal(result.proposedSolutions[0].uniqueName, 'Test_Catalog');
   assert.equal(result.proposedSolutions[1].uniqueName, 'Test_Orders');
   assert.equal(result.proposedSolutions[2].uniqueName, 'Test_Site');
+  assert.equal(result.proposedSolutions[3].uniqueName, 'Test_Future');
+  assert.equal(result.proposedSolutions[3].isFutureBuffer, true);
 });
 
 test('computeSplitPlan Strategy 3 falls back to prefix heuristic when no domains configured', () => {
@@ -197,6 +210,79 @@ test('computeSplitPlan additive Strategy 4 prepends EnvVars solution', () => {
   assert.ok(result.appliedStrategies.includes('strategy-4-config-isolation'));
   assert.equal(result.proposedSolutions[0].uniqueName, 'Test_EnvVars');
   assert.equal(result.proposedSolutions[0].order, 1);
+  // Even additive flows still end with the Future buffer.
+  const last = result.proposedSolutions[result.proposedSolutions.length - 1];
+  assert.equal(last.uniqueName, 'Test_Future');
+  assert.equal(last.isFutureBuffer, true);
+});
+
+// --- Future buffer behavior -------------------------------------------------
+
+test('single-solution plan does NOT get a Future buffer appended', () => {
+  const result = computeSplitPlan({
+    estimate: baseEstimate(),
+    config: baseConfig(),
+    meta: { baseName: 'Test', siteName: 'Test Site' },
+  });
+  assert.equal(result.splitStrategy, 'single');
+  assert.equal(result.proposedSolutions.length, 1, 'single plan should stay one solution');
+  assert.ok(
+    !result.proposedSolutions.some((s) => s.isFutureBuffer),
+    'single plan has no partition to protect — no Future buffer expected'
+  );
+});
+
+test('Future buffer has zero size, zero count, and isFutureBuffer flag set', () => {
+  const result = computeSplitPlan({
+    estimate: baseEstimate({ totalSizeMB: 142, webFilesAggregateMB: 110 }),
+    config: baseConfig(),
+    meta: { baseName: 'Test', siteName: 'Test Site' },
+  });
+  const future = result.proposedSolutions.find((s) => s.isFutureBuffer);
+  assert.ok(future, 'Future buffer should be present in a multi-solution split');
+  assert.equal(future.sizeMB, 0);
+  assert.equal(future.componentCount, 0);
+  assert.deepEqual(future.components, []);
+  assert.deepEqual(future.componentTypes, ['Any']);
+  assert.match(future.description, /new components added to the site/i);
+});
+
+test('Future buffer uses consistent naming and is always the last entry', () => {
+  // Run multiple strategies; Future should always come last with the same suffix.
+  const cases = [
+    { label: 'layer', est: baseEstimate({ totalSizeMB: 142, webFilesAggregateMB: 110 }) },
+    { label: 'change-freq', est: baseEstimate({ totalSizeMB: 74, componentCount: 7200, cloudFlowCount: 12 }) },
+    { label: 'schema', est: baseEstimate({ tableCount: 34, schemaAttrCount: 32000 }) },
+  ];
+  for (const c of cases) {
+    const result = computeSplitPlan({
+      estimate: c.est,
+      config: baseConfig(),
+      meta: { baseName: 'Test', siteName: 'Test Site' },
+    });
+    const last = result.proposedSolutions[result.proposedSolutions.length - 1];
+    assert.equal(last.uniqueName, 'Test_Future', `${c.label}: last solution should be Test_Future`);
+    assert.equal(last.order, result.proposedSolutions.length, `${c.label}: Future should have the highest order`);
+  }
+});
+
+test('appendFutureBuffer exported and idempotent-safe on single-entry arrays', () => {
+  const { appendFutureBuffer } = require('../lib/compute-split-plan');
+  const single = [{ uniqueName: 'Alpha', order: 1 }];
+  // Single-entry arrays represent a single-solution plan — no buffer.
+  assert.deepEqual(appendFutureBuffer(single, { baseName: 'X', siteName: 'X' }), single);
+  // Multi-entry arrays get the buffer appended exactly once.
+  const multi = [
+    { uniqueName: 'Alpha', order: 1 },
+    { uniqueName: 'Beta', order: 2 },
+  ];
+  const out = appendFutureBuffer(multi, { baseName: 'X', siteName: 'X Site' });
+  assert.equal(out.length, 3);
+  assert.equal(out[2].uniqueName, 'X_Future');
+  assert.equal(out[2].order, 3);
+  // Empty/invalid input shape: return as-is.
+  assert.deepEqual(appendFutureBuffer([], { baseName: 'X', siteName: 'X' }), []);
+  assert.deepEqual(appendFutureBuffer(null, { baseName: 'X', siteName: 'X' }), null);
 });
 
 // --- Asset advisory ---------------------------------------------------------

--- a/plugins/power-pages/scripts/tests/compute-split-plan.test.js
+++ b/plugins/power-pages/scripts/tests/compute-split-plan.test.js
@@ -27,7 +27,7 @@ function baseEstimate(overrides = {}) {
     siteName: 'Test',
     publisherPrefix: 'tst',
     totalSizeMB: 40,
-    componentCount: 1500,
+    componentCountSiteTotal: 1500,
     tableCount: 3,
     schemaAttrCount: 60,
     webFilesAggregateMB: 4,
@@ -56,7 +56,7 @@ test('Scenario B (Feedback Portal): Size red + web-heavy → Strategy 1 Layer', 
   const est = baseEstimate({
     totalSizeMB: 142,
     webFilesAggregateMB: 110,
-    componentCount: 2100,
+    componentCountSiteTotal: 2100,
   });
   const { primary } = selectStrategy(est, baseConfig());
   assert.equal(primary, 'strategy-1-layer');
@@ -67,7 +67,7 @@ test('Scenario C (Prabhat 34x950 schema): schema red → Strategy 3 Schema Segme
     totalSizeMB: 68,
     tableCount: 34,
     schemaAttrCount: 32300,
-    componentCount: 35000,
+    componentCountSiteTotal: 35000,
   });
   const { primary } = selectStrategy(est, baseConfig());
   assert.equal(primary, 'strategy-3-schema-segmentation');
@@ -85,7 +85,7 @@ test('Scenario D (Brad 1400 env vars): only envVarCount red → Strategy 4 alone
 test('Scenario E (component-heavy with many flows): Strategy 2 Change-Frequency', () => {
   const est = baseEstimate({
     totalSizeMB: 74,
-    componentCount: 7200,
+    componentCountSiteTotal: 7200,
     cloudFlowCount: 12,
   });
   const { primary } = selectStrategy(est, baseConfig());
@@ -143,7 +143,7 @@ test('computeSplitPlan produces 2 partition solutions + 1 Future buffer for Laye
 
 test('computeSplitPlan produces 4 partition solutions + 1 Future buffer for Change-Frequency split', () => {
   const result = computeSplitPlan({
-    estimate: baseEstimate({ totalSizeMB: 74, componentCount: 7200, cloudFlowCount: 12 }),
+    estimate: baseEstimate({ totalSizeMB: 74, componentCountSiteTotal: 7200, cloudFlowCount: 12 }),
     config: baseConfig(),
     meta: { baseName: 'Test', siteName: 'Test Site' },
   });
@@ -251,7 +251,7 @@ test('Future buffer uses consistent naming and is always the last entry', () => 
   // Run multiple strategies; Future should always come last with the same suffix.
   const cases = [
     { label: 'layer', est: baseEstimate({ totalSizeMB: 142, webFilesAggregateMB: 110 }) },
-    { label: 'change-freq', est: baseEstimate({ totalSizeMB: 74, componentCount: 7200, cloudFlowCount: 12 }) },
+    { label: 'change-freq', est: baseEstimate({ totalSizeMB: 74, componentCountSiteTotal: 7200, cloudFlowCount: 12 }) },
     { label: 'schema', est: baseEstimate({ tableCount: 34, schemaAttrCount: 32000 }) },
   ];
   for (const c of cases) {
@@ -336,7 +336,7 @@ test('Strategy 3 surfaces the 10+ hour warning in recommendations', () => {
 
 test('buildSizeAnalysis tags signals as green/yellow/red', () => {
   const analysis = buildSizeAnalysis(
-    baseEstimate({ totalSizeMB: 100, componentCount: 7000, schemaAttrCount: 200 }),
+    baseEstimate({ totalSizeMB: 100, componentCountSiteTotal: 7000, schemaAttrCount: 200 }),
     DEFAULTS,
   );
   assert.equal(analysis.totalSizeMB.tier, 'red');
@@ -349,14 +349,14 @@ test('buildSizeAnalysis tags signals as green/yellow/red', () => {
 test('Hard-flag component count still routes to Strategy 2 (not silent single)', () => {
   // 12,000 components is above hardFlagComponentCount (10,000) — earlier code
   // fell through to `single`. Now it should still recommend a split.
-  const est = baseEstimate({ componentCount: 12000 });
+  const est = baseEstimate({ componentCountSiteTotal: 12000 });
   const { primary } = selectStrategy(est, baseConfig());
   assert.equal(primary, 'strategy-2-change-frequency');
 });
 
 test('Hard-flag component count emits an error-type recommendation', () => {
   const result = computeSplitPlan({
-    estimate: baseEstimate({ componentCount: 12000 }),
+    estimate: baseEstimate({ componentCountSiteTotal: 12000 }),
     config: baseConfig(),
     meta: { baseName: 'Test', siteName: 'Test Site' },
   });
@@ -367,7 +367,7 @@ test('Hard-flag component count emits an error-type recommendation', () => {
 // --- Size / count consistency in Change-Frequency partition ----------------
 
 test('partitionByChangeFrequency sums sizeMB back to totalSizeMB (±0.5)', () => {
-  const est = baseEstimate({ totalSizeMB: 74, componentCount: 7200, cloudFlowCount: 12 });
+  const est = baseEstimate({ totalSizeMB: 74, componentCountSiteTotal: 7200, cloudFlowCount: 12 });
   const solutions = partitionByChangeFrequency(est, { baseName: 'T', siteName: 'T' });
   const sum = solutions.reduce((s, sol) => s + sol.sizeMB, 0);
   assert.ok(

--- a/plugins/power-pages/scripts/tests/estimate-solution-size.test.js
+++ b/plugins/power-pages/scripts/tests/estimate-solution-size.test.js
@@ -5,18 +5,23 @@ const { classifyPPCs, estimateTotalSize, BYTES_PER } = require('../lib/estimate-
 
 // --- classifyPPCs -----------------------------------------------------------
 
-test('classifyPPCs buckets components by known Power Pages type numbers', () => {
+test('classifyPPCs buckets components by authoritative powerpagecomponenttype picklist values', () => {
+  // Picklist values sourced from MS Learn / PPC_TYPE_LABELS. Earlier iterations
+  // of this test asserted against swapped constants (WEB_FILE=2, WEB_PAGE=4,
+  // WEB_TEMPLATE=11) which happened to hide a real bug where web file sizing
+  // was silently querying web pages. Fixed 2026-04-22.
   const ppcs = [
-    { powerpagecomponentid: 'a', powerpagecomponenttype: 9 },  // Site Setting
-    { powerpagecomponentid: 'b', powerpagecomponenttype: 9 },
-    { powerpagecomponentid: 'c', powerpagecomponenttype: 16 }, // Web Role
-    { powerpagecomponentid: 'd', powerpagecomponenttype: 18 }, // Table Permission
-    { powerpagecomponentid: 'e', powerpagecomponenttype: 27 }, // Bot Consumer
-    { powerpagecomponentid: 'f', powerpagecomponenttype: 33 }, // Cloud Flow Link
-    { powerpagecomponentid: 'g', powerpagecomponenttype: 2 },  // Web File
-    { powerpagecomponentid: 'h', powerpagecomponenttype: 4 },  // Web Page
-    { powerpagecomponentid: 'i', powerpagecomponenttype: 11 }, // Web Template
-    { powerpagecomponentid: 'j', powerpagecomponenttype: 999 }, // unknown
+    { powerpagecomponentid: 'a', name: 'FeatureFlag', powerpagecomponenttype: 9 },   // Site Setting
+    { powerpagecomponentid: 'b', name: 'SearchEnabled', powerpagecomponenttype: 9 },
+    { powerpagecomponentid: 'c', name: 'Admin', powerpagecomponenttype: 11 },        // Web Role
+    { powerpagecomponentid: 'd', name: 'Contact permission', powerpagecomponenttype: 18 }, // Table Permission
+    { powerpagecomponentid: 'e', name: 'Bot Consumer', powerpagecomponenttype: 27 }, // Bot Consumer
+    { powerpagecomponentid: 'f', name: 'FlowBinding', powerpagecomponenttype: 33 },  // Cloud Flow
+    { powerpagecomponentid: 'g', name: 'hero.jpg', powerpagecomponenttype: 3 },      // Web File (static asset)
+    { powerpagecomponentid: 'g2', name: 'Home-BPuZZDcA.js', powerpagecomponenttype: 3 }, // Web File (bundle chunk)
+    { powerpagecomponentid: 'h', name: 'Home', powerpagecomponenttype: 2 },          // Web Page
+    { powerpagecomponentid: 'i', name: 'layout', powerpagecomponenttype: 8 },        // Web Template
+    { powerpagecomponentid: 'j', name: '?', powerpagecomponenttype: 999 },           // unknown
   ];
   const c = classifyPPCs(ppcs);
   assert.equal(c.siteSettings.length, 2);
@@ -24,12 +29,38 @@ test('classifyPPCs buckets components by known Power Pages type numbers', () => 
   assert.equal(c.tablePermissions.length, 1);
   assert.equal(c.botConsumers.length, 1);
   assert.equal(c.cloudFlowLinks.length, 1);
-  assert.equal(c.webFiles.length, 1);
+  // webFiles is now the "real content" bucket — bundle chunks are split out.
+  assert.equal(c.webFiles.length, 1, 'hero.jpg is a real web file');
+  assert.equal(c.bundleChunks.length, 1, 'Home-BPuZZDcA.js is a hash-suffixed chunk');
   assert.equal(c.webPages.length, 1);
   assert.equal(c.webTemplates.length, 1);
-  assert.equal(c.all.length, 10);
+  assert.equal(c.all.length, 11);
   // Unknown types stay in byType but don't appear in any named bucket.
   assert.ok(c.byType.has(999));
+});
+
+test('classifyPPCs isProbablyBundleChunk heuristic identifies Vite/Rollup chunks without false positives on real assets', () => {
+  const samples = [
+    // Should be flagged as chunks
+    { name: 'Home-BPuZZDcA.js', powerpagecomponenttype: 3 },
+    { name: 'index-DyzztwOp.js', powerpagecomponenttype: 3 },
+    { name: 'purchaseOrderService-CEILvOTp.js', powerpagecomponenttype: 3 },
+    { name: 'chunk-RxR9EgHz.mjs', powerpagecomponenttype: 3 },
+    { name: 'vendor.a1b2c3d4.js', powerpagecomponenttype: 3 },
+    { name: 'style.Z0qHD57j.css', powerpagecomponenttype: 3 },
+    { name: 'index-DyzztwOp.js.map', powerpagecomponenttype: 3 },
+    // Should NOT be flagged
+    { name: 'hero.jpg', powerpagecomponenttype: 3 },
+    { name: 'logo.svg', powerpagecomponenttype: 3 },
+    { name: 'favicon.ico', powerpagecomponenttype: 3 },
+    { name: 'app.js', powerpagecomponenttype: 3 },
+    { name: 'style.css', powerpagecomponenttype: 3 },
+    { name: 'robots.txt', powerpagecomponenttype: 3 },
+    { name: 'fonts/Inter-Regular.woff2', powerpagecomponenttype: 3 },
+  ];
+  const c = classifyPPCs(samples);
+  assert.equal(c.bundleChunks.length, 7, 'should flag all 7 hash-suffixed chunks');
+  assert.equal(c.webFiles.length, 7, 'should keep all 7 real assets as web files');
 });
 
 test('classifyPPCs returns empty arrays when a type is missing', () => {

--- a/plugins/power-pages/scripts/tests/integration/discover-integration.test.js
+++ b/plugins/power-pages/scripts/tests/integration/discover-integration.test.js
@@ -129,6 +129,65 @@ test('integration: discover survives an empty site (no components, no solutionId
   }
 });
 
+test('integration: countSolutionMembership cross-site safety check flags ppcs not on target site', async () => {
+  const { countSolutionMembership } = require('../../lib/estimate-solution-size');
+  const mock = await startMock([
+    {
+      method: 'GET',
+      matcher: '/solutioncomponents?',
+      body: {
+        value: [
+          { objectid: 'ppc-on-site-1', componenttype: 10373 },
+          { objectid: 'ppc-on-site-2', componenttype: 10373 },
+          { objectid: 'ppc-from-OTHER-site', componenttype: 10373 }, // ← cross-site
+          { objectid: 'table-1', componenttype: 1 }, // not a ppc — not checked
+          { objectid: 'website-1', componenttype: 10374 },
+        ],
+      },
+    },
+  ]);
+  try {
+    const sitePpcIdSet = new Set(['ppc-on-site-1', 'ppc-on-site-2']);
+    const result = await countSolutionMembership(
+      mock.baseUrl,
+      'sol-xyz',
+      'fake-token',
+      sitePpcIdSet,
+    );
+    assert.equal(result.total, 5);
+    assert.equal(result.byComponentType[10373], 3);
+    assert.deepEqual(result.crossSitePpcs, ['ppc-from-other-site'],
+      'the ppc not in the site set should be flagged, and the check is case-insensitive');
+  } finally {
+    await mock.close();
+  }
+});
+
+test('integration: countSolutionMembership returns empty crossSitePpcs when sitePpcIdSet is null', async () => {
+  const { countSolutionMembership } = require('../../lib/estimate-solution-size');
+  const mock = await startMock([
+    {
+      method: 'GET',
+      matcher: '/solutioncomponents?',
+      body: {
+        value: [{ objectid: 'x', componenttype: 10373 }],
+      },
+    },
+  ]);
+  try {
+    const result = await countSolutionMembership(
+      mock.baseUrl,
+      'sol-xyz',
+      'fake-token',
+      null,
+    );
+    assert.deepEqual(result.crossSitePpcs, [],
+      'no cross-site check when caller did not supply the site set');
+  } finally {
+    await mock.close();
+  }
+});
+
 test('integration: discover with publisherPrefix queries env vars + tables endpoints', async () => {
   const mock = await startMock([
     { method: 'GET', matcher: '/powerpagecomponents', body: { value: [] } },

--- a/plugins/power-pages/scripts/tests/integration/discover-integration.test.js
+++ b/plugins/power-pages/scripts/tests/integration/discover-integration.test.js
@@ -1,0 +1,191 @@
+'use strict';
+
+// Integration test for discover-site-components.js — runs against a real HTTP
+// mock server (not injected makeRequest) so we validate the actual network
+// code paths, URL construction, authorization header handling, and pagination.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { startMock } = require('./mock-dataverse');
+const {
+  discoverSiteComponents,
+} = require('../../lib/discover-site-components');
+
+test('integration: discover follows @odata.nextLink pagination against a real HTTP server', async () => {
+  let mockBase = null;
+
+  const routes = [
+    // Page 2 — serves rows when nextPage=1 is in the query
+    {
+      method: 'GET',
+      matcher: (req) =>
+        req.url.includes('/powerpagecomponents') && req.url.includes('nextPage=1'),
+      body: {
+        value: [
+          { powerpagecomponentid: 'p3', name: 'Page3', powerpagecomponenttype: 2 },
+          { powerpagecomponentid: 'p4', name: 'index-abc.js', powerpagecomponenttype: 3 },
+        ],
+      },
+    },
+    // Page 1 — serves rows + nextLink
+    {
+      method: 'GET',
+      matcher: (req) =>
+        req.url.includes('/powerpagecomponents') && !req.url.includes('nextPage='),
+      body: () => ({
+        value: [
+          { powerpagecomponentid: 'p1', name: 'Home', powerpagecomponenttype: 2 },
+          { powerpagecomponentid: 'p2', name: 'About', powerpagecomponenttype: 2 },
+        ],
+        '@odata.nextLink': `${mockBase}/api/data/v9.2/powerpagecomponents?nextPage=1`,
+      }),
+    },
+    { method: 'GET', matcher: '/workflows?', body: { value: [] } },
+    {
+      method: 'GET',
+      matcher: '/solutioncomponents?',
+      body: {
+        value: [
+          { objectid: 'p1', componenttype: 10373 },
+          { objectid: 'p2', componenttype: 10373 },
+          // p3, p4 missing
+        ],
+      },
+    },
+  ];
+
+  const mock = await startMock(routes);
+  mockBase = mock.baseUrl;
+
+  try {
+    const result = await discoverSiteComponents({
+      envUrl: mock.baseUrl,
+      token: 'fake-integration-token',
+      siteId: 'site-42',
+      solutionId: 'sol-integration',
+    });
+
+    assert.equal(result.powerpagecomponents.total, 4, 'should aggregate both pages');
+    assert.equal(result.missing.powerpagecomponents.length, 2);
+    assert.deepEqual(
+      result.missing.powerpagecomponents.map((c) => c.name).sort(),
+      ['Page3', 'index-abc.js']
+    );
+    assert.equal(result.inSolution.total, 2);
+
+    // Every call must have carried the Authorization header
+    for (const call of mock.calls) {
+      assert.equal(
+        call.authorization,
+        'Bearer fake-integration-token',
+        `Auth header missing on ${call.method} ${call.url}`
+      );
+    }
+
+    // Two ppc calls confirm pagination was exercised
+    const ppcCalls = mock.calls.filter((c) => c.url.includes('/powerpagecomponents'));
+    assert.equal(ppcCalls.length, 2, 'expected two ppc requests (page 1 + page 2)');
+  } finally {
+    await mock.close();
+  }
+});
+
+test('integration: discover surfaces HTTP 500 with a clear error', async () => {
+  const mock = await startMock([
+    {
+      method: 'GET',
+      matcher: '/powerpagecomponents',
+      status: 500,
+      body: { error: { message: 'Synthetic failure' } },
+    },
+  ]);
+  try {
+    await assert.rejects(
+      discoverSiteComponents({ envUrl: mock.baseUrl, token: 'x', siteId: 'site-42' }),
+      /HTTP 500/
+    );
+  } finally {
+    await mock.close();
+  }
+});
+
+test('integration: discover survives an empty site (no components, no solutionId)', async () => {
+  const mock = await startMock([
+    { method: 'GET', matcher: '/powerpagecomponents', body: { value: [] } },
+    { method: 'GET', matcher: '/workflows?', body: { value: [] } },
+  ]);
+  try {
+    const result = await discoverSiteComponents({
+      envUrl: mock.baseUrl,
+      token: 'x',
+      siteId: 'site-empty',
+    });
+    assert.equal(result.powerpagecomponents.total, 0);
+    assert.deepEqual(Object.keys(result.powerpagecomponents.byType), []);
+    assert.equal(result.cloudFlows.length, 0);
+    assert.strictEqual(result.missing, undefined, 'missing block only populates when solutionId passed');
+  } finally {
+    await mock.close();
+  }
+});
+
+test('integration: discover with publisherPrefix queries env vars + tables endpoints', async () => {
+  const mock = await startMock([
+    { method: 'GET', matcher: '/powerpagecomponents', body: { value: [] } },
+    { method: 'GET', matcher: '/workflows?', body: { value: [] } },
+    {
+      method: 'GET',
+      matcher: '/environmentvariabledefinitions',
+      body: {
+        value: [
+          {
+            environmentvariabledefinitionid: 'ev1',
+            schemaname: 'contoso_FeatureFlag',
+            displayname: 'Feature Flag',
+            type: 100000000,
+            defaultvalue: 'false',
+          },
+        ],
+      },
+    },
+    {
+      method: 'GET',
+      matcher: '/EntityDefinitions',
+      body: {
+        value: [
+          {
+            MetadataId: 'meta-1',
+            LogicalName: 'contoso_account',
+            SchemaName: 'contoso_Account',
+            DisplayName: { UserLocalizedLabel: { Label: 'Account' } },
+          },
+          {
+            MetadataId: 'meta-2',
+            LogicalName: 'other_widget',
+            SchemaName: 'other_Widget',
+            DisplayName: { UserLocalizedLabel: { Label: 'Widget' } },
+          },
+        ],
+      },
+    },
+  ]);
+  try {
+    const result = await discoverSiteComponents({
+      envUrl: mock.baseUrl,
+      token: 'x',
+      siteId: 'site-42',
+      publisherPrefix: 'contoso',
+    });
+    assert.equal(result.envVars.length, 1);
+    assert.equal(result.envVars[0].schemaName, 'contoso_FeatureFlag');
+    assert.equal(result.customTables.length, 1);
+    assert.equal(result.customTables[0].logicalName, 'contoso_account');
+
+    const evCalls = mock.calls.filter((c) => c.url.includes('/environmentvariabledefinitions'));
+    assert.equal(evCalls.length, 1);
+    const edCalls = mock.calls.filter((c) => c.url.includes('/EntityDefinitions'));
+    assert.equal(edCalls.length, 1);
+  } finally {
+    await mock.close();
+  }
+});

--- a/plugins/power-pages/scripts/tests/integration/mock-dataverse.js
+++ b/plugins/power-pages/scripts/tests/integration/mock-dataverse.js
@@ -1,0 +1,85 @@
+'use strict';
+
+// Minimal HTTP mock for Dataverse OData responses used by integration tests.
+//
+// Built once per test: give it a map of URL-path → response body (or a handler
+// function that returns { statusCode, body }). Start it, use the URL it binds
+// to, stop it when done.
+//
+// Why this exists: `discover-site-components.js`, `resolve-target-solution.js`,
+// and `estimate-solution-size.js` are exercised via unit tests with injected
+// makeRequest, but the real code paths go through Node's https module + an
+// actual URL. An integration test running against a real HTTP surface catches
+// regressions like accidental URL-encoding bugs, missing Authorization header
+// handling, and token-refresh patterns that injected-mock tests can't surface.
+
+const http = require('http');
+
+/**
+ * Starts a localhost http server that responds to OData-like requests.
+ *
+ * @param {Array<{
+ *   matcher: string | RegExp | ((req) => boolean),
+ *   status?: number,
+ *   headers?: object,
+ *   body?: any
+ * } | ((req) => any)>} routes
+ *   Each route either matches by path fragment (string), regex, or predicate.
+ *   `body` can be a plain object (serialized to JSON) or a function that
+ *   receives the request and returns a body.
+ * @returns {Promise<{ baseUrl: string, port: number, close: () => Promise<void>, calls: Array }>}
+ */
+async function startMock(routes) {
+  const calls = [];
+  const server = http.createServer((req, res) => {
+    const url = req.url;
+    const authHeader = req.headers.authorization;
+    let body = '';
+    req.on('data', (c) => (body += c));
+    req.on('end', () => {
+      calls.push({ method: req.method, url, authorization: authHeader, body });
+      for (const route of routes) {
+        const match =
+          typeof route === 'function'
+            ? route({ method: req.method, url, body })
+            : routeMatches(route, req.method, url);
+        if (match) {
+          const r = typeof route === 'function' ? route({ method: req.method, url, body }) : route;
+          const status = r.status || 200;
+          const respBody =
+            typeof r.body === 'function'
+              ? r.body({ method: req.method, url, body })
+              : r.body || {};
+          const headers = { 'Content-Type': 'application/json', ...(r.headers || {}) };
+          res.writeHead(status, headers);
+          res.end(typeof respBody === 'string' ? respBody : JSON.stringify(respBody));
+          return;
+        }
+      }
+      res.writeHead(404, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: { message: `Mock: no route matched ${req.method} ${url}` } }));
+    });
+  });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const port = server.address().port;
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    port,
+    calls,
+    close: () =>
+      new Promise((resolve) => {
+        server.close(() => resolve());
+      }),
+  };
+}
+
+function routeMatches(route, method, url) {
+  if (route.method && route.method !== method) return false;
+  const m = route.matcher;
+  if (typeof m === 'string') return url.includes(m);
+  if (m instanceof RegExp) return m.test(url);
+  if (typeof m === 'function') return m({ method, url });
+  return false;
+}
+
+module.exports = { startMock };

--- a/plugins/power-pages/scripts/tests/render-alm-plan.test.js
+++ b/plugins/power-pages/scripts/tests/render-alm-plan.test.js
@@ -413,3 +413,180 @@ test('render-alm-plan: PLAN_STATUS value drives CSS class on plan-status span', 
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 });
+
+// ── Test 11: Solutions tab surfaces an Asset Advisory callout when the
+//             primary recommendation is externalize-media ───────────────────
+
+test('render-alm-plan: Solutions tab shows a callout + link to Asset Advisory when recommendation is externalize-media', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'render-alm-out-'));
+  const outputPath = path.join(tmpDir, 'alm-plan.html');
+
+  try {
+    const data = makeValidData({
+      // Non-trivial proposedSolutions so buildSolutionsHtml exercises the card path
+      // and prefixes the callout. Without solutions the "(None)" note-box is rendered.
+      proposedSolutions: [
+        { uniqueName: 'Site_Core', displayName: 'Core', order: 1, sizeMB: 45, componentCount: 200, componentTypes: ['Web Page'] },
+        { uniqueName: 'Site_Web', displayName: 'Web Assets', order: 2, sizeMB: 90, componentCount: 150, componentTypes: ['Web File'] },
+      ],
+      assetAdvisory: {
+        enabled: true,
+        recommendation: 'externalize-media',
+        candidates: [
+          { name: 'hero.jpg', sizeMB: 5.2, rationale: 'Large media asset', recommendation: 'azure-blob', suggestedUrlFormat: '' },
+          { name: 'bg.png', sizeMB: 3.8, rationale: 'Large media asset', recommendation: 'cdn', suggestedUrlFormat: '' },
+        ],
+      },
+    });
+    const { status } = runScript(data, outputPath);
+    assert.equal(status, 0, 'Expected exit 0');
+
+    const html = fs.readFileSync(outputPath, 'utf8');
+
+    // Callout text itself
+    assert.ok(html.includes('A split may not be necessary.'),
+      'Solutions tab should include the externalize callout headline');
+
+    // Aggregate size from candidates (5.2 + 3.8 = 9.0)
+    assert.ok(html.includes('9.0 MB'),
+      'Callout should show aggregate MB from candidates');
+
+    // Link to the Asset Advisory tab — verify the target tab exists and
+    // the callout references it by the existing data-tab value.
+    assert.ok(html.includes('data-tab="advisory"'),
+      'Advisory tab button must still exist');
+    assert.ok(html.includes('solutions-to-advisory'),
+      'Callout should use the dedicated class so the interaction is testable');
+
+    // The callout must appear inside the Solutions tab section and before the
+    // next tab opens (Pipelines). Template order is: Advisory → EnvVars →
+    // Solutions → Pipelines, so the callout sits between `tab-solutions` and
+    // `tab-pipelines` markers.
+    const solIdx = html.indexOf('id="tab-solutions"');
+    const pipeIdx = html.indexOf('id="tab-pipelines"');
+    const calloutIdx = html.indexOf('A split may not be necessary.');
+    assert.ok(solIdx !== -1 && pipeIdx !== -1 && calloutIdx !== -1, 'All markers present');
+    assert.ok(calloutIdx > solIdx, 'Callout should appear after the Solutions tab opens');
+    assert.ok(calloutIdx < pipeIdx, 'Callout should appear before the Pipelines tab (i.e., within Solutions)');
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('render-alm-plan: Solutions tab has NO callout when recommendation is not externalize-media', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'render-alm-out-'));
+  const outputPath = path.join(tmpDir, 'alm-plan.html');
+
+  try {
+    const data = makeValidData({
+      proposedSolutions: [
+        { uniqueName: 'Site_Core', displayName: 'Core', order: 1, sizeMB: 45, componentCount: 200, componentTypes: ['Web Page'] },
+      ],
+      assetAdvisory: {
+        enabled: true,
+        recommendation: null, // nothing flagged
+        candidates: [],
+      },
+    });
+    const { status } = runScript(data, outputPath);
+    assert.equal(status, 0);
+    const html = fs.readFileSync(outputPath, 'utf8');
+    assert.ok(!html.includes('A split may not be necessary.'),
+      'No callout when externalize is not recommended');
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('render-alm-plan: Solutions tab has NO callout when asset advisory is disabled', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'render-alm-out-'));
+  const outputPath = path.join(tmpDir, 'alm-plan.html');
+
+  try {
+    const data = makeValidData({
+      proposedSolutions: [
+        { uniqueName: 'Site_Core', displayName: 'Core', order: 1, sizeMB: 45, componentCount: 200, componentTypes: ['Web Page'] },
+      ],
+      assetAdvisory: { enabled: false, recommendation: 'externalize-media', candidates: [] },
+    });
+    const { status } = runScript(data, outputPath);
+    assert.equal(status, 0);
+    const html = fs.readFileSync(outputPath, 'utf8');
+    assert.ok(!html.includes('A split may not be necessary.'),
+      'Disabled advisory must not surface the callout');
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+// ── Test 12: Pipelines tab shows ONE pipeline + multiple runs in multi-solution plans
+
+test('render-alm-plan: multi-solution Pipelines tab shows a single pipeline with N runs (not N pipelines)', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'render-alm-out-'));
+  const outputPath = path.join(tmpDir, 'alm-plan.html');
+
+  try {
+    const data = makeValidData({
+      SITE_NAME: 'IdeaSphere',
+      proposedSolutions: [
+        { uniqueName: 'IdeaSphere_Core', displayName: 'Core', order: 1, sizeMB: 45, componentCount: 200, componentTypes: ['Web Page'] },
+        { uniqueName: 'IdeaSphere_WebAssets', displayName: 'Web Assets', order: 2, sizeMB: 90, componentCount: 150, componentTypes: ['Web File'] },
+        { uniqueName: 'IdeaSphere_Future', displayName: 'Future Growth', order: 3, sizeMB: 0, componentCount: 0, componentTypes: ['Any'], isFutureBuffer: true },
+      ],
+    });
+    const { status } = runScript(data, outputPath);
+    assert.equal(status, 0);
+    const html = fs.readFileSync(outputPath, 'utf8');
+
+    // Single pipeline header, not one per solution.
+    assert.ok(html.includes('IdeaSphere-Pipeline'),
+      'Should show a single pipeline named after the site');
+    assert.ok(!html.includes('IdeaSphere_Core-Pipeline'),
+      'Old per-solution pipeline name should NOT appear');
+    assert.ok(!html.includes('IdeaSphere_WebAssets-Pipeline'),
+      'Old per-solution pipeline name should NOT appear');
+
+    // Tab title should not say "Deployment Pipelines (N)".
+    assert.ok(!/Deployment Pipelines \(\d+\)/.test(html),
+      'Tab title should say "Deployment Pipeline" (singular) now');
+
+    // "Deployment order" block lists solutions.
+    assert.ok(html.includes('Deployment order'),
+      'Should show a Deployment order block');
+    assert.ok(html.includes('IdeaSphere_Core'),
+      'Solution names still surface per run');
+    assert.ok(html.includes('IdeaSphere_WebAssets'));
+
+    // Future buffer is labeled as skipped, not as "Run 3".
+    assert.ok(html.includes('Skipped (empty)'),
+      'Future buffer should show "Skipped (empty)" label');
+
+    // Descriptor text reflects 1 pipeline.
+    assert.ok(html.includes('One Power Platform Pipeline runs 2 solutions'),
+      'Description should state 1 pipeline running 2 deployable solutions');
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('render-alm-plan: single-solution Pipelines tab keeps simple stage flow', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'render-alm-out-'));
+  const outputPath = path.join(tmpDir, 'alm-plan.html');
+
+  try {
+    const data = makeValidData({
+      proposedSolutions: [
+        { uniqueName: 'SiteSolution', displayName: 'Site', order: 1, sizeMB: 30, componentCount: 80, componentTypes: ['All'] },
+      ],
+    });
+    const { status } = runScript(data, outputPath);
+    assert.equal(status, 0);
+    const html = fs.readFileSync(outputPath, 'utf8');
+    // Single-solution path should NOT include the "Deployment order" subheading.
+    assert.ok(!html.includes('Deployment order'),
+      'Single-solution plan should not show a per-run list');
+    assert.ok(!html.includes('Skipped (empty)'));
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});

--- a/plugins/power-pages/skills/deploy-pipeline/SKILL.md
+++ b/plugins/power-pages/skills/deploy-pipeline/SKILL.md
@@ -79,10 +79,13 @@ Steps:
 3. Locate `.last-pipeline.json` in the project root — if not found, stop and advise running `/power-pages:setup-pipeline` first.
 
    **Manifest version check:**
-   - If `schemaVersion === 2`, set `MULTI_PIPELINE_MODE = true` and store `pipelines[]` as `PIPELINES_LIST`. The skill will deploy all pipelines for the selected target stage, in `order`, one after the other (Core → WebAssets, etc.). A failure on any pipeline halts the chain for that stage.
-   - Otherwise read `pipelineId`, `pipelineName`, `hostEnvUrl`, `sourceDeploymentEnvironmentId`, `solutionName`, `stages[]` (single-pipeline mode — existing behavior).
+   - If `schemaVersion === 3`, set `MULTI_RUN_MODE = true` and store `deploymentOrder[]` as `DEPLOYMENT_ORDER`. There is a **single pipeline** with a single set of stages; multi-solution is expressed via N stage runs against the same stage, one per solution in `order`. This is the current recommended layout.
+   - If `schemaVersion === 2` (legacy), set `MULTI_PIPELINE_MODE = true` and store `pipelines[]` as `PIPELINES_LIST`. The skill falls back to the older "loop over N separate `deploymentpipelines` records" behavior. Advise the user to re-run `setup-pipeline` to migrate to v3.
+   - Otherwise read `pipelineId`, `pipelineName`, `hostEnvUrl`, `sourceDeploymentEnvironmentId`, `solutionName`, `stages[]` (single-solution mode — existing behavior).
 
-   **In `MULTI_PIPELINE_MODE`**, resolve `solutionName` per pipeline in the loop (not globally). All pipelines share the same `hostEnvUrl` and `sourceDeploymentEnvironmentId`.
+   **In `MULTI_RUN_MODE`**, resolve `solutionName` + `solutionId` per iteration of `DEPLOYMENT_ORDER`. Entries where `status === "skipped-empty"` (typically the `{Prefix}_Future` buffer) are short-circuited — no stage run is created for them. The single `pipelineId` / `hostEnvUrl` / `sourceDeploymentEnvironmentId` apply to every run.
+
+   **In `MULTI_PIPELINE_MODE`** (legacy v2), resolve `solutionName` per pipeline in the loop (not globally). All pipelines share the same `hostEnvUrl` and `sourceDeploymentEnvironmentId`.
 
 4. Acquire host environment token:
    ```bash
@@ -107,12 +110,17 @@ Otherwise, ask via `AskUserQuestion`:
 
 Store selected stage as `SELECTED_STAGE` (with `stageId`, `name`, `targetDeploymentEnvironmentId`, `targetEnvironmentUrl`).
 
-**In `MULTI_PIPELINE_MODE`:** The selected stage label (e.g., "Staging") is matched against each pipeline's `stages[]` — each pipeline has its own `stageId` for the same target environment. All subsequent phases (validate, deploy, poll) are looped over `PIPELINES_LIST` in `order`:
+**In `MULTI_RUN_MODE` (v3 — recommended):** The selected stage is looked up once from the single `stages[]` array. The skill then **loops over `DEPLOYMENT_ORDER`** in `order`, creating one stage run per solution against the same `stageId`:
+1. For each entry in `DEPLOYMENT_ORDER` where `status !== "skipped-empty"`: resolve its `solutionUniqueName` + `solutionId`, set `ARTIFACT_SOLUTION_NAME` / `ARTIFACT_SOLUTION_ID`, then run Phases 3–6 (resolve info → validate → configure → deploy → poll) against the same pipeline.
+2. If any iteration fails (validation or deployment), halt the loop and report **which solution** failed and which had already landed.
+3. Write one `.last-deploy.json` at the end summarizing all runs for the selected stage. Record per-solution `status` (`Succeeded` / `Failed` / `NotAttempted` / `SkippedEmpty`) plus the shared `pipelineId`.
+
+**In `MULTI_PIPELINE_MODE` (v2 — legacy):** The selected stage label (e.g., "Staging") is matched against each pipeline's `stages[]` — each pipeline has its own `stageId` for the same target environment. All subsequent phases (validate, deploy, poll) are looped over `PIPELINES_LIST` in `order`:
 1. Loop iteration i: use `pipelines[i].stageId` where stage label matches `SELECTED_STAGE.name`, `pipelines[i].solutionName`, etc.
 2. If any iteration fails (validation or deployment), halt the loop and report which pipeline failed and which were already deployed.
 3. Write one `.last-deploy.json` at the end summarizing all pipeline runs for this stage. Record per-pipeline `status` (`Succeeded` / `Failed` / `NotAttempted`) so a retry can tell which ones still need to run.
 
-> **Partial-deploy risk.** When the loop halts (e.g., `Core` succeeded, `WebAssets` failed), the target environment is left in a mixed state — there is no automatic rollback of solutions that already imported. The per-pipeline `status` in `.last-deploy.json` is the source of truth for what landed. When the user re-runs `deploy-pipeline` after fixing the failure, the loop iterates all pipelines again from the start; rely on the solution-import idempotency (same version = no-op) rather than skipping. Warn the user of this before starting a multi-pipeline deploy to production.
+> **Partial-deploy risk.** When the loop halts (e.g., `Core` succeeded, `WebAssets` failed), the target environment is left in a mixed state — there is no automatic rollback of solutions that already imported. The per-solution (v3) or per-pipeline (v2) `status` in `.last-deploy.json` is the source of truth for what landed. When the user re-runs `deploy-pipeline` after fixing the failure, the loop iterates all entries again from the start; rely on the solution-import idempotency (same version = no-op) rather than skipping. Warn the user of this before starting a multi-solution deploy to production.
 
 Check `.last-deploy.json` — if the last deployment to this stage failed, warn the user:
 > "The last deployment to `{stageName}` had status: **Failed**. Would you like to retry? 1. Yes, retry / 2. No, cancel"

--- a/plugins/power-pages/skills/deploy-pipeline/SKILL.md
+++ b/plugins/power-pages/skills/deploy-pipeline/SKILL.md
@@ -602,15 +602,17 @@ Then resume polling from Phase 6.2.
 
 If **Exit**: stop and present the failure summary above.
 
-**7.7 Check site activation** (only if deployment **Succeeded** and solution has Power Pages components):
+**7.7 Check site activation** (only if deployment **Succeeded** and this is a Power Pages project):
 
-Query the source environment to check whether the solution contains a website component (componentType `10374`):
+> **Trigger rule (updated 2026-04-22):** run this check whenever the source project's `powerpages.config.json` has a `websiteRecordId` — i.e. this project is a Power Pages site project. The earlier rule ("only if the solution we just deployed contains a website componentType 10374") misses a real-world case: the site may pre-exist on the target and the solution we deployed may only contain tables/flows/bots. A Power Pages project's post-deploy is always incomplete if its site isn't activated on the target, regardless of which specific solution was shipped this time.
+
+Read `websiteRecordId` from `powerpages.config.json`. If the field is absent, skip the rest of 7.7 (this is a non-Power-Pages ALM run — e.g. a pure data-model solution).
+
+Optional secondary check: query the source solution for a website componentType `10374` only to **log** whether the site was included in this specific solution — informational, not gating:
 ```
 GET {sourceEnvUrl}/api/data/v9.2/solutioncomponents?$filter=_solutionid_value eq '{solutionId}' and componenttype eq 10374&$select=objectid
 Authorization: Bearer {SOURCE_TOKEN}
 ```
-
-If no results, skip the rest of 7.7.
 
 If found, temporarily switch PAC CLI to the target environment so `check-activation-status.js` queries the correct env:
 ```bash

--- a/plugins/power-pages/skills/plan-alm/SKILL.md
+++ b/plugins/power-pages/skills/plan-alm/SKILL.md
@@ -164,6 +164,47 @@ Steps:
     Asset advisory: {K} files flagged for Azure Blob externalization.
     ```
 
+11. **Pre-plan completeness check** (only runs when `SOLUTION_DONE = true`).
+
+    Before the user approves a plan, verify the existing solution already covers everything on the live site. Components created after the last `/power-pages:setup-solution` run (server logic from `add-server-logic`, flows from `add-cloud-flow`, env vars from `configure-env-variables` or `setup-auth`) are silently excluded from any plan built on top of a stale solution.
+
+    Run the shared discovery helper against the source environment:
+
+    ```bash
+    node "${CLAUDE_PLUGIN_ROOT}/scripts/lib/discover-site-components.js" \
+      --envUrl "{envUrl}" --token "{token}" \
+      --siteId "{websiteRecordId from powerpages.config.json}" \
+      --publisherPrefix "{solutionManifest.publisher.prefix}" \
+      --solutionId "{solutionManifest.solution.solutionId}"
+    ```
+
+    Parse stdout and evaluate `missing.*`:
+
+    - **All `missing.*` arrays empty** → report "Solution contents match the site — proceeding with fresh plan inputs." Continue to Phase 2.
+    - **Any non-empty `missing.*` array** → report a compact summary:
+      > "Your solution is **missing {N} component(s)** that exist on the site:
+      >
+      > - **{X}** site components (e.g. {first 3 names})
+      > - **{Y}** cloud flows
+      > - **{Z}** environment variable definitions
+      > - **{W}** custom tables
+      >
+      > A plan built now will ignore these components. How would you like to proceed?"
+
+      Ask via `AskUserQuestion`:
+
+      | Question | Header | Options |
+      |---|---|---|
+      | Run `/power-pages:setup-solution` in sync mode to adopt the missing components before planning? | Completeness Check | Yes — sync first (Recommended), No — plan with current solution contents, Cancel |
+
+      - **Yes, sync first (Recommended)**: invoke `/power-pages:setup-solution` (auto-detects the existing manifest and enters sync mode). After it completes, re-run the discovery helper; if `missing.*` is now empty proceed to Phase 2, otherwise repeat the prompt.
+      - **No, plan with current contents**: store the gap summary as `KNOWN_GAPS` so Phase 3 can surface it in the plan HTML's Risks section, then continue.
+      - **Cancel**: stop the skill so the user can investigate.
+
+    > **Why this exists**: the same check runs at export (`export-solution` Phase 2.5) and deploy (`deploy-pipeline` Phase 3.5). Adding it here catches gaps at the earliest possible gate — before the user invests time reviewing a plan built on stale inputs. See AGENTS.md → ALM-aware by default.
+
+    > **Skip when `SOLUTION_DONE = false`**: if there is no manifest yet, there is nothing to be stale against — Phase 2 Q1 will handle first-time solution setup.
+
 ---
 
 ## Phase 2 — Gather ALM Strategy
@@ -447,6 +488,7 @@ Populate `risks` based on gathered data:
 - If `GIT_STATUS = "no"`: `{ type: "info", message: "Consider enabling source control to track changes before deploying to production." }`
 - If `EXPORT_TYPE = "unmanaged"` and strategy includes a production target: `{ type: "warning", message: "Unmanaged solutions can be edited in the target environment — consider using Managed for production." }`
 - If `SOLUTION_DONE = false`: `{ type: "info", message: "A Dataverse solution will be created first — publisher prefix is irreversible once chosen." }`
+- If `KNOWN_GAPS` is set (the pre-plan completeness check in Phase 1 Step 11 found gaps and the user chose to continue): `{ type: "warning", message: "{X} site components, {Y} cloud flows, {Z} env vars, and {W} custom tables exist on the site but are not in the current solution. This plan will not promote them — run /power-pages:setup-solution sync mode before deploying, or re-run plan-alm after syncing." }`. Substitute the counts from `KNOWN_GAPS.missing.*.length`.
 
 Write `planData` to `docs/.alm-plan-data.json` (create `docs/` if it doesn't exist).
 

--- a/plugins/power-pages/skills/plan-alm/scripts/render-alm-plan.js
+++ b/plugins/power-pages/skills/plan-alm/scripts/render-alm-plan.js
@@ -291,12 +291,36 @@ function buildSolutionsTabDesc() {
     : 'All components packaged in a single managed solution.';
 }
 
+function buildAssetAdvisoryCallout() {
+  // Surface the advisory on the Solutions tab when the primary recommendation
+  // is to move assets out of the solution. Without this pointer, users only
+  // see "N proposed solutions" and miss the fact that a CDN/Blob move would
+  // likely avoid the split altogether.
+  if (!assetAdvisory.enabled) return '';
+  if (assetAdvisory.recommendation !== 'externalize-media') return '';
+  const candidateCount = Array.isArray(assetAdvisory.candidates) ? assetAdvisory.candidates.length : 0;
+  const candidateMB = Array.isArray(assetAdvisory.candidates)
+    ? assetAdvisory.candidates.reduce((s, c) => s + Number(c.sizeMB || 0), 0).toFixed(1)
+    : '0.0';
+  return `<div class="warning-box" style="margin-bottom:16px;">
+  <span style="font-size:18px;">&#9888;</span>
+  <div>
+    <strong>A split may not be necessary.</strong>
+    ${escapeHtml(String(candidateCount))} large asset(s) totalling ${escapeHtml(candidateMB)} MB could be moved to Azure Blob or a CDN instead of packaged into solutions.
+    Externalizing them typically lets the site stay in a single solution — review the full list on the
+    <a href="#" class="solutions-to-advisory" onclick="const b=document.querySelector('.nav-btn[data-tab=&quot;advisory&quot;]');if(b){b.click();window.scrollTo(0,0);}return false;">Asset Advisory tab</a>
+    before committing to the split below.
+  </div>
+</div>`;
+}
+
 function buildSolutionsHtml() {
   if (proposedSolutions.length === 0) {
     return '<div class="note-box neutral">Solution structure will be determined during Setup Solution.</div>';
   }
+  const calloutHtml = buildAssetAdvisoryCallout();
   const colors = ['#0078d4', '#ca5010', '#107c10', '#8764b8', '#038387', '#5c2d91'];
-  return proposedSolutions.map((sol, i) => {
+  const cards = proposedSolutions.map((sol, i) => {
     const color = colors[i % colors.length];
     const overLimit = sol.sizeMB > SIZE_LIMIT_MB;
     const sColor = overLimit ? 'var(--high)' : 'var(--pass)';
@@ -327,41 +351,60 @@ function buildSolutionsHtml() {
   </div>
 </div>`;
   }).join('\n');
+  return `${calloutHtml}${cards}`;
 }
 
-function buildPipelinesTabTitle() { return proposedSolutions.length > 1 ? `Deployment Pipelines (${proposedSolutions.length})` : 'Deployment Pipeline'; }
+function buildPipelinesTabTitle() {
+  // We always provision a single pipeline now, even in multi-solution plans —
+  // multi-solution is expressed via deploymentOrder against the same pipeline.
+  return 'Deployment Pipeline';
+}
 function buildPipelinesTabDesc() {
+  const nDeployable = proposedSolutions.filter((s) => !s.isFutureBuffer).length;
   return proposedSolutions.length > 1
-    ? 'One pipeline per solution, deployed in dependency order. All pipelines share the same deployment environments.'
+    ? `One Power Platform Pipeline runs ${nDeployable} solution${nDeployable === 1 ? '' : 's'} in dependency order against each target environment. The empty Future solution is created but skipped during deployment until it has content.`
     : `Power Platform Pipelines configuration for promoting ${escapeHtml(data.SITE_NAME)} across environments.`;
 }
 
 function buildPipelinesHtml() {
   const colors = ['#0078d4', '#ca5010', '#107c10', '#8764b8', '#038387'];
   const stages = Array.isArray(data.stages) ? data.stages : [];
+  const stagesHtml = stages.map((st) => `<div class="pipeline-stage ${st.type === 'source' ? 'stage-active' : ''}">
+    <div class="stage-name">${escapeHtml(st.label || '')}</div>
+    <div class="stage-env">${escapeHtml(st.envUrl || '')}</div>
+  </div>`).join('');
 
   if (proposedSolutions.length > 1) {
-    return proposedSolutions.map((sol, i) => {
-      const color = colors[i % colors.length];
-      return `<div class="pipeline-solution-label">
-  <span class="pipeline-solution-dot" style="background:${color};"></span>
-  <span class="pipeline-solution-name">${escapeHtml(sol.uniqueName)}-Pipeline</span>
-  <span style="margin-left:auto;font-size:11px;color:var(--text-dim);">order ${sol.order || i + 1}</span>
+    // Header — single pipeline name
+    const pipelineName = `${escapeHtml(data.SITE_NAME || 'Site')}-Pipeline`;
+    const header = `<div class="pipeline-solution-label">
+  <span class="pipeline-solution-dot" style="background:${colors[0]};"></span>
+  <span class="pipeline-solution-name">${pipelineName}</span>
+  <span style="margin-left:auto;font-size:11px;color:var(--text-dim);">1 pipeline · ${proposedSolutions.filter((s) => !s.isFutureBuffer).length} run${proposedSolutions.filter((s) => !s.isFutureBuffer).length === 1 ? '' : 's'}</span>
 </div>
-<div class="pipeline-container">
-  ${stages.map((st) => `<div class="pipeline-stage ${st.type === 'source' ? 'stage-active' : ''}">
-    <div class="stage-name">${escapeHtml(st.label || '')}</div>
-    <div class="stage-env">${escapeHtml(st.envUrl || '')}</div>
-  </div>`).join('')}
+<div class="pipeline-container">${stagesHtml}</div>`;
+
+    // Deployment order list — each solution is a stage run. Future buffer shown
+    // distinctly so reviewers understand it's created but not deployed yet.
+    const orderRows = proposedSolutions.map((sol, i) => {
+      const color = colors[i % colors.length];
+      const isFuture = !!sol.isFutureBuffer;
+      const label = isFuture ? 'Skipped (empty)' : `Run ${sol.order || i + 1}`;
+      const labelColor = isFuture ? 'var(--text-dim)' : color;
+      return `<div class="pipeline-solution-label" style="margin-top:8px;">
+  <span class="pipeline-solution-dot" style="background:${labelColor};"></span>
+  <span class="pipeline-solution-name">${escapeHtml(sol.uniqueName)}</span>
+  <span style="margin-left:auto;font-size:11px;color:${isFuture ? 'var(--text-dim)' : 'var(--text-dim)'};">${label}</span>
 </div>`;
-    }).join('\n');
+    }).join('');
+
+    return `${header}
+<div style="margin-top:16px;">
+  <h4 style="margin:0 0 8px 0;font-size:12px;color:var(--text-dim);text-transform:uppercase;letter-spacing:0.08em;">Deployment order</h4>
+  ${orderRows}
+</div>`;
   }
-  return `<div class="pipeline-container">
-  ${stages.map((st) => `<div class="pipeline-stage ${st.type === 'source' ? 'stage-active' : ''}">
-    <div class="stage-name">${escapeHtml(st.label || '')}</div>
-    <div class="stage-env">${escapeHtml(st.envUrl || '')}</div>
-  </div>`).join('')}
-</div>`;
+  return `<div class="pipeline-container">${stagesHtml}</div>`;
 }
 
 function buildChecklistHtml() {

--- a/plugins/power-pages/skills/plan-alm/scripts/render-alm-plan.js
+++ b/plugins/power-pages/skills/plan-alm/scripts/render-alm-plan.js
@@ -62,6 +62,13 @@ const breakdown = data.breakdown || {};
 
 const totalSizeMB = Number(sizeAnalysis?.totalSizeMB?.value ?? 0);
 const componentCount = Number(sizeAnalysis?.componentCount?.value ?? 0);
+// Optional two-number semantics (estimator output when --solutionId was passed):
+// siteTotal = everything on the site in Dataverse. inSolution = what the target
+// solution actually contains. orphans = siteTotal - inSolution.
+const componentCountSiteTotal = Number(data.componentCountSiteTotal ?? componentCount);
+const componentCountInSolution = (data.componentCountInSolution == null) ? null : Number(data.componentCountInSolution);
+const orphansOnSite = (data.orphansOnSite == null) ? null : Number(data.orphansOnSite);
+const hasSolutionMembershipBreakout = componentCountInSolution !== null;
 const SIZE_LIMIT_MB = 95;
 const exceedsSize = totalSizeMB > SIZE_LIMIT_MB;
 const sizeTier = sizeAnalysis?.totalSizeMB?.tier || 'unknown';
@@ -314,10 +321,26 @@ function buildAssetAdvisoryCallout() {
 </div>`;
 }
 
+function buildSolutionMembershipBanner() {
+  // When the estimator had a --solutionId context, show the site-vs-solution
+  // split so reviewers don't conflate "908 components on the site" with "908
+  // components in the solution about to ship."
+  if (!hasSolutionMembershipBreakout) return '';
+  const orphansClass = (orphansOnSite && orphansOnSite > 0) ? 'warn' : 'pass';
+  const orphansNote = (orphansOnSite && orphansOnSite > 0)
+    ? ` · ${orphansOnSite.toLocaleString()} orphan(s) on the site are NOT in this solution — run <code>/power-pages:setup-solution</code> in sync mode to adopt them.`
+    : ` · solution is fully in sync with the site.`;
+  return `<div class="note-box ${orphansClass}" style="margin-bottom:16px;">
+  <strong>Solution membership vs. site inventory.</strong>
+  The site currently holds <strong>${componentCountSiteTotal.toLocaleString()}</strong> components in Dataverse; the target solution owns <strong>${componentCountInSolution.toLocaleString()}</strong> of them.${orphansNote}
+</div>`;
+}
+
 function buildSolutionsHtml() {
   if (proposedSolutions.length === 0) {
     return '<div class="note-box neutral">Solution structure will be determined during Setup Solution.</div>';
   }
+  const membershipHtml = buildSolutionMembershipBanner();
   const calloutHtml = buildAssetAdvisoryCallout();
   const colors = ['#0078d4', '#ca5010', '#107c10', '#8764b8', '#038387', '#5c2d91'];
   const cards = proposedSolutions.map((sol, i) => {
@@ -351,7 +374,7 @@ function buildSolutionsHtml() {
   </div>
 </div>`;
   }).join('\n');
-  return `${calloutHtml}${cards}`;
+  return `${membershipHtml}${calloutHtml}${cards}`;
 }
 
 function buildPipelinesTabTitle() {

--- a/plugins/power-pages/skills/plan-alm/scripts/render-alm-plan.js
+++ b/plugins/power-pages/skills/plan-alm/scripts/render-alm-plan.js
@@ -61,14 +61,24 @@ const assetAdvisory = data.assetAdvisory || { enabled: false, candidates: [], re
 const breakdown = data.breakdown || {};
 
 const totalSizeMB = Number(sizeAnalysis?.totalSizeMB?.value ?? 0);
-const componentCount = Number(sizeAnalysis?.componentCount?.value ?? 0);
-// Optional two-number semantics (estimator output when --solutionId was passed):
-// siteTotal = everything on the site in Dataverse. inSolution = what the target
-// solution actually contains. orphans = siteTotal - inSolution.
-const componentCountSiteTotal = Number(data.componentCountSiteTotal ?? componentCount);
+// Three-number semantics when the estimator ran with --solutionId:
+//   componentCountSiteTotal      — RAW Dataverse rows on the site. What the
+//                                  Maker UI would show if the entire site
+//                                  were adopted into a solution.
+//   componentCountInSolution     — solutioncomponents rows for the target
+//                                  solution. Matches the Maker "Objects" count.
+//   orphansOnSite                — ppcs on the site that aren't in the solution,
+//                                  excluding stale bundle chunks.
+// For the headline "X components" we prefer inSolution when present (that's
+// what the pipeline ships). Fall back to siteTotal or the legacy
+// sizeAnalysis.componentCount value when the estimator ran without a solution
+// context.
+const fallbackComponentCount = Number(sizeAnalysis?.componentCount?.value ?? 0);
+const componentCountSiteTotal = Number(data.componentCountSiteTotal ?? fallbackComponentCount);
 const componentCountInSolution = (data.componentCountInSolution == null) ? null : Number(data.componentCountInSolution);
 const orphansOnSite = (data.orphansOnSite == null) ? null : Number(data.orphansOnSite);
 const hasSolutionMembershipBreakout = componentCountInSolution !== null;
+const componentCount = hasSolutionMembershipBreakout ? componentCountInSolution : componentCountSiteTotal;
 const SIZE_LIMIT_MB = 95;
 const exceedsSize = totalSizeMB > SIZE_LIMIT_MB;
 const sizeTier = sizeAnalysis?.totalSizeMB?.tier || 'unknown';
@@ -323,16 +333,17 @@ function buildAssetAdvisoryCallout() {
 
 function buildSolutionMembershipBanner() {
   // When the estimator had a --solutionId context, show the site-vs-solution
-  // split so reviewers don't conflate "908 components on the site" with "908
-  // components in the solution about to ship."
+  // split so reviewers can reconcile what they see in the Maker UI with what
+  // ships. Numbers are all raw row counts — bundle chunks included — so they
+  // match the "Objects" page in Power Platform's solution explorer.
   if (!hasSolutionMembershipBreakout) return '';
   const orphansClass = (orphansOnSite && orphansOnSite > 0) ? 'warn' : 'pass';
   const orphansNote = (orphansOnSite && orphansOnSite > 0)
-    ? ` · ${orphansOnSite.toLocaleString()} orphan(s) on the site are NOT in this solution — run <code>/power-pages:setup-solution</code> in sync mode to adopt them.`
-    : ` · solution is fully in sync with the site.`;
+    ? ` · ${orphansOnSite.toLocaleString()} actionable orphan(s) on the site are NOT in this solution — run <code>/power-pages:setup-solution</code> in sync mode to adopt them. (Stale bundle-chunk orphans are excluded from this count.)`
+    : ` · solution is fully in sync with the site (no actionable orphans).`;
   return `<div class="note-box ${orphansClass}" style="margin-bottom:16px;">
   <strong>Solution membership vs. site inventory.</strong>
-  The site currently holds <strong>${componentCountSiteTotal.toLocaleString()}</strong> components in Dataverse; the target solution owns <strong>${componentCountInSolution.toLocaleString()}</strong> of them.${orphansNote}
+  The site holds <strong>${componentCountSiteTotal.toLocaleString()}</strong> raw rows in Dataverse; the target solution owns <strong>${componentCountInSolution.toLocaleString()}</strong> components.${orphansNote}
 </div>`;
 }
 

--- a/plugins/power-pages/skills/setup-pipeline/SKILL.md
+++ b/plugins/power-pages/skills/setup-pipeline/SKILL.md
@@ -245,15 +245,25 @@ Extract:
 
 On failure: the script writes the error to stderr and exits 1 — stop and report the error to the user.
 
-### Phase 6b — Multi-solution loop (only if `MULTI_SOLUTION_MODE = true`)
+### Phase 6b — Multi-solution deploymentOrder (only if `MULTI_SOLUTION_MODE = true`)
 
-When the manifest is `schemaVersion: 2`, repeat the pipeline-creation flow for **each entry** in `SOLUTIONS_LIST`:
+> **Design note (updated v1.3.x):** A single Power Platform Pipeline can deploy
+> multiple solutions through separate stage runs — each run just specifies a
+> different `artifactname` + `solutionid` on the same `deploymentstages` record.
+> Creating one pipeline per solution was wasteful and cluttered the Pipelines
+> UI. **We now create ONE pipeline + one stage per target env, and record the
+> per-solution deployment order in `.last-pipeline.json`**. `deploy-pipeline`
+> then loops over the order, creating a stage run per solution against the same
+> stage.
 
-1. Derive `pipelineName = "{solution.uniqueName}-Pipeline"` (e.g. `IdeaSphere_Core-Pipeline`).
-2. Re-use the same `HOST_ENV_URL`, `SOURCE_DEPLOYMENT_ENV_ID`, and `TARGET_DEPLOYMENT_ENV_IDS` across all pipelines. Only the pipeline record + its stage records are created per solution — the deployment environments are shared.
-3. Iterate `SOLUTIONS_LIST` **in `order`** so lower-order solutions get their pipelines first.
-4. Collect each created pipelineId into `PIPELINES[]`.
-5. When writing `.last-pipeline.json` in Phase 7, include `pipelines[]` with one entry per solution (see below).
+When the manifest is `schemaVersion: 2`, do **not** call `create-deployment-pipeline.js` multiple times. Instead:
+
+1. Call `create-deployment-pipeline.js` **once** with:
+   - `pipelineName = "{siteName}-Pipeline"` (e.g. `IdeaSphere-Pipeline`).
+   - `description` listing the solutions that will deploy through it (e.g. `"Deploys IdeaSphere_Core → IdeaSphere_WebAssets → IdeaSphere_Future in order"`).
+   - One `deploymentstages` record per target environment (not per solution).
+2. Build the `deploymentOrder` array from `SOLUTIONS_LIST` sorted by `order`. Each entry has `{ solutionUniqueName, solutionId, order }`. Skip entries where `isFutureBuffer: true` AND `components.length === 0` — an empty Future solution has nothing to deploy; it's created by `setup-solution` but does not participate in the deployment loop until it has content. Keep it in the order array with `status: "skipped-empty"` so the renderer can show the intent.
+3. Collect the single `pipelineId` and its `stages[]`. Persist `deploymentOrder` to `.last-pipeline.json` (see Phase 7).
 
 ### Phase 7 — Verify, Write Artifacts, Commit
 
@@ -288,32 +298,35 @@ Confirm `statecode = 0` (Active). If the query fails, report as "verification in
 }
 ```
 
-**Multi-solution marker (manifest v2):** When `MULTI_SOLUTION_MODE = true`, `.last-pipeline.json` uses `schemaVersion: 2` with a `pipelines[]` array:
+**Multi-solution marker (manifest v2):** When `MULTI_SOLUTION_MODE = true`, `.last-pipeline.json` uses `schemaVersion: 3` with a **single** pipeline and a `deploymentOrder[]` describing which solutions deploy through it, in what order:
+
 ```json
 {
-  "schemaVersion": 2,
+  "schemaVersion": 3,
+  "pipelineId": "...",
+  "pipelineName": "IdeaSphere-Pipeline",
   "hostEnvUrl": "{HOST_ENV_URL}",
   "sourceDeploymentEnvironmentId": "{SOURCE_DEPLOYMENT_ENV_ID}",
   "sourceEnvironmentUrl": "{devEnvUrl}",
   "createdAt": "{ISO timestamp}",
-  "pipelines": [
+  "stages": [
     {
-      "pipelineId": "...",
-      "pipelineName": "IdeaSphere_Core-Pipeline",
-      "solutionName": "IdeaSphere_Core",
-      "order": 1,
-      "stages": [ /* same shape as v1 stages[] */ ]
-    },
-    {
-      "pipelineId": "...",
-      "pipelineName": "IdeaSphere_WebAssets-Pipeline",
-      "solutionName": "IdeaSphere_WebAssets",
-      "order": 2,
-      "stages": [ /* ... */ ]
+      "stageId": "...",
+      "name": "Deploy to Staging",
+      "rank": 1,
+      "targetDeploymentEnvironmentId": "...",
+      "targetEnvironmentUrl": "https://staging.crm.dynamics.com"
     }
+  ],
+  "deploymentOrder": [
+    { "solutionUniqueName": "IdeaSphere_Core", "solutionId": "...", "order": 1 },
+    { "solutionUniqueName": "IdeaSphere_WebAssets", "solutionId": "...", "order": 2 },
+    { "solutionUniqueName": "IdeaSphere_Future", "solutionId": "...", "order": 3, "status": "skipped-empty", "isFutureBuffer": true }
   ]
 }
 ```
+
+> **Migration note:** Earlier versions of this skill used `schemaVersion: 2` with a `pipelines[]` array (one Dataverse pipeline record per solution). Projects pinned to v2 continue to work with the old `deploy-pipeline` MULTI_PIPELINE_MODE path; the v3 format should be used for all new setups. When re-running `setup-pipeline` on a v2 project, ask via `AskUserQuestion` whether to migrate (delete the N-1 extra pipelines and collapse to a single one) or keep the legacy layout.
 
 **7.3 Write `docs/pipeline-setup.md`** (create `docs/` directory if needed):
 

--- a/plugins/power-pages/skills/setup-solution/SKILL.md
+++ b/plugins/power-pages/skills/setup-solution/SKILL.md
@@ -165,7 +165,7 @@ Refer to `${CLAUDE_PLUGIN_ROOT}/references/solution-api-patterns.md` for exact r
 
 Refer to `${CLAUDE_PLUGIN_ROOT}/references/solution-api-patterns.md` for `AddSolutionComponent` body templates and `powerpagecomponents` discovery patterns.
 
-> **Sync-mode behavior**: When `syncMode = true`, run the discovery helper with `--solutionId` populated and use the returned `missing.*` arrays as the candidate set. Everything else in this phase (dynamic component-type lookup in 5.1, categorization in 5.3, OAuth secret conversion in 5.4, orphan adoption in 5.4b, manifest summary in 5.5, bulk add in 5.6) runs the same way, just with a pre-filtered "only things that aren't already in the solution" list. The goal of sync mode is: a user who added a server logic, bot, flow, or env var *after* `setup-solution` last ran can re-invoke the skill and get those components adopted without any fresh-setup prompts.
+> **Sync-mode behavior**: When `syncMode = true`, run the discovery helper with `--solutionId` populated and use the returned `missing.*` arrays as the candidate set. Everything else in this phase (dynamic component-type lookup in 5.1, categorization in 5.3, OAuth secret conversion in 5.4, env var adoption in 5.4b, **orphan ppc adoption in 5.4c**, manifest summary in 5.5, bulk add in 5.6) runs the same way, just with a pre-filtered "only things that aren't already in the solution" list. The goal of sync mode is: a user who added a server logic, bot, flow, env var, or page *after* `setup-solution` last ran can re-invoke the skill and get those components adopted without any fresh-setup prompts.
 >
 > **Fresh-mode behavior** (`syncMode = false`): run the full discovery as documented below — every ppc, every site language, every custom table, every publisher-prefix env var becomes a candidate for inclusion.
 
@@ -360,6 +360,47 @@ If none are selected or the list is empty, `adoptedEnvVars` stays empty — the 
 
 > **Why this step exists**: before this check, env vars created by other skills were silently excluded from the site's solution and didn't travel to staging/prod. Surfacing them here is the cross-skill safety net required by the ALM-aware-by-default principle in `AGENTS.md`.
 
+#### Step 5.4c — Adopt Orphaned Power Pages Components
+
+Symmetric to 5.4b but for `powerpagecomponent` rows. Catches components on the site that were created by other skills or by `pac pages upload-code-site` without being wrapped into a user solution. Canonical examples surfaced in 2026-04-22 live validation:
+
+- **`invoice-checker` server logic** (type 35) — added via `/power-pages:add-server-logic` in an earlier session, never registered into the user solution.
+- **`index.html`** (type 3) — the current SPA entry page refreshed by `pac pages upload-code-site`; on every rebuild a new `index.html` record is created but nothing auto-adds it to the user solution.
+
+Use the shared discovery helper to collect the orphan list (it already excludes Vite/Rollup bundle chunks — `Home-XYZ.js`, `index-XYZ.css`, etc. — so the prompt doesn't drown the user in hash-named noise):
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/lib/discover-site-components.js" \
+  --envUrl "{envUrl}" --token "{token}" \
+  --siteId "{websiteRecordId}" \
+  --publisherPrefix "{publisherPrefix}" \
+  --solutionId "{solutionId}"
+```
+
+From the JSON output, take `missing.powerpagecomponents` and partition:
+
+- **Real content orphans** — entries whose `name` does NOT match the bundle-chunk regex (`[-.][A-Za-z0-9_-]{7,14}\.(js|mjs|cjs|css)(\.map)?$`). These are the ones to adopt.
+- **Bundle-chunk orphans** — keep a count for the summary, but do NOT prompt for adoption. They're stale build artifacts, not real content. Report them in the Phase 7 summary with a suggestion to clean up via a separate housekeeping pass.
+
+For each real-content orphan, also deduplicate by `name`: if there are multiple `index.html` rows and one is already in the solution (newer `modifiedon`), the older orphan is a stale duplicate — **exclude it from the adoption prompt** and log it as a stale duplicate instead. Rule: keep only the most-recent orphan per `(powerpagecomponenttype, name)` pair.
+
+If the real-content orphan list is non-empty, prompt via `AskUserQuestion` with `multiSelect: true`:
+
+> "Found **{N}** site components not yet in **{solutionUniqueName}**:
+>
+> 1. `{name}` (type {type} {typeLabel}) — currently in: **{currentSolution}**
+> 2. ...
+>
+> Plus: **Include all orphans (Recommended)** / **Skip for now**"
+
+Collect selections into `adoptedPpcs: [{ id, name, type, typeLabel }]`.
+
+When the user selects, call `AddSolutionComponent` per entry with `ComponentType: 10373` and `AddRequiredComponents: false`. Do **not** set `DoNotIncludeSubcomponents: true` — the Dataverse API rejects that flag for non-Entity root components (HTTP 400 `0x80040216`) and it's not needed for type-10373 rows anyway.
+
+If zero real-content orphans, the step runs silently.
+
+> **Why this step exists**: before this check, a recurring failure pattern was that `setup-solution` finished with the user convinced everything was wrapped up, while `invoice-checker` / `index.html` / similar site-linked records quietly stayed in the `Active` solution and didn't travel to staging/prod. Today's live validation found 1 real orphan (`invoice-checker`) on SupplierInvoicePortal — adopted via AddSolutionComponent, solution bumped from v1.0.0.1 → v1.0.0.2.
+
 #### Step 5.5 — Present Full Manifest and Get User Confirmation
 
 **This is the key decision point.** Build a full manifest of everything that will be added and present it to the user before writing anything.
@@ -420,6 +461,7 @@ Total to add: ~{N} components
 For clarity, use these tags after each env var entry in the manifest:
 - `[converted from OAuth secret]` — created in Step 5.4 from a site setting
 - `[ADOPTED — was in Default only]` — existed before this run; being pulled into the solution in Step 5.4b
+- `[ADOPTED ppc — was in Active only]` — powerpagecomponent adopted in Step 5.4c (e.g. `invoice-checker` server logic, real site pages not yet registered)
 - `[ADOPTED — also in {otherSolutionName}]` — existed in another user solution; being additionally added here (user explicitly opted in)
 
 If `cloudFlows` is non-empty, use `AskUserQuestion` with `multiSelect: true`:
@@ -460,6 +502,7 @@ The components array should be built in this order:
 5. **Dataverse tables** — `{ componentType: 1, componentId: MetadataId }`
 6. **Confirmed cloud flows** (from Step 5.5) — `{ componentId: workflowId, componentType: workflowComponentType }` (uses runtime-discovered type)
 7. **Confirmed bot components** — `{ componentId: botId, componentType: botComponentType }` (uses runtime-discovered type)
+8. **Adopted orphan ppcs** (from Step 5.4c) — `{ componentId: ppc.id, componentType: 10373, addRequired: false }`. Do **not** set `DoNotIncludeSubcomponents: true` — Dataverse rejects that flag on non-Entity components (HTTP 400 `0x80040216`).
 
 Write the array to a temp file (e.g., `C:/Users/{user}/AppData/Local/Temp/components-to-add.json`), then run:
 ```bash


### PR DESCRIPTION
## Summary

Full ALM validation cycle run end-to-end on a live Power Platform environment. Surfaced and fixed 7 bugs in the existing estimator + plan-alm + deploy-pipeline code that previously produced misleading numbers or missed orphaned components. Added new test coverage (integration harness + unit), a live-test learning log, and memory-level ALM-run tracking.

**Branch:** `users/nityagi/ALMValidations` → target `users/nityagi/PowerPagesALM`
**Commits:** 12 since branch divergence
**Env exercised:** dev `org1e98cc97` · staging `org60573626` · host `pascalepipelineshost`
**Live runs:** 2 (1 full succeeded, 1 partial-deploy edge-case canceled as designed)

## Major changes

### Estimator — multiple correctness fixes (live-verified)

Before today, `componentCount` on `SupplierInvoicePortal` site was reported as **908**. Actual solution count: **361**. Four distinct bugs conspired:

1. **`schemaAttrCount` double-counted** as individual components. Fixed — attributes ride along with the table (type 1 solutioncomponent). 908 → 407.
2. **`classifyPPCs` had swapped picklist constants** (`WEB_FILE=2` but the authoritative enum says 2 is Web Page, 3 is Web File; similar errors for WEB_PAGE=4 and WEB_TEMPLATE=11). Fixed against MS Learn's authoritative picklist.
3. **Bots + bot components not queried** site-wide — classified as a known undercount. Added `discoverBotsAndComponents` that walks type-27 bot consumer ppcs, parses the `content` JSON (not `name` — that's literally "Bot Consumer"), and looks up scoped bots + components.
4. **Vite/Rollup hash-named bundle chunks counted as real content**. Added `isProbablyBundleChunk` regex heuristic; split classified.webFiles into real content vs. chunks. Both siteTotal and inSolution subtract the chunks so the comparison stays apples-to-apples.

**Final live numbers on SIP:**
- siteTotal (real, no chunks): 231
- inSolution (real, no chunks): 233
- orphansOnSite: 0 ✅
- bundleChunkCount: 208 (on site) · 128 (in solution)

### Solution selection and component counting

- `EntityDefinitions $top=500` removed — the metadata endpoint returns HTTP 400 for `$top`. Replaced with `$filter=IsCustomEntity eq true`.
- `countSolutionMembership` gets a cross-site safety check: when the caller provides the site's ppc id set, the helper flags any type-10373 solutioncomponents rows pointing at a different site as `crossSitePpcs`.

### setup-solution · Step 5.4c (new)

Mirrors the existing 5.4b (env var adoption) but for powerpagecomponent rows. Catches server logic, pages, and other site-linked records that other skills or `pac pages upload-code-site` created without wrapping into the user solution. Excludes bundle chunks from the adoption prompt; dedupes stale duplicates. Today's live validation adopted `invoice-checker` this way.

### deploy-pipeline · Phase 7.7 activation trigger

Old trigger required the current solution to contain a website (componenttype=10374). That missed the real case where the site pre-exists on target and the deployed solution only ships tables/flows/bots. New trigger: run activation check whenever the project's `powerpages.config.json` has a `websiteRecordId`.

### plan-alm renderer

- Solutions tab gets a new "Solution membership vs. site inventory" banner when the estimator has both counts. Surfaces orphan count and links to sync-mode.

### Integration test harness

New `scripts/tests/integration/` directory with a minimal `http.createServer` mock so the estimator + discover-site-components + countSolutionMembership code paths run end-to-end against real network sockets (not injected `makeRequest`). 6 tests cover pagination, Authorization header propagation, empty-site, HTTP 500, cross-site detection.

### Docs + memory

- `creating-alm-for-powerpages-learning.md/.html` — extended with April 20–22 discoveries (conventions, plan-alm refinements, cleanup lessons, decision log)
- `Solutioning/solution-splitting-logic.md/.html` — flipped to "Implemented · Live-verified", added D1–D5 decision log
- `memory/alm-run-history.md` — persistent counter (1 full · 1 partial · 0 failed today)

## Test plan

- [x] `node --test plugins/power-pages/scripts/tests/**/*.test.js` — **332/338** (6 pre-existing / env-dependent failures, all unrelated)
- [x] `node plugins/power-pages/scripts/lint-skills-alm.js` — **0 findings**
- [x] Live dev → staging v3 pipeline deploy — succeeded (stage run `7c67a1b4-…`)
- [x] Partial-deploy edge case — canceled as designed (stage run `f60e622a-…`)
- [x] Per-type orphan analysis on SIP — 82 orphans decomposed: 80 bundle chunks + 1 stale index.html duplicate + 1 real server logic (adopted today)
- [ ] Reviewer sanity: walk through Step 5.4c logic against another site (e.g., re-run `setup-solution` in sync mode on IdeaSphere when resumed)

## Commits

| Commit | Area |
|---|---|
| `977996b` | plan-alm completeness check + OData verification |
| `6a693be` | EntityDefinitions \$top fix |
| `26fd2d0` | 3 plan-alm refinements (Future buffer, single pipeline, callout) |
| `5ec68e0` | siteTotal/inSolution + Phase 7.7 + integration-test harness |
| `783567f` | Attribute double-count (908 → 407) |
| `5888fdc` | Bot + bot component queries (407 → 439) |
| `f22f1bf` | Bundle chunk filter + picklist constants (439 → 231) |
| `8951e4a` | Test updates for picklist + bundle-chunk heuristic |
| `f55c2c8` | Cross-site safety check |
| `cded449` | setup-solution Step 5.4c orphan ppc adoption |

🤖 Generated with [Claude Code](https://claude.com/claude-code)