### PR TITLE
[Pages] Stub child_process.execSync directly in validation-helpers test

### DIFF
--- a/plugins/power-pages/scripts/tests/validation-helpers.test.js
+++ b/plugins/power-pages/scripts/tests/validation-helpers.test.js
@@ -1,39 +1,31 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const path = require('path');
+const childProcess = require('child_process');
 
 const helpersPath = path.join(__dirname, '..', 'lib', 'validation-helpers.js');
-const childProcessId = require.resolve('child_process');
 
-test('getAuthToken passes --allow-no-subscriptions to az', () => {
-  const originalChildProcess = require.cache[childProcessId];
+test('getAuthToken passes --allow-no-subscriptions to az', (t) => {
+  const originalExecSync = childProcess.execSync;
   let capturedCommand = null;
 
-  require.cache[childProcessId] = {
-    id: childProcessId,
-    filename: childProcessId,
-    loaded: true,
-    exports: {
-      execSync: (command, options) => {
-        capturedCommand = command;
-        const out = 'fake-token-value\n';
-        return options && options.encoding ? out : Buffer.from(out);
-      },
-    },
+  childProcess.execSync = (command, options) => {
+    capturedCommand = command;
+    const out = 'fake-token-value\n';
+    return options && options.encoding ? out : Buffer.from(out);
   };
   delete require.cache[require.resolve(helpersPath)];
 
-  try {
-    const { getAuthToken } = require(helpersPath);
-    const token = getAuthToken('https://example.crm.dynamics.com');
-
-    assert.equal(token, 'fake-token-value');
-    assert.match(capturedCommand, /^az account get-access-token /);
-    assert.match(capturedCommand, /--allow-no-subscriptions/);
-    assert.match(capturedCommand, /--resource "https:\/\/example\.crm\.dynamics\.com"/);
-  } finally {
-    if (originalChildProcess) require.cache[childProcessId] = originalChildProcess;
-    else delete require.cache[childProcessId];
+  t.after(() => {
+    childProcess.execSync = originalExecSync;
     delete require.cache[require.resolve(helpersPath)];
-  }
+  });
+
+  const { getAuthToken } = require(helpersPath);
+  const token = getAuthToken('https://example.crm.dynamics.com');
+
+  assert.equal(token, 'fake-token-value');
+  assert.match(capturedCommand, /^az account get-access-token /);
+  assert.match(capturedCommand, /--allow-no-subscriptions/);
+  assert.match(capturedCommand, /--resource "https:\/\/example\.crm\.dynamics\.com"/);
 });


### PR DESCRIPTION
## Summary

Follow-up to #132 addressing copilot review feedback that arrived right around the time #132 was squash-merged (the fix commit landed on the branch but missed the merge).

The initial test in #132 stubbed `child_process` by swapping the entry in `require.cache`. Node treats built-in modules as native and the cache behavior for them is an implementation detail — works on current Node but not guaranteed across versions, and not the idiomatic node:test approach.

This PR switches to monkeypatching `childProcess.execSync` directly before requiring `validation-helpers.js`, with cleanup via `t.after()`. The helper is now exercised through its real `require('child_process')` call.

- 1 file changed: `plugins/power-pages/scripts/tests/validation-helpers.test.js` (+18 / -26)
- Test still passes (~30ms), no other behavior change.

## Test plan

- [ ] `node --test plugins/power-pages/scripts/tests/validation-helpers.test.js` passes
- [ ] `node --test plugins/power-pages/scripts/tests/` full suite stays green (141/141 locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)