### PR TITLE
feat(power-pages): adopt 1DS telemetry — synced library, hooks, valid…

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,3 +211,7 @@ trademarks or logos is subject to and must follow
 [Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/legal/intellectualproperty/trademarks/usage/general).
 Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
 Any use of third-party trademarks or logos are subject to those third-party's policies.
+
+## Telemetry
+
+Plugins that ship 1DS telemetry (currently: `power-pages`) gather anonymous usage signals. Telemetry is default-on; users opt out via `POWER_PLATFORM_SKILLS_TELEMETRY=0`. See `shared/telemetry/README.md` for what is sent.

--- a/docs/superpowers/handoff/PowerPagesPluginEvent-annotation.xml
+++ b/docs/superpowers/handoff/PowerPagesPluginEvent-annotation.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<EventStreamingAnnotation name="^PowerPagesPluginEvent$">
+  <Indexing>
+    <Content><![CDATA[
+    {
+      "Interchange": {
+        "CollectorEventMappingList": ["ffdb4c99ca3a4ad5b8e9ffb08bf7da0d:PowerPagesPluginEvent"],
+        "FieldNameMappings": [
+          "data_eventName:EventName",
+          "data_eventType:EventType",
+          "data_severity:Severity",
+          "data_pluginName:PluginName",
+          "data_pluginVersion:PluginVersion",
+          "data_sessionId:SessionId",
+          "data_correlationId:CorrelationId",
+          "data_osName:OsName",
+          "data_osVersion:OsVersion",
+          "data_nodeVersion:NodeVersion",
+          "data_skillName:SkillName",
+          "data_scriptName:ScriptName",
+          "data_outcome:Outcome",
+          "data_durationMs:DurationMs",
+          "data_errorClass:ErrorClass",
+          "data_errorDescription:ErrorDescription",
+          "data_orgId:OrgId",
+          "data_tenantId:TenantId",
+          "data_pacCliVersion:PacCliVersion",
+          "data_aiAgentName:AiAgentName",
+          "data_aiAgentVersion:AiAgentVersion",
+          "data_eventInfo:EventInfo",
+          "iKey:iKey",
+          "ver:Ver"
+        ],
+        "IncludeFields": [
+          "EventName", "EventType", "Severity",
+          "PluginName", "PluginVersion",
+          "SessionId", "CorrelationId",
+          "OsName", "OsVersion", "NodeVersion",
+          "SkillName", "ScriptName",
+          "Outcome", "DurationMs", "ErrorClass", "ErrorDescription",
+          "OrgId", "TenantId",
+          "PacCliVersion", "AiAgentName", "AiAgentVersion",
+          "EventInfo",
+          "iKey", "Ver"
+        ],
+        "EnableOriginalMessage": false
+      }
+    }
+    ]]></Content>
+  </Indexing>
+</EventStreamingAnnotation>

--- a/plugins/power-pages/AGENTS.md
+++ b/plugins/power-pages/AGENTS.md
@@ -80,6 +80,17 @@ These patterns have caused repeated PR review feedback. Check for them before su
 - **Template placeholders in `<script>` blocks need special care** — `render-template.js` injects string values as-is (no encoding), which is safe for HTML text contexts but risky inside JavaScript. Avoid declaring JS variables with `"__PLACEHOLDER__"` in script blocks; prefer reading from the DOM or using `JSON.stringify` for JS contexts.
 - **Guidance must be consistent within a skill** — If one section says "always use raw fetch", a framework-specific table in the same file must not recommend a different HTTP client without qualification. Reviewers will flag contradictions.
 
+## Telemetry
+
+This plugin ships 1DS telemetry for skill-run and script-run signals. The shared library lives at the repo-root `shared/telemetry/`; the synced copy at `scripts/lib/telemetry/` is the live code. Zero npm dependencies — nothing to install.
+
+- **DO NOT hand-edit** files under `scripts/lib/telemetry/`. Edit `shared/telemetry/` and re-run `node shared/telemetry/sync-to-plugin.js --target plugins/power-pages`.
+- **Privacy posture:** anonymous telemetry is **default-on**. There is no consent prompt in skills. Users opt out via `POWER_PLATFORM_SKILLS_TELEMETRY=0` (env kill switch).
+- **Strict allowlist:** `shared/telemetry/lib/events.js` enforces exactly the fields listed in the spec. Never add a field to a builder without first adding it to the allowlist and documenting it in the design doc.
+- **Fail closed:** telemetry code must never change a script's exit code or break a skill run. Emission is fire-and-forget via a detached dispatcher child, so the hook or script returns before the HTTPS POST completes.
+
+See `docs/superpowers/specs/2026-05-04-1ds-telemetry-rebuild-design.md` for the full design.
+
 ## Maintaining This File
 
 Update when plugin structure or conventions change or you learn something which can be useful for new skills or agents.

--- a/plugins/power-pages/hooks/hooks.json
+++ b/plugins/power-pages/hooks/hooks.json
@@ -1,5 +1,17 @@
 {
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/run-skill-pretool-telemetry.js\"",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Skill",

--- a/plugins/power-pages/hooks/run-skill-posttool-validation.js
+++ b/plugins/power-pages/hooks/run-skill-posttool-validation.js
@@ -69,13 +69,12 @@ process.stdin.on('end', async () => {
 
   // Telemetry emission: fail-closed, never changes exit code.
   try {
-    const emitSpawn = require(path.join(TELEMETRY_DIR, 'lib', 'emit-spawn'));
-    const eventsLib = require(path.join(TELEMETRY_DIR, 'lib', 'events'));
-    const correlationLib = require(path.join(TELEMETRY_DIR, 'lib', 'correlation'));
-    const sessionLib = require(path.join(TELEMETRY_DIR, 'lib', 'session'));
-    const pacAuthLib = require(path.join(TELEMETRY_DIR, 'lib', 'pac-auth'));
-    const agentInfoLib = require(path.join(TELEMETRY_DIR, 'lib', 'agent-info'));
-
+    // Fast-path opt-out / kill-switch: cheap checks BEFORE the pac
+    // shell-outs (`pac auth who` ~3s + `pac --version` ~2s) so disabled /
+    // opted-out invocations don't pay the latency.
+    if (process.env.POWER_PLATFORM_SKILLS_TELEMETRY === '0') {
+      process.exit(validatorStatus);
+    }
     const ikeyCfg = (() => {
       try {
         return JSON.parse(
@@ -85,6 +84,15 @@ process.stdin.on('end', async () => {
         return { ikey: '', collector_url: '', event_stream_name: '' };
       }
     })();
+    if (ikeyCfg.disabled === true) process.exit(validatorStatus);
+    if (!ikeyCfg.instrumentationKey) process.exit(validatorStatus);
+
+    const emitSpawn = require(path.join(TELEMETRY_DIR, 'lib', 'emit-spawn'));
+    const eventsLib = require(path.join(TELEMETRY_DIR, 'lib', 'events'));
+    const correlationLib = require(path.join(TELEMETRY_DIR, 'lib', 'correlation'));
+    const sessionLib = require(path.join(TELEMETRY_DIR, 'lib', 'session'));
+    const pacAuthLib = require(path.join(TELEMETRY_DIR, 'lib', 'pac-auth'));
+    const agentInfoLib = require(path.join(TELEMETRY_DIR, 'lib', 'agent-info'));
 
     const pluginVersion = (() => {
       try {

--- a/plugins/power-pages/hooks/run-skill-posttool-validation.js
+++ b/plugins/power-pages/hooks/run-skill-posttool-validation.js
@@ -1,16 +1,27 @@
 #!/usr/bin/env node
 
 const path = require('path');
+const fs = require('fs');
+const os = require('os');
 const { spawnSync } = require('child_process');
 const {
   getTrackedSkillFromToolInput,
   getValidatorScript,
 } = require('../scripts/lib/powerpages-hook-utils');
 
+const PLUGIN_ROOT = path.resolve(__dirname, '..');
+const TELEMETRY_DIR = path.join(PLUGIN_ROOT, 'scripts', 'lib', 'telemetry');
 const DEBUG = process.env.DEBUG === '1' || process.env.DEBUG === 'true';
 
 function debug(msg) {
   if (DEBUG) process.stderr.write(msg);
+}
+
+function osFriendlyName(platform) {
+  if (platform === 'win32') return 'Windows';
+  if (platform === 'darwin') return 'Mac';
+  if (platform === 'linux') return 'Linux';
+  return platform;
 }
 
 debug('[power-pages hook] run-skill-posttool-validation.js started\n');
@@ -21,43 +32,134 @@ process.stdin.on('data', (chunk) => {
   inputData += chunk;
 });
 
-process.stdin.on('end', () => {
+process.stdin.on('end', async () => {
   debug(`[power-pages hook] stdin closed, received ${inputData.length} bytes\n`);
+
+  const startTs = Date.now();
+  let validatorStatus = 0;
+  let skillName = null;
+  let validatorRan = false;
+
   try {
     const input = JSON.parse(inputData);
-    const skillName = getTrackedSkillFromToolInput(input.tool_input);
+    skillName = getTrackedSkillFromToolInput(input.tool_input);
     if (!skillName) {
       debug('[power-pages hook] No tracked skill detected — skipping validation\n');
       process.exit(0);
     }
 
     const validatorScript = getValidatorScript(skillName);
-    if (!validatorScript) {
-      debug(`[power-pages hook] Skill "${skillName}" has no validator — skipping\n`);
-      process.exit(0);
+    if (validatorScript) {
+      validatorRan = true;
+      const validatorPath = path.join(__dirname, '..', validatorScript);
+      const result = spawnSync(process.execPath, [validatorPath], {
+        input: inputData,
+        encoding: 'utf8',
+        cwd: input.cwd || process.cwd(),
+      });
+      if (result.stdout) process.stdout.write(result.stdout);
+      if (result.stderr) process.stderr.write(result.stderr);
+      validatorStatus = result.status ?? 0;
+      debug(`[power-pages hook] Validator exited with code ${validatorStatus}\n`);
     }
-
-    debug(`[power-pages hook] Running validator for skill "${skillName}": ${validatorScript}\n`);
-
-    const validatorPath = path.join(__dirname, '..', validatorScript);
-    const result = spawnSync(process.execPath, [validatorPath], {
-      input: inputData,
-      encoding: 'utf8',
-      cwd: input.cwd || process.cwd(),
-    });
-
-    if (result.stdout) {
-      process.stdout.write(result.stdout);
-    }
-
-    if (result.stderr) {
-      process.stderr.write(result.stderr);
-    }
-
-    debug(`[power-pages hook] Validator exited with code ${result.status ?? 0}\n`);
-    process.exit(result.status ?? 0);
   } catch (err) {
     process.stderr.write(`[power-pages hook] Unexpected error: ${err.message}\n`);
-    process.exit(0);
+    validatorStatus = 0;
   }
+
+  // Telemetry emission: fail-closed, never changes exit code.
+  try {
+    const emitSpawn = require(path.join(TELEMETRY_DIR, 'lib', 'emit-spawn'));
+    const eventsLib = require(path.join(TELEMETRY_DIR, 'lib', 'events'));
+    const correlationLib = require(path.join(TELEMETRY_DIR, 'lib', 'correlation'));
+    const sessionLib = require(path.join(TELEMETRY_DIR, 'lib', 'session'));
+    const pacAuthLib = require(path.join(TELEMETRY_DIR, 'lib', 'pac-auth'));
+    const agentInfoLib = require(path.join(TELEMETRY_DIR, 'lib', 'agent-info'));
+
+    const ikeyCfg = (() => {
+      try {
+        return JSON.parse(
+          fs.readFileSync(path.join(TELEMETRY_DIR, 'ikey.json'), 'utf8')
+        );
+      } catch {
+        return { ikey: '', collector_url: '', event_stream_name: '' };
+      }
+    })();
+
+    const pluginVersion = (() => {
+      try {
+        return JSON.parse(
+          fs.readFileSync(path.join(PLUGIN_ROOT, '.claude-plugin', 'plugin.json'), 'utf8')
+        ).version || 'unknown';
+      } catch {
+        return 'unknown';
+      }
+    })();
+
+    const corr = correlationLib.read({ skillName }) || {
+      correlation_id: require('crypto').randomUUID(),
+      start_ts: startTs,
+    };
+
+    const configDir = process.env.POWER_PLATFORM_SKILLS_CONFIG_DIR || '';
+    const fakeProbe = process.env.POWER_PLATFORM_SKILLS_FAKE_HTTPS || '';
+    const outcome =
+      !validatorRan || validatorStatus === 0 ? 'success' : 'failure';
+
+    let pacAuth = null;
+    try {
+      pacAuth = pacAuthLib.readPacAuth();
+    } catch {
+      pacAuth = null;
+    }
+
+    let agentInfo = {};
+    try {
+      agentInfo = {
+        ...agentInfoLib.readAiAgent(),
+        pacCliVersion: agentInfoLib.readPacCliVersion(),
+      };
+    } catch {
+      agentInfo = {};
+    }
+
+    const fields = {
+      pluginName: 'power-pages',
+      pluginVersion,
+      sessionId: sessionLib.getSessionId(),
+      correlationId: corr.correlation_id,
+      osName: osFriendlyName(process.platform),
+      osVersion: os.release(),
+      nodeVersion: 'v' + String(process.versions.node).split('.')[0],
+      skillName,
+      outcome,
+      durationMs: Date.now() - (corr.start_ts || startTs),
+      errorClass: '',
+      errorDescription: '',
+    };
+    if (pacAuth && pacAuth.orgId) fields.orgId = pacAuth.orgId;
+    if (pacAuth && pacAuth.tenantId) fields.tenantId = pacAuth.tenantId;
+    if (agentInfo.aiAgentName) fields.aiAgentName = agentInfo.aiAgentName;
+    if (agentInfo.aiAgentVersion) fields.aiAgentVersion = agentInfo.aiAgentVersion;
+    if (agentInfo.pacCliVersion) fields.pacCliVersion = agentInfo.pacCliVersion;
+
+    emitSpawn.fireAndForget(
+      eventsLib.buildSkillCompleted(
+        ikeyCfg.event_stream_name || '',
+        fields
+      ),
+      {
+        iKey: ikeyCfg.instrumentationKey || '',
+        collectorUrl: ikeyCfg.collector_url || '',
+        configDir,
+        fakeProbe,
+      }
+    );
+
+    correlationLib.clear({ skillName });
+  } catch {
+    // fail closed: telemetry never affects skill outcome
+  }
+
+  process.exit(validatorStatus);
 });

--- a/plugins/power-pages/hooks/run-skill-pretool-telemetry.js
+++ b/plugins/power-pages/hooks/run-skill-pretool-telemetry.js
@@ -47,9 +47,10 @@ function readIkey() {
       ikey: cfg.instrumentationKey || "",
       collectorUrl: cfg.collector_url || "",
       eventStreamName: cfg.event_stream_name || "",
+      disabled: cfg.disabled === true,
     };
   } catch {
-    return { ikey: "", collectorUrl: "", eventStreamName: "" };
+    return { ikey: "", collectorUrl: "", eventStreamName: "", disabled: false };
   }
 }
 
@@ -71,6 +72,9 @@ function readStdin() {
 }
 
 (async () => {
+  // Fast-path opt-out: skip stdin read and every other side effect.
+  if (process.env.POWER_PLATFORM_SKILLS_TELEMETRY === "0") process.exit(0);
+
   const raw = await readStdin();
   let parsed;
   try {
@@ -82,9 +86,15 @@ function readStdin() {
   const skillName = hookUtils.getTrackedSkillFromToolInput(parsed.tool_input);
   if (!skillName) process.exit(0);
 
+  // Fast-path kill switch / unconfigured: gate BEFORE the pac shell-outs
+  // (`pac auth who` ~3s + `pac --version` ~2s) so disabled / opted-out
+  // hook invocations cost effectively nothing.
+  const { ikey, collectorUrl, eventStreamName, disabled } = readIkey();
+  if (disabled) process.exit(0);
+  if (!ikey) process.exit(0);
+
   const { correlation_id } = correlationLib.write({ skillName });
 
-  const { ikey, collectorUrl, eventStreamName } = readIkey();
   const configDir = process.env.POWER_PLATFORM_SKILLS_CONFIG_DIR || "";
   const fakeProbe = process.env.POWER_PLATFORM_SKILLS_FAKE_HTTPS || "";
 

--- a/plugins/power-pages/hooks/run-skill-pretool-telemetry.js
+++ b/plugins/power-pages/hooks/run-skill-pretool-telemetry.js
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+"use strict";
+
+const path = require("node:path");
+const fs = require("node:fs");
+const os = require("node:os");
+
+const PLUGIN_ROOT = path.resolve(__dirname, "..");
+const TELEMETRY_DIR = path.join(PLUGIN_ROOT, "scripts", "lib", "telemetry");
+
+let emitSpawn, eventsLib, correlationLib, sessionLib, pacAuthLib, agentInfoLib;
+try {
+  emitSpawn = require(path.join(TELEMETRY_DIR, "lib", "emit-spawn"));
+  eventsLib = require(path.join(TELEMETRY_DIR, "lib", "events"));
+  correlationLib = require(path.join(TELEMETRY_DIR, "lib", "correlation"));
+  sessionLib = require(path.join(TELEMETRY_DIR, "lib", "session"));
+  pacAuthLib = require(path.join(TELEMETRY_DIR, "lib", "pac-auth"));
+  agentInfoLib = require(path.join(TELEMETRY_DIR, "lib", "agent-info"));
+} catch {
+  process.exit(0);
+}
+
+let hookUtils;
+try {
+  hookUtils = require(path.join(PLUGIN_ROOT, "scripts", "lib", "powerpages-hook-utils"));
+} catch {
+  process.exit(0);
+}
+
+function readPluginVersion() {
+  try {
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(PLUGIN_ROOT, ".claude-plugin", "plugin.json"), "utf8")
+    );
+    return manifest.version || "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+function readIkey() {
+  try {
+    const cfg = JSON.parse(
+      fs.readFileSync(path.join(TELEMETRY_DIR, "ikey.json"), "utf8")
+    );
+    return {
+      ikey: cfg.instrumentationKey || "",
+      collectorUrl: cfg.collector_url || "",
+      eventStreamName: cfg.event_stream_name || "",
+    };
+  } catch {
+    return { ikey: "", collectorUrl: "", eventStreamName: "" };
+  }
+}
+
+function osFriendlyName(platform) {
+  if (platform === "win32") return "Windows";
+  if (platform === "darwin") return "Mac";
+  if (platform === "linux") return "Linux";
+  return platform;
+}
+
+function readStdin() {
+  return new Promise((resolve) => {
+    let buf = "";
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", (c) => (buf += c));
+    process.stdin.on("end", () => resolve(buf));
+    process.stdin.on("error", () => resolve(buf));
+  });
+}
+
+(async () => {
+  const raw = await readStdin();
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    process.exit(0);
+  }
+
+  const skillName = hookUtils.getTrackedSkillFromToolInput(parsed.tool_input);
+  if (!skillName) process.exit(0);
+
+  const { correlation_id } = correlationLib.write({ skillName });
+
+  const { ikey, collectorUrl, eventStreamName } = readIkey();
+  const configDir = process.env.POWER_PLATFORM_SKILLS_CONFIG_DIR || "";
+  const fakeProbe = process.env.POWER_PLATFORM_SKILLS_FAKE_HTTPS || "";
+
+  let pacAuth = null;
+  try {
+    pacAuth = pacAuthLib.readPacAuth();
+  } catch {
+    pacAuth = null;
+  }
+
+  let agentInfo = {};
+  try {
+    agentInfo = {
+      ...agentInfoLib.readAiAgent(),
+      pacCliVersion: agentInfoLib.readPacCliVersion(),
+    };
+  } catch {
+    agentInfo = {};
+  }
+
+  const fields = {
+    pluginName: "power-pages",
+    pluginVersion: readPluginVersion(),
+    sessionId: sessionLib.getSessionId(),
+    correlationId: correlation_id,
+    osName: osFriendlyName(process.platform),
+    osVersion: os.release(),
+    nodeVersion: "v" + String(process.versions.node).split(".")[0],
+    skillName,
+  };
+  if (pacAuth && pacAuth.orgId) fields.orgId = pacAuth.orgId;
+  if (pacAuth && pacAuth.tenantId) fields.tenantId = pacAuth.tenantId;
+  if (agentInfo.aiAgentName) fields.aiAgentName = agentInfo.aiAgentName;
+  if (agentInfo.aiAgentVersion) fields.aiAgentVersion = agentInfo.aiAgentVersion;
+  if (agentInfo.pacCliVersion) fields.pacCliVersion = agentInfo.pacCliVersion;
+
+  try {
+    emitSpawn.fireAndForget(
+      eventsLib.buildSkillStarted(eventStreamName, fields),
+      { iKey: ikey, collectorUrl, configDir, fakeProbe }
+    );
+  } catch {
+    // fail closed
+  }
+
+  process.exit(0);
+})().catch(() => process.exit(0));

--- a/plugins/power-pages/scripts/check-activation-status.js
+++ b/plugins/power-pages/scripts/check-activation-status.js
@@ -16,74 +16,75 @@ const fs = require('fs');
 const path = require('path');
 const { execSync } = require('child_process');
 const { findPath, getPacAuthInfo, getAuthToken, makeRequest, CLOUD_TO_API } = require('./lib/validation-helpers');
+const { runInstrumented } = require('./lib/telemetry-runner');
 
 function output(obj) {
   process.stdout.write(JSON.stringify(obj));
   process.exit(0);
 }
 
-// --- Parse --projectRoot argument ---
-const args = process.argv.slice(2);
-const rootIdx = args.indexOf('--projectRoot');
-const projectRoot = rootIdx !== -1 ? args[rootIdx + 1] : process.cwd();
+async function main() {
+  // --- Parse --projectRoot argument ---
+  const args = process.argv.slice(2);
+  const rootIdx = args.indexOf('--projectRoot');
+  const projectRoot = rootIdx !== -1 ? args[rootIdx + 1] : process.cwd();
 
-// --- Read siteName from powerpages.config.json ---
-const configPath = findPath(projectRoot, 'powerpages.config.json');
-if (!configPath) {
-  output({ error: 'powerpages.config.json not found' });
-}
-
-let siteName;
-try {
-  const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
-  siteName = config.siteName;
-} catch {
-  output({ error: 'Failed to parse powerpages.config.json' });
-}
-if (!siteName) {
-  output({ error: 'siteName not found in powerpages.config.json' });
-}
-
-// --- Get websiteRecordId from pac pages list ---
-let websiteRecordId = null;
-try {
-  const pacOutput = execSync('pac pages list', { encoding: 'utf8', timeout: 15000 });
-  // pac pages list outputs a table with columns. Find the row matching siteName.
-  // Column headers vary but Website Record ID is always a GUID column.
-  const lines = pacOutput.split(/\r?\n/).filter((l) => l.trim());
-  for (const line of lines) {
-    // Skip header/separator lines
-    if (line.includes('----') || line.toLowerCase().includes('website name')) continue;
-    // Check if this line contains our site name (case-insensitive)
-    if (line.toLowerCase().includes(siteName.toLowerCase())) {
-      // Extract GUID from the line
-      const guidMatch = line.match(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i);
-      if (guidMatch) {
-        websiteRecordId = guidMatch[0];
-      }
-      break;
-    }
+  // --- Read siteName from powerpages.config.json ---
+  const configPath = findPath(projectRoot, 'powerpages.config.json');
+  if (!configPath) {
+    output({ error: 'powerpages.config.json not found' });
   }
-} catch {
-  // pac pages list failed — continue without websiteRecordId
-}
 
-// --- Get PAC auth info ---
-const pacInfo = getPacAuthInfo();
-if (!pacInfo) {
-  output({ error: 'PAC CLI not authenticated' });
-}
+  let siteName;
+  try {
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    siteName = config.siteName;
+  } catch {
+    output({ error: 'Failed to parse powerpages.config.json' });
+  }
+  if (!siteName) {
+    output({ error: 'siteName not found in powerpages.config.json' });
+  }
 
-const ppApiBaseUrl = CLOUD_TO_API[pacInfo.cloud] || CLOUD_TO_API['Public'];
+  // --- Get websiteRecordId from pac pages list ---
+  let websiteRecordId = null;
+  try {
+    const pacOutput = execSync('pac pages list', { encoding: 'utf8', timeout: 15000 });
+    // pac pages list outputs a table with columns. Find the row matching siteName.
+    // Column headers vary but Website Record ID is always a GUID column.
+    const lines = pacOutput.split(/\r?\n/).filter((l) => l.trim());
+    for (const line of lines) {
+      // Skip header/separator lines
+      if (line.includes('----') || line.toLowerCase().includes('website name')) continue;
+      // Check if this line contains our site name (case-insensitive)
+      if (line.toLowerCase().includes(siteName.toLowerCase())) {
+        // Extract GUID from the line
+        const guidMatch = line.match(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i);
+        if (guidMatch) {
+          websiteRecordId = guidMatch[0];
+        }
+        break;
+      }
+    }
+  } catch {
+    // pac pages list failed — continue without websiteRecordId
+  }
 
-// --- Get Azure CLI token ---
-const token = getAuthToken(ppApiBaseUrl);
-if (!token) {
-  output({ error: 'Azure CLI token not available' });
-}
+  // --- Get PAC auth info ---
+  const pacInfo = getPacAuthInfo();
+  if (!pacInfo) {
+    output({ error: 'PAC CLI not authenticated' });
+  }
 
-// --- Query websites API ---
-(async () => {
+  const ppApiBaseUrl = CLOUD_TO_API[pacInfo.cloud] || CLOUD_TO_API['Public'];
+
+  // --- Get Azure CLI token ---
+  const token = getAuthToken(ppApiBaseUrl);
+  if (!token) {
+    output({ error: 'Azure CLI token not available' });
+  }
+
+  // --- Query websites API ---
   const websites = await getWebsites(ppApiBaseUrl, token, pacInfo.environmentId);
   if (websites === null) {
     output({ error: 'Websites API call failed' });
@@ -114,7 +115,7 @@ if (!token) {
       websiteRecordId,
     });
   }
-})();
+}
 
 async function getWebsites(ppApiBaseUrl, token, environmentId) {
   try {
@@ -135,3 +136,12 @@ async function getWebsites(ppApiBaseUrl, token, environmentId) {
     return null;
   }
 }
+
+if (require.main === module) {
+  runInstrumented('check-activation-status', main).catch((err) => {
+    process.stderr.write(String((err && err.stack) || err) + '\n');
+    process.exit(1);
+  });
+}
+
+module.exports = { main };

--- a/plugins/power-pages/scripts/clear-site-cache.js
+++ b/plugins/power-pages/scripts/clear-site-cache.js
@@ -14,50 +14,51 @@ const fs = require('fs');
 const path = require('path');
 const { execSync } = require('child_process');
 const { findPath, getPacAuthInfo, getAuthToken, makeRequest, CLOUD_TO_API } = require('./lib/validation-helpers');
+const { runInstrumented } = require('./lib/telemetry-runner');
 
 function output(obj) {
   process.stdout.write(JSON.stringify(obj));
   process.exit(obj.success ? 0 : 1);
 }
 
-// --- Parse --projectRoot argument ---
-const args = process.argv.slice(2);
-const rootIdx = args.indexOf('--projectRoot');
-const projectRoot = rootIdx !== -1 ? args[rootIdx + 1] : process.cwd();
+async function main() {
+  // --- Parse --projectRoot argument ---
+  const args = process.argv.slice(2);
+  const rootIdx = args.indexOf('--projectRoot');
+  const projectRoot = rootIdx !== -1 ? args[rootIdx + 1] : process.cwd();
 
-// --- Read siteName from powerpages.config.json ---
-const configPath = findPath(projectRoot, 'powerpages.config.json');
-if (!configPath) {
-  output({ success: false, error: 'powerpages.config.json not found' });
-}
+  // --- Read siteName from powerpages.config.json ---
+  const configPath = findPath(projectRoot, 'powerpages.config.json');
+  if (!configPath) {
+    output({ success: false, error: 'powerpages.config.json not found' });
+  }
 
-let siteName;
-try {
-  const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
-  siteName = config.siteName;
-} catch {
-  output({ success: false, error: 'Failed to parse powerpages.config.json' });
-}
-if (!siteName) {
-  output({ success: false, error: 'siteName not found in powerpages.config.json' });
-}
+  let siteName;
+  try {
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    siteName = config.siteName;
+  } catch {
+    output({ success: false, error: 'Failed to parse powerpages.config.json' });
+  }
+  if (!siteName) {
+    output({ success: false, error: 'siteName not found in powerpages.config.json' });
+  }
 
-// --- Get PAC auth info ---
-const pacInfo = getPacAuthInfo();
-if (!pacInfo) {
-  output({ success: false, error: 'PAC CLI not authenticated' });
-}
+  // --- Get PAC auth info ---
+  const pacInfo = getPacAuthInfo();
+  if (!pacInfo) {
+    output({ success: false, error: 'PAC CLI not authenticated' });
+  }
 
-const ppApiBaseUrl = CLOUD_TO_API[pacInfo.cloud] || CLOUD_TO_API['Public'];
+  const ppApiBaseUrl = CLOUD_TO_API[pacInfo.cloud] || CLOUD_TO_API['Public'];
 
-// --- Get Power Platform API token ---
-const token = getAuthToken(ppApiBaseUrl);
-if (!token) {
-  output({ success: false, error: 'Failed to get Azure CLI access token. Ensure you are logged in with: az login --allow-no-subscriptions' });
-}
+  // --- Get Power Platform API token ---
+  const token = getAuthToken(ppApiBaseUrl);
+  if (!token) {
+    output({ success: false, error: 'Failed to get Azure CLI access token. Ensure you are logged in with: az login --allow-no-subscriptions' });
+  }
 
-// --- Find the website and restart it to clear cache ---
-(async () => {
+  // --- Find the website and restart it to clear cache ---
   // Get websites for this environment
   const listResult = await makeRequest({
     url: `${ppApiBaseUrl}/powerpages/environments/${pacInfo.environmentId}/websites?api-version=2022-03-01-preview`,
@@ -119,4 +120,13 @@ if (!token) {
   } else {
     output({ success: false, error: `Restart returned HTTP ${restartResult.statusCode}: ${restartResult.body}` });
   }
-})();
+}
+
+if (require.main === module) {
+  runInstrumented('clear-site-cache', main).catch((err) => {
+    process.stderr.write(String((err && err.stack) || err) + '\n');
+    process.exit(1);
+  });
+}
+
+module.exports = { main };

--- a/plugins/power-pages/scripts/lib/telemetry-runner.js
+++ b/plugins/power-pages/scripts/lib/telemetry-runner.js
@@ -1,0 +1,50 @@
+"use strict";
+
+const path = require("node:path");
+const fs = require("node:fs");
+
+const PLUGIN_ROOT = path.resolve(__dirname, "..", "..");
+const TELEMETRY_DIR = path.join(PLUGIN_ROOT, "scripts", "lib", "telemetry");
+
+function readPluginVersion() {
+  try {
+    return JSON.parse(
+      fs.readFileSync(path.join(PLUGIN_ROOT, ".claude-plugin", "plugin.json"), "utf8")
+    ).version || "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+function loadTelemetryDeps() {
+  try {
+    return {
+      withTelemetry: require(path.join(TELEMETRY_DIR, "lib", "with-telemetry"))
+        .withTelemetry,
+      ikeyCfg: JSON.parse(
+        fs.readFileSync(path.join(TELEMETRY_DIR, "ikey.json"), "utf8")
+      ),
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function runInstrumented(scriptName, asyncFn) {
+  const deps = loadTelemetryDeps();
+  if (!deps) return asyncFn();
+
+  const configDir = process.env.POWER_PLATFORM_SKILLS_CONFIG_DIR || "";
+
+  return deps.withTelemetry(scriptName, asyncFn, {
+    pluginName: "power-pages",
+    pluginVersion: readPluginVersion(),
+    spawnOpts: {
+      iKey: deps.ikeyCfg.ikey,
+      collectorUrl: deps.ikeyCfg.collector_url,
+      configDir,
+    },
+  });
+}
+
+module.exports = { runInstrumented };

--- a/plugins/power-pages/scripts/lib/telemetry-runner.js
+++ b/plugins/power-pages/scripts/lib/telemetry-runner.js
@@ -32,7 +32,7 @@ function loadTelemetryDeps() {
 
 async function runInstrumented(scriptName, asyncFn, _overrides = {}) {
   const deps = _overrides.deps || loadTelemetryDeps();
-  if (!deps) return asyncFn();
+  if (!deps) return await asyncFn();
 
   const configDir = process.env.POWER_PLATFORM_SKILLS_CONFIG_DIR || "";
 

--- a/plugins/power-pages/scripts/lib/telemetry-runner.js
+++ b/plugins/power-pages/scripts/lib/telemetry-runner.js
@@ -30,17 +30,18 @@ function loadTelemetryDeps() {
   }
 }
 
-async function runInstrumented(scriptName, asyncFn) {
-  const deps = loadTelemetryDeps();
+async function runInstrumented(scriptName, asyncFn, _overrides = {}) {
+  const deps = _overrides.deps || loadTelemetryDeps();
   if (!deps) return asyncFn();
 
   const configDir = process.env.POWER_PLATFORM_SKILLS_CONFIG_DIR || "";
 
   return deps.withTelemetry(scriptName, asyncFn, {
+    envelopeName: deps.ikeyCfg.event_stream_name || "",
     pluginName: "power-pages",
     pluginVersion: readPluginVersion(),
     spawnOpts: {
-      iKey: deps.ikeyCfg.ikey,
+      iKey: deps.ikeyCfg.instrumentationKey,
       collectorUrl: deps.ikeyCfg.collector_url,
       configDir,
     },

--- a/plugins/power-pages/scripts/lib/telemetry/ikey.json
+++ b/plugins/power-pages/scripts/lib/telemetry/ikey.json
@@ -1,0 +1,6 @@
+{
+  "instrumentationKey": "ffdb4c99ca3a4ad5b8e9ffb08bf7da0d-65357ff3-efcd-47fc-b2fd-ad95a52373f4-7402",
+  "collector_url": "https://self.pipe.aria.int.microsoft.com/OneCollector/1.0/",
+  "event_stream_name": "PowerPagesPluginEvent",
+  "disabled": true
+}

--- a/plugins/power-pages/scripts/lib/telemetry/lib/agent-info.js
+++ b/plugins/power-pages/scripts/lib/telemetry/lib/agent-info.js
@@ -35,8 +35,9 @@ function _resetCache() {
   pacCliVersionCache = undefined;
 }
 
-// Detects the AI agent host. Prefers explicit env vars; falls back to the
-// Claude Code package.json version when CLAUDECODE=1.
+// Detects the AI agent host. Prefers explicit env vars; falls back to
+// built-in detection for Claude Code (CLAUDECODE=1) and GitHub Copilot
+// CLI (COPILOT_CLI=1).
 function readAiAgent(env = process.env) {
   const explicitName = env.AI_AGENT_NAME;
   const explicitVersion = env.AI_AGENT_VERSION;
@@ -59,6 +60,12 @@ function readAiAgent(env = process.env) {
       }
     }
     return { aiAgentName: "Claude Code", aiAgentVersion: version };
+  }
+  if (env.COPILOT_CLI === "1") {
+    return {
+      aiAgentName: "Copilot CLI",
+      aiAgentVersion: env.COPILOT_CLI_BINARY_VERSION || "",
+    };
   }
   return { aiAgentName: "", aiAgentVersion: "" };
 }

--- a/plugins/power-pages/scripts/lib/telemetry/lib/agent-info.js
+++ b/plugins/power-pages/scripts/lib/telemetry/lib/agent-info.js
@@ -1,0 +1,66 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+const { execFileSync } = require("node:child_process");
+
+let pacCliVersionCache;
+
+// Reads the PAC CLI version once per process via `pac --version`. Best-effort
+// and fail-closed: missing executable, timeout, or unparseable output all
+// resolve to "".
+function readPacCliVersion(opts = {}) {
+  if (pacCliVersionCache !== undefined) return pacCliVersionCache;
+  if (opts._exec === false) {
+    pacCliVersionCache = "";
+    return "";
+  }
+  const exec = typeof opts._exec === "function" ? opts._exec : execFileSync;
+  try {
+    const out = exec("pac", ["--version"], {
+      encoding: "utf8",
+      timeout: 2000,
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    const match = String(out || "").match(/(\d+\.\d+\.\d+(?:\.\d+)?)/);
+    pacCliVersionCache = match ? match[1] : "";
+  } catch {
+    pacCliVersionCache = "";
+  }
+  return pacCliVersionCache;
+}
+
+// Test seam.
+function _resetCache() {
+  pacCliVersionCache = undefined;
+}
+
+// Detects the AI agent host. Prefers explicit env vars; falls back to the
+// Claude Code package.json version when CLAUDECODE=1.
+function readAiAgent(env = process.env) {
+  const explicitName = env.AI_AGENT_NAME;
+  const explicitVersion = env.AI_AGENT_VERSION;
+  if (explicitName) {
+    return {
+      aiAgentName: explicitName,
+      aiAgentVersion: explicitVersion || "",
+    };
+  }
+  if (env.CLAUDECODE === "1") {
+    let version = "";
+    const execPath = env.CLAUDE_CODE_EXECPATH;
+    if (execPath) {
+      try {
+        const pkgPath = path.join(path.dirname(execPath), "..", "package.json");
+        const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
+        if (pkg && typeof pkg.version === "string") version = pkg.version;
+      } catch {
+        // pkg unreadable; leave version empty
+      }
+    }
+    return { aiAgentName: "Claude Code", aiAgentVersion: version };
+  }
+  return { aiAgentName: "", aiAgentVersion: "" };
+}
+
+module.exports = { readPacCliVersion, readAiAgent, _resetCache };

--- a/plugins/power-pages/scripts/lib/telemetry/lib/correlation.js
+++ b/plugins/power-pages/scripts/lib/telemetry/lib/correlation.js
@@ -1,0 +1,55 @@
+"use strict";
+
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+function correlationPath({ skillName, tmpDir }) {
+  const dir = tmpDir || os.tmpdir();
+  const safe = String(skillName || "unknown").replace(/[^a-z0-9-]/gi, "_");
+  return path.join(dir, `ppskills-corr-${safe}.json`);
+}
+
+function write({ skillName, tmpDir }) {
+  const record = {
+    correlation_id: crypto.randomUUID(),
+    start_ts: Date.now(),
+  };
+  try {
+    fs.writeFileSync(
+      correlationPath({ skillName, tmpDir }),
+      JSON.stringify(record),
+      "utf8"
+    );
+  } catch {
+    // fail closed
+  }
+  return record;
+}
+
+function read({ skillName, tmpDir }) {
+  try {
+    const raw = fs.readFileSync(correlationPath({ skillName, tmpDir }), "utf8");
+    const parsed = JSON.parse(raw);
+    if (
+      typeof parsed.correlation_id === "string" &&
+      typeof parsed.start_ts === "number"
+    ) {
+      return parsed;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function clear({ skillName, tmpDir }) {
+  try {
+    fs.unlinkSync(correlationPath({ skillName, tmpDir }));
+  } catch {
+    // ignore
+  }
+}
+
+module.exports = { correlationPath, write, read, clear };

--- a/plugins/power-pages/scripts/lib/telemetry/lib/emit-dispatcher.js
+++ b/plugins/power-pages/scripts/lib/telemetry/lib/emit-dispatcher.js
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+"use strict";
+
+const https = require("node:https");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { FIELD_TYPES, pick } = require("./events");
+
+function exitSilently() {
+  process.exit(0);
+}
+
+process.on("uncaughtException", exitSilently);
+process.on("unhandledRejection", exitSilently);
+process.stdin.on("error", exitSilently);
+
+const PLACEHOLDER_IKEY = "PLACEHOLDER_REPLACE_BEFORE_SHIPPING";
+const DEFAULT_LOCAL_DIR = path.join(os.homedir(), ".power-platform-skills");
+
+const IKEY = process.env.POWER_PLATFORM_SKILLS_IKEY || "";
+const COLLECTOR_URL = process.env.POWER_PLATFORM_SKILLS_COLLECTOR || "";
+const FAKE_PROBE = process.env.POWER_PLATFORM_SKILLS_FAKE_HTTPS || "";
+
+// Anonymous telemetry is default-on. The single user-facing opt-out is the
+// POWER_PLATFORM_SKILLS_TELEMETRY=0 env kill switch.
+function isUserOptedOut() {
+  return process.env.POWER_PLATFORM_SKILLS_TELEMETRY === "0";
+}
+
+// Path to the ikey.json config. Overridable via POWER_PLATFORM_SKILLS_IKEY_JSON
+// so tests can point at a temp file with their own disabled / iKey state.
+function ikeyJsonPath() {
+  return (
+    process.env.POWER_PLATFORM_SKILLS_IKEY_JSON ||
+    path.join(__dirname, "..", "ikey.json")
+  );
+}
+
+// Repo-side kill switch: when ikey.json contains "disabled": true, no events
+// are emitted regardless of opt-out or iKey state. Lets the infrastructure
+// PRs land while the tenant-side annotation + Kusto table are still being
+// provisioned. Flip to false in a single PR when ready.
+function isDisabledByConfig() {
+  try {
+    const cfg = JSON.parse(fs.readFileSync(ikeyJsonPath(), "utf8"));
+    return cfg.disabled === true;
+  } catch {
+    return false; // ikey.json missing/unreadable → fail open.
+  }
+}
+
+// Reserved meta fields that builders always write into event.data. They are
+// not user-facing telemetry columns, so they live outside FIELD_TYPES but
+// must survive sanitization.
+const RESERVED_META_FIELDS = new Set(["eventName", "eventType", "severity"]);
+
+// Defense-in-depth allowlist filter. The builders in events.js are the
+// intended entry point and already enforce FIELD_TYPES, but the dispatcher
+// receives JSON over stdin from a separate process and cannot assume that.
+// Re-run pick() against FIELD_TYPES here so any field that bypasses the
+// builders is dropped before it reaches the wire.
+function sanitizeData(data) {
+  if (!data || typeof data !== "object") return {};
+  const filtered = pick(data, Object.keys(FIELD_TYPES));
+  for (const key of RESERVED_META_FIELDS) {
+    if (typeof data[key] === "string") filtered[key] = data[key];
+  }
+  return filtered;
+}
+
+function buildEnvelope(event) {
+  return {
+    ver: "4.0",
+    name: event.name,
+    time: new Date().toISOString(),
+    iKey: "o:" + IKEY.split("-")[0],
+    data: sanitizeData(event.data),
+  };
+}
+
+function writeProbe(filePath, { headers, body }) {
+  try {
+    fs.writeFileSync(filePath, JSON.stringify({ headers, body }), "utf8");
+  } catch {
+    // ignore
+  }
+}
+
+function writeLocalLog(event) {
+  try {
+    const { appendLocal } = require("./local-log");
+    const configDir =
+      process.env.POWER_PLATFORM_SKILLS_CONFIG_DIR || DEFAULT_LOCAL_DIR;
+    appendLocal(event, { configDir });
+  } catch {
+    // fail closed
+  }
+}
+
+// ---- Repo-side kill switch (applies before placeholder / network logic) ----
+if (isDisabledByConfig()) exitSilently();
+
+// ---- User env-var opt-out --------------------------------------------------
+if (isUserOptedOut()) exitSilently();
+
+// ---- Read stdin ------------------------------------------------------------
+let raw = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (c) => (raw += c));
+process.stdin.on("end", () => {
+  let event;
+  try {
+    event = JSON.parse(raw);
+  } catch {
+    return exitSilently();
+  }
+
+  // Placeholder / unprovisioned mode → append to local dev log and exit.
+  const keyMissing = !IKEY || IKEY === PLACEHOLDER_IKEY || !COLLECTOR_URL;
+  if (keyMissing) {
+    writeLocalLog(event);
+    return exitSilently();
+  }
+
+  // Real iKey → Common Schema envelope → HTTPS POST.
+  const envelope = buildEnvelope(event);
+  const body = JSON.stringify(envelope) + "\n";
+  const headers = {
+    "Content-Type": "application/x-json-stream; charset=utf-8",
+    "x-apikey": IKEY,
+    "Content-Length": Buffer.byteLength(body),
+  };
+
+  // Test seam: if POWER_PLATFORM_SKILLS_FAKE_HTTPS is set, write the probe
+  // payload to that file and exit without calling the real network.
+  if (FAKE_PROBE) {
+    writeProbe(FAKE_PROBE, { headers, body });
+    return exitSilently();
+  }
+
+  let url;
+  try {
+    url = new URL(COLLECTOR_URL);
+  } catch {
+    return exitSilently();
+  }
+  const req = https.request(
+    {
+      hostname: url.hostname,
+      path: url.pathname + (url.search || ""),
+      method: "POST",
+      headers,
+    },
+    (res) => {
+      res.on("data", () => {});
+      res.on("end", exitSilently);
+    }
+  );
+  req.on("error", exitSilently);
+  req.setTimeout(4000, () => {
+    req.destroy();
+    exitSilently();
+  });
+  req.write(body);
+  req.end();
+});

--- a/plugins/power-pages/scripts/lib/telemetry/lib/emit-from-prompt.js
+++ b/plugins/power-pages/scripts/lib/telemetry/lib/emit-from-prompt.js
@@ -1,0 +1,108 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+const os = require("node:os");
+const crypto = require("node:crypto");
+
+const { detectSlashCommand } = require("./prompt-detector");
+const { buildSkillStarted } = require("./events");
+const { getSessionId } = require("./session");
+const { fireAndForget } = require("./emit-spawn");
+const { readPacAuth } = require("./pac-auth");
+const { readPacCliVersion, readAiAgent } = require("./agent-info");
+
+function readIkey(telemetryDir) {
+  try {
+    const cfg = JSON.parse(
+      fs.readFileSync(path.join(telemetryDir, "ikey.json"), "utf8")
+    );
+    return {
+      ikey: cfg.instrumentationKey || "",
+      collectorUrl: cfg.collector_url || "",
+      eventStreamName: cfg.event_stream_name || "",
+    };
+  } catch {
+    return { ikey: "", collectorUrl: "", eventStreamName: "" };
+  }
+}
+
+function osFriendlyName(platform) {
+  if (platform === "win32") return "Windows";
+  if (platform === "darwin") return "Mac";
+  if (platform === "linux") return "Linux";
+  return platform;
+}
+
+function emitSkillStartedFromPrompt(promptText, opts = {}) {
+  const {
+    pluginName,
+    pluginVersion,
+    trackedSkills,
+    telemetryDir,
+    _emit, // test seam; defaults to fireAndForget
+    _readPacAuth, // test seam; defaults to lib/pac-auth
+    _readAgentInfo, // test seam; defaults to lib/agent-info
+  } = opts;
+
+  const skillName = detectSlashCommand(promptText, { pluginName, trackedSkills });
+  if (!skillName) return { emitted: false, skillName: null };
+
+  const { ikey, collectorUrl, eventStreamName } = readIkey(telemetryDir);
+
+  const pacReader = typeof _readPacAuth === "function" ? _readPacAuth : readPacAuth;
+  let pacAuth = null;
+  try {
+    pacAuth = pacReader();
+  } catch {
+    pacAuth = null;
+  }
+
+  const agentReader =
+    typeof _readAgentInfo === "function"
+      ? _readAgentInfo
+      : () => ({
+          ...readAiAgent(),
+          pacCliVersion: readPacCliVersion(),
+        });
+  let agentInfo;
+  try {
+    agentInfo = agentReader() || {};
+  } catch {
+    agentInfo = {};
+  }
+
+  const fields = {
+    pluginName,
+    pluginVersion: pluginVersion || "unknown",
+    sessionId: getSessionId(),
+    correlationId: crypto.randomUUID(),
+    osName: osFriendlyName(process.platform),
+    osVersion: os.release(),
+    nodeVersion: "v" + String(process.versions.node).split(".")[0],
+    skillName,
+  };
+  if (pacAuth && pacAuth.orgId) fields.orgId = pacAuth.orgId;
+  if (pacAuth && pacAuth.tenantId) fields.tenantId = pacAuth.tenantId;
+  if (agentInfo.aiAgentName) fields.aiAgentName = agentInfo.aiAgentName;
+  if (agentInfo.aiAgentVersion) fields.aiAgentVersion = agentInfo.aiAgentVersion;
+  if (agentInfo.pacCliVersion) fields.pacCliVersion = agentInfo.pacCliVersion;
+
+  const event = buildSkillStarted(eventStreamName, fields);
+
+  const emit = typeof _emit === "function" ? _emit : fireAndForget;
+  try {
+    emit(event, {
+      iKey: ikey,
+      collectorUrl,
+      configDir: process.env.POWER_PLATFORM_SKILLS_CONFIG_DIR || "",
+      fakeProbe: process.env.POWER_PLATFORM_SKILLS_FAKE_HTTPS || "",
+    });
+  } catch {
+    // fail closed — telemetry never propagates errors
+  }
+
+  return { emitted: true, skillName };
+}
+
+module.exports = { emitSkillStartedFromPrompt };

--- a/plugins/power-pages/scripts/lib/telemetry/lib/emit-spawn.js
+++ b/plugins/power-pages/scripts/lib/telemetry/lib/emit-spawn.js
@@ -1,0 +1,53 @@
+"use strict";
+
+const { spawn } = require("node:child_process");
+const path = require("node:path");
+
+const DISPATCHER = path.resolve(__dirname, "emit-dispatcher.js");
+
+function fireAndForget(event, opts = {}) {
+  const iKey = opts.iKey || "";
+  const collectorUrl = opts.collectorUrl || "";
+  const configDir = opts.configDir || "";
+  const fakeProbe = opts.fakeProbe || "";
+
+  try {
+    const child = spawn(process.execPath, [DISPATCHER], {
+      detached: true,
+      stdio: ["pipe", "ignore", "ignore"],
+      env: {
+        // Pass only the minimum env the dispatcher needs. Avoid spreading
+        // process.env so secrets (AZURE_CLIENT_SECRET, GITHUB_TOKEN, etc.)
+        // never reach the telemetry child.
+        PATH: process.env.PATH || "",
+        SystemRoot: process.env.SystemRoot || "",
+        HOME: process.env.HOME || "",
+        USERPROFILE: process.env.USERPROFILE || "",
+        APPDATA: process.env.APPDATA || "",
+        POWER_PLATFORM_SKILLS_IKEY: iKey,
+        POWER_PLATFORM_SKILLS_COLLECTOR: collectorUrl,
+        POWER_PLATFORM_SKILLS_CONFIG_DIR: configDir,
+        POWER_PLATFORM_SKILLS_FAKE_HTTPS: fakeProbe,
+        // User-side kill switch: forward so the dispatcher's TELEMETRY=0
+        // check works when set in the parent's env.
+        POWER_PLATFORM_SKILLS_TELEMETRY:
+          process.env.POWER_PLATFORM_SKILLS_TELEMETRY || "",
+        // ikey.json path override (test seam — production reads the
+        // bundled file next to lib/ when this is unset).
+        POWER_PLATFORM_SKILLS_IKEY_JSON:
+          process.env.POWER_PLATFORM_SKILLS_IKEY_JSON || "",
+      },
+    });
+    try {
+      child.stdin.write(JSON.stringify(event));
+      child.stdin.end();
+    } catch {
+      // child may have already exited; swallow.
+    }
+    child.unref();
+  } catch {
+    // spawn failed — fail closed.
+  }
+}
+
+module.exports = { fireAndForget };

--- a/plugins/power-pages/scripts/lib/telemetry/lib/events.js
+++ b/plugins/power-pages/scripts/lib/telemetry/lib/events.js
@@ -1,0 +1,157 @@
+"use strict";
+
+// Per-field type metadata. Drives the type-aware picker so the wire payload
+// always matches the Kusto column type. Types and defaults:
+//
+//   "string"     — Kusto column type `string`. Empty strings ARE sent (lets
+//                  errorClass/errorDescription distinguish "explicit empty"
+//                  from "not present"). Non-strings are dropped.
+//   "int"        — Kusto column type `int`. Coerced via Number(); non-finite
+//                  or negative values clamp to 0. Sent as number, not string.
+//   "object"     — Kusto column type `dynamic` (JSON). Plain objects and
+//                  arrays pass through; primitives, Date, RegExp, etc. are
+//                  dropped to avoid Kusto type confusion.
+//   "enum:a|b|c" — Kusto column type `string`. Only the listed values are
+//                  accepted; anything else is dropped.
+//
+// Both `null` and `undefined` are dropped uniformly. Empty string is allowed
+// only for "string" types (deliberate — see above).
+const FIELD_TYPES = {
+  // Common — identity / context
+  pluginName: "string",
+  pluginVersion: "string",
+  sessionId: "string",
+  correlationId: "string",
+  osName: "string",
+  osVersion: "string",
+  nodeVersion: "string",
+  // Common — PAC + agent
+  orgId: "string",
+  tenantId: "string",
+  pacCliVersion: "string",
+  aiAgentName: "string",
+  aiAgentVersion: "string",
+  // Common — caller-supplied dynamic JSON
+  eventInfo: "object",
+  // Skill / script
+  skillName: "string",
+  scriptName: "string",
+  // Completed-only
+  outcome: "enum:success|failure",
+  durationMs: "int",
+  errorClass: "string",
+  errorDescription: "string",
+};
+
+const COMMON_FIELDS = [
+  "pluginName",
+  "pluginVersion",
+  "sessionId",
+  "correlationId",
+  "osName",
+  "osVersion",
+  "nodeVersion",
+  "orgId",
+  "tenantId",
+  "pacCliVersion",
+  "aiAgentName",
+  "aiAgentVersion",
+  "eventInfo",
+];
+
+const SKILL_FIELDS = ["skillName"];
+const SCRIPT_FIELDS = ["scriptName"];
+const COMPLETED_FIELDS = ["outcome", "durationMs", "errorClass", "errorDescription"];
+
+function isPlainStructured(v) {
+  if (v === null || typeof v !== "object") return false;
+  if (Array.isArray(v)) return true;
+  if (v instanceof Date) return false;
+  if (v instanceof RegExp) return false;
+  if (v instanceof Map || v instanceof Set) return false;
+  return true;
+}
+
+function clampInt(v) {
+  const n = Number(v);
+  if (!Number.isFinite(n) || n < 0) return 0;
+  return Math.floor(n);
+}
+
+// Type-aware pick. Drops null/undefined for every type. For each kept value,
+// validates against its declared type and coerces as needed.
+function pick(input, keys) {
+  const out = {};
+  if (!input || typeof input !== "object") return out;
+  for (const k of keys) {
+    const v = input[k];
+    if (v === undefined || v === null) continue;
+    const type = FIELD_TYPES[k];
+    if (type === "string") {
+      if (typeof v === "string") out[k] = v;
+    } else if (type === "int") {
+      out[k] = clampInt(v);
+    } else if (type === "object") {
+      if (isPlainStructured(v)) out[k] = v;
+    } else if (typeof type === "string" && type.startsWith("enum:")) {
+      const allowed = type.slice(5).split("|");
+      if (typeof v === "string" && allowed.includes(v)) out[k] = v;
+    }
+    // unknown types: drop (defensive — no field should hit this branch).
+  }
+  return out;
+}
+
+function buildEvent(envelopeName, eventName, info, severity) {
+  return {
+    name: envelopeName,
+    data: { eventName, eventType: "Trace", severity, ...info },
+  };
+}
+
+function buildSkillStarted(envelopeName, input) {
+  return buildEvent(
+    envelopeName,
+    "skill_started",
+    pick(input, [...COMMON_FIELDS, ...SKILL_FIELDS]),
+    "Info"
+  );
+}
+
+function buildSkillCompleted(envelopeName, input) {
+  const severity = input && input.outcome === "failure" ? "Error" : "Info";
+  return buildEvent(
+    envelopeName,
+    "skill_completed",
+    pick(input, [...COMMON_FIELDS, ...SKILL_FIELDS, ...COMPLETED_FIELDS]),
+    severity
+  );
+}
+
+function buildScriptStarted(envelopeName, input) {
+  return buildEvent(
+    envelopeName,
+    "script_started",
+    pick(input, [...COMMON_FIELDS, ...SCRIPT_FIELDS]),
+    "Info"
+  );
+}
+
+function buildScriptCompleted(envelopeName, input) {
+  const severity = input && input.outcome === "failure" ? "Error" : "Info";
+  return buildEvent(
+    envelopeName,
+    "script_completed",
+    pick(input, [...COMMON_FIELDS, ...SCRIPT_FIELDS, ...COMPLETED_FIELDS]),
+    severity
+  );
+}
+
+module.exports = {
+  buildSkillStarted,
+  buildSkillCompleted,
+  buildScriptStarted,
+  buildScriptCompleted,
+  FIELD_TYPES,
+  pick,
+};

--- a/plugins/power-pages/scripts/lib/telemetry/lib/local-log.js
+++ b/plugins/power-pages/scripts/lib/telemetry/lib/local-log.js
@@ -1,0 +1,52 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const LOG_FILE_NAME = "events.jsonl";
+const ROTATE_BYTES = 10 * 1024 * 1024; // 10 MB
+
+function rotationName(now = new Date()) {
+  const pad = (n) => String(n).padStart(2, "0");
+  const stamp =
+    now.getUTCFullYear().toString() +
+    pad(now.getUTCMonth() + 1) +
+    pad(now.getUTCDate()) +
+    pad(now.getUTCHours()) +
+    pad(now.getUTCMinutes()) +
+    pad(now.getUTCSeconds());
+  return `events.${stamp}.old`;
+}
+
+function rotateIfNeeded(dir, logFile) {
+  try {
+    const stat = fs.statSync(logFile);
+    if (stat.size > ROTATE_BYTES) {
+      try {
+        fs.renameSync(logFile, path.join(dir, rotationName()));
+      } catch {
+        // best effort: if rename fails (file locked, etc.), keep appending.
+      }
+    }
+  } catch {
+    // no existing log — nothing to rotate
+  }
+}
+
+function appendLocal(event, { configDir } = {}) {
+  if (!configDir) return;
+  try {
+    fs.mkdirSync(configDir, { recursive: true });
+  } catch {
+    return;
+  }
+  const logFile = path.join(configDir, LOG_FILE_NAME);
+  rotateIfNeeded(configDir, logFile);
+  try {
+    fs.appendFileSync(logFile, JSON.stringify(event) + "\n", "utf8");
+  } catch {
+    // swallow — fail closed
+  }
+}
+
+module.exports = { appendLocal, LOG_FILE_NAME, ROTATE_BYTES };

--- a/plugins/power-pages/scripts/lib/telemetry/lib/pac-auth.js
+++ b/plugins/power-pages/scripts/lib/telemetry/lib/pac-auth.js
@@ -1,0 +1,68 @@
+"use strict";
+
+const { execFileSync } = require("node:child_process");
+
+// Reads PAC CLI auth state by shelling out to `pac auth who` and parsing the
+// banner output. Matches the convention used by
+// plugins/power-pages/scripts/lib/validation-helpers.js (getPacAuthInfo /
+// getEnvironmentUrl) so telemetry stays consistent with the rest of the repo.
+//
+// PAC's JSON profile files are an internal/undocumented format that varies
+// across versions. The banner output is stable and is what other code paths
+// already parse via the AUTH_KEYS list documented in the VSCode 1DS extension.
+//
+// Best-effort and fail-closed: missing executable, timeout, non-zero exit, or
+// unparseable output all resolve to null. The result is cached per process so
+// repeated hook invocations only fork once.
+
+const TIMEOUT_MS = 3000;
+
+let cache;
+
+function _resetCache() {
+  cache = undefined;
+}
+
+function pickLine(text, label) {
+  // Match "Label:    value" — case-insensitive, trims whitespace.
+  const re = new RegExp("^\\s*" + label + "\\s*:\\s*(\\S.*?)\\s*$", "im");
+  const match = text.match(re);
+  return match ? match[1] : null;
+}
+
+function readPacAuth(opts = {}) {
+  if (cache !== undefined) return cache;
+  if (opts._exec === false) {
+    cache = null;
+    return null;
+  }
+  const exec = typeof opts._exec === "function" ? opts._exec : execFileSync;
+  let output;
+  try {
+    output = exec("pac", ["auth", "who"], {
+      encoding: "utf8",
+      timeout: TIMEOUT_MS,
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+  } catch {
+    cache = null;
+    return null;
+  }
+  if (typeof output !== "string" || !output) {
+    cache = null;
+    return null;
+  }
+  const tenantId = pickLine(output, "Tenant Id");
+  const orgId = pickLine(output, "Organization Id");
+  if (!tenantId && !orgId) {
+    cache = null;
+    return null;
+  }
+  cache = {
+    orgId: orgId || "",
+    tenantId: tenantId || "",
+  };
+  return cache;
+}
+
+module.exports = { readPacAuth, _resetCache };

--- a/plugins/power-pages/scripts/lib/telemetry/lib/prompt-detector.js
+++ b/plugins/power-pages/scripts/lib/telemetry/lib/prompt-detector.js
@@ -1,0 +1,20 @@
+"use strict";
+
+function detectSlashCommand(promptText, { pluginName, trackedSkills } = {}) {
+  if (typeof promptText !== "string" || !promptText) return null;
+  if (!pluginName || !trackedSkills) return null;
+
+  const escapedPlugin = pluginName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const re = new RegExp(
+    String.raw`^\s*\/` + escapedPlugin + String.raw`:([a-z0-9-]+)(?=\s|$|\r|\n)`
+  );
+  const match = promptText.match(re);
+  if (!match) return null;
+
+  const skillName = match[1];
+  return Object.prototype.hasOwnProperty.call(trackedSkills, skillName)
+    ? skillName
+    : null;
+}
+
+module.exports = { detectSlashCommand };

--- a/plugins/power-pages/scripts/lib/telemetry/lib/scrubber.js
+++ b/plugins/power-pages/scripts/lib/telemetry/lib/scrubber.js
@@ -1,0 +1,11 @@
+"use strict";
+
+// Placeholder. The spec allowlist already restricts payload fields to values
+// that cannot contain PII. This module exists as a documented seam for a
+// future regex-based pass if the allowlist ever needs to carry user strings.
+
+function scrub(value) {
+  return value;
+}
+
+module.exports = { scrub };

--- a/plugins/power-pages/scripts/lib/telemetry/lib/session.js
+++ b/plugins/power-pages/scripts/lib/telemetry/lib/session.js
@@ -1,0 +1,14 @@
+"use strict";
+
+const crypto = require("node:crypto");
+
+let cached;
+
+function getSessionId() {
+  if (!cached) {
+    cached = crypto.randomUUID();
+  }
+  return cached;
+}
+
+module.exports = { getSessionId };

--- a/plugins/power-pages/scripts/lib/telemetry/lib/with-telemetry.js
+++ b/plugins/power-pages/scripts/lib/telemetry/lib/with-telemetry.js
@@ -1,0 +1,109 @@
+"use strict";
+
+const crypto = require("node:crypto");
+const os = require("node:os");
+const { getSessionId } = require("./session");
+const { buildScriptStarted, buildScriptCompleted } = require("./events");
+const { fireAndForget } = require("./emit-spawn");
+const { readPacCliVersion, readAiAgent } = require("./agent-info");
+
+function osFriendlyName(platform) {
+  if (platform === "win32") return "Windows";
+  if (platform === "darwin") return "Mac";
+  if (platform === "linux") return "Linux";
+  return platform;
+}
+
+function commonFields({ pluginName, pluginVersion, agentInfo }) {
+  const out = {
+    pluginName,
+    pluginVersion,
+    sessionId: getSessionId(),
+    osName: osFriendlyName(process.platform),
+    osVersion: os.release(),
+    nodeVersion: "v" + String(process.versions.node).split(".")[0],
+  };
+  if (agentInfo) {
+    if (agentInfo.aiAgentName) out.aiAgentName = agentInfo.aiAgentName;
+    if (agentInfo.aiAgentVersion) out.aiAgentVersion = agentInfo.aiAgentVersion;
+    if (agentInfo.pacCliVersion) out.pacCliVersion = agentInfo.pacCliVersion;
+  }
+  return out;
+}
+
+function defaultEmitter(event, spawnOpts) {
+  fireAndForget(event, spawnOpts);
+}
+
+function defaultAgentInfo() {
+  return { ...readAiAgent(), pacCliVersion: readPacCliVersion() };
+}
+
+async function withTelemetry(scriptName, asyncFn, opts = {}) {
+  const envelopeName = opts.envelopeName || "";
+  const pluginName = opts.pluginName;
+  const pluginVersion = opts.pluginVersion;
+  const emitter = opts.emitter || defaultEmitter;
+  const spawnOpts = opts.spawnOpts || {};
+  const correlationId = crypto.randomUUID();
+  const startTs = Date.now();
+
+  const readAgentInfo =
+    typeof opts._readAgentInfo === "function" ? opts._readAgentInfo : defaultAgentInfo;
+  let agentInfo = {};
+  try {
+    agentInfo = readAgentInfo() || {};
+  } catch {
+    agentInfo = {};
+  }
+
+  try {
+    emitter(
+      buildScriptStarted(envelopeName, {
+        ...commonFields({ pluginName, pluginVersion, agentInfo }),
+        scriptName,
+        correlationId,
+      }),
+      spawnOpts
+    );
+  } catch {
+    // fail closed
+  }
+
+  let outcome = "success";
+  let errorClass = "";
+  let errorDescription = "";
+  let caught;
+  try {
+    return await asyncFn();
+  } catch (err) {
+    outcome = "failure";
+    errorClass = err && err.constructor ? err.constructor.name : "Error";
+    // PII-safe: emit only err.code (short, non-PII metadata like "ENOENT"
+    // or "ERR_INVALID_ARG_TYPE"). err.message is never emitted because it
+    // may contain file paths, GUIDs, or other user context.
+    errorDescription = err && err.code ? String(err.code) : "";
+    caught = err;
+  } finally {
+    const durationMs = Date.now() - startTs;
+    try {
+      emitter(
+        buildScriptCompleted(envelopeName, {
+          ...commonFields({ pluginName, pluginVersion, agentInfo }),
+          scriptName,
+          correlationId,
+          outcome,
+          durationMs,
+          errorClass,
+          errorDescription,
+        }),
+        spawnOpts
+      );
+    } catch {
+      // fail closed
+    }
+    if (caught) throw caught;
+  }
+}
+
+module.exports = { withTelemetry };

--- a/plugins/power-pages/scripts/render-audit-report.js
+++ b/plugins/power-pages/scripts/render-audit-report.js
@@ -11,19 +11,31 @@
 
 const path = require('path');
 const { renderTemplate, parseArgs } = require('./lib/render-template');
+const { runInstrumented } = require('./lib/telemetry-runner');
 
-const args = parseArgs(process.argv);
+async function main() {
+  const args = parseArgs(process.argv);
 
-if (!args.output || !args.data) {
-  console.error(
-    'Usage: node render-audit-report.js --output <path> --data <json-file>'
-  );
-  process.exit(1);
+  if (!args.output || !args.data) {
+    console.error(
+      'Usage: node render-audit-report.js --output <path> --data <json-file>'
+    );
+    process.exit(1);
+  }
+
+  renderTemplate({
+    templatePath: path.join(__dirname, '..', 'skills', 'audit-permissions', 'assets', 'audit-report.html'),
+    outputPath: path.resolve(args.output),
+    dataPath: path.resolve(args.data),
+    requiredKeys: ['SITE_NAME', 'AUDIT_DESC', 'SUMMARY', 'FINDINGS_DATA', 'INVENTORY_DATA'],
+  });
 }
 
-renderTemplate({
-  templatePath: path.join(__dirname, '..', 'skills', 'audit-permissions', 'assets', 'audit-report.html'),
-  outputPath: path.resolve(args.output),
-  dataPath: path.resolve(args.data),
-  requiredKeys: ['SITE_NAME', 'AUDIT_DESC', 'SUMMARY', 'FINDINGS_DATA', 'INVENTORY_DATA'],
-});
+if (require.main === module) {
+  runInstrumented('render-audit-report', main).catch((err) => {
+    process.stderr.write(String((err && err.stack) || err) + '\n');
+    process.exit(1);
+  });
+}
+
+module.exports = { main };

--- a/plugins/power-pages/scripts/tests/telemetry-hook-posttool.test.js
+++ b/plugins/power-pages/scripts/tests/telemetry-hook-posttool.test.js
@@ -1,0 +1,46 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const HOOK = path.resolve(
+  __dirname,
+  "../../hooks/run-skill-posttool-validation.js"
+);
+
+function mkConfigDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "ppskills-ho-"));
+}
+
+function runHook({ input, configDir, off }) {
+  return spawnSync(process.execPath, [HOOK], {
+    input,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      POWER_PLATFORM_SKILLS_CONFIG_DIR: configDir,
+      POWER_PLATFORM_SKILLS_TELEMETRY: off ? "0" : "",
+    },
+  });
+}
+
+test("posttool hook exits 0 with no tracked skill (preserves existing behavior)", () => {
+  const { status } = runHook({
+    input: JSON.stringify({ tool_input: { skill: "nothing" } }),
+    configDir: mkConfigDir(),
+  });
+  assert.equal(status, 0);
+});
+
+test("posttool hook exits 0 when env opt-out is set (no emit, validator still runs)", () => {
+  const { status } = runHook({
+    input: JSON.stringify({ tool_input: { skill: "create-site" } }),
+    configDir: mkConfigDir(),
+    off: true,
+  });
+  assert.equal(status, 0);
+});

--- a/plugins/power-pages/scripts/tests/telemetry-hook-pretool.test.js
+++ b/plugins/power-pages/scripts/tests/telemetry-hook-pretool.test.js
@@ -1,0 +1,59 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const HOOK = path.resolve(
+  __dirname,
+  "../../hooks/run-skill-pretool-telemetry.js"
+);
+
+function mkConfigDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "ppskills-ph-"));
+}
+
+function runHook({ input, configDir, off }) {
+  return spawnSync(process.execPath, [HOOK], {
+    input,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      POWER_PLATFORM_SKILLS_CONFIG_DIR: configDir,
+      POWER_PLATFORM_SKILLS_TELEMETRY: off ? "0" : "",
+    },
+  });
+}
+
+test("exits 0 and emits nothing when tool_input has no tracked skill", () => {
+  const { status } = runHook({
+    input: JSON.stringify({ tool_input: { skill: "other-plugin:foo" } }),
+    configDir: mkConfigDir(),
+  });
+  assert.equal(status, 0);
+});
+
+test("exits 0 when env opt-out is set", () => {
+  const { status } = runHook({
+    input: JSON.stringify({ tool_input: { skill: "create-site" } }),
+    configDir: mkConfigDir(),
+    off: true,
+  });
+  assert.equal(status, 0);
+});
+
+test("exits 0 when malformed stdin", () => {
+  const { status } = runHook({ input: "{not json", configDir: mkConfigDir() });
+  assert.equal(status, 0);
+});
+
+test("exits 0 when skill is tracked (placeholder iKey → no-op emit)", () => {
+  const { status } = runHook({
+    input: JSON.stringify({ tool_input: { skill: "create-site" } }),
+    configDir: mkConfigDir(),
+  });
+  assert.equal(status, 0);
+});

--- a/plugins/power-pages/scripts/tests/telemetry-runner.test.js
+++ b/plugins/power-pages/scripts/tests/telemetry-runner.test.js
@@ -1,0 +1,21 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("node:path");
+
+const { runInstrumented } = require("../lib/telemetry-runner");
+
+test("runInstrumented awaits the async fn and returns its value", async () => {
+  const result = await runInstrumented("dummy-script", async () => 123);
+  assert.equal(result, 123);
+});
+
+test("runInstrumented rethrows errors from the fn", async () => {
+  await assert.rejects(
+    runInstrumented("dummy-script", async () => {
+      throw new Error("nope");
+    }),
+    /nope/
+  );
+});

--- a/plugins/power-pages/scripts/tests/telemetry-runner.test.js
+++ b/plugins/power-pages/scripts/tests/telemetry-runner.test.js
@@ -19,3 +19,38 @@ test("runInstrumented rethrows errors from the fn", async () => {
     /nope/
   );
 });
+
+test("runInstrumented forwards envelopeName from ikey.json event_stream_name", async () => {
+  let captured;
+  const fakeDeps = {
+    withTelemetry: (scriptName, fn, opts) => {
+      captured = opts;
+      return fn();
+    },
+    ikeyCfg: {
+      instrumentationKey: "key-value",
+      collector_url: "https://x",
+      event_stream_name: "PowerPagesPluginEvent",
+    },
+  };
+  await runInstrumented("my-script", async () => "ok", { deps: fakeDeps });
+  assert.equal(captured.envelopeName, "PowerPagesPluginEvent");
+});
+
+test("runInstrumented reads iKey from instrumentationKey property (not legacy 'ikey')", async () => {
+  let captured;
+  const fakeDeps = {
+    withTelemetry: (scriptName, fn, opts) => {
+      captured = opts;
+      return fn();
+    },
+    ikeyCfg: {
+      instrumentationKey: "the-real-key",
+      ikey: "DO-NOT-READ-THIS-LEGACY-FIELD",
+      collector_url: "https://x",
+      event_stream_name: "PowerPagesPluginEvent",
+    },
+  };
+  await runInstrumented("my-script", async () => "ok", { deps: fakeDeps });
+  assert.equal(captured.spawnOpts.iKey, "the-real-key");
+});

--- a/plugins/power-pages/scripts/verify-dataverse-access.js
+++ b/plugins/power-pages/scripts/verify-dataverse-access.js
@@ -6,6 +6,7 @@
 // Exit 0 on success, exit 1 on failure (error message on stderr).
 
 const { getAuthToken, makeRequest } = require('./lib/validation-helpers');
+const { runInstrumented } = require('./lib/telemetry-runner');
 
 async function main() {
   const envUrl = process.argv[2];
@@ -55,4 +56,11 @@ async function main() {
   }));
 }
 
-main();
+if (require.main === module) {
+  runInstrumented('verify-dataverse-access', main).catch((err) => {
+    process.stderr.write(String((err && err.stack) || err) + '\n');
+    process.exit(1);
+  });
+}
+
+module.exports = { main };

--- a/plugins/power-pages/skills/activate-site/scripts/validate-activation.js
+++ b/plugins/power-pages/skills/activate-site/scripts/validate-activation.js
@@ -8,35 +8,43 @@
 const path = require('path');
 const { execSync } = require('child_process');
 const { approve, block, runValidation, findPath } = require('../../../scripts/lib/validation-helpers');
+const { runInstrumented } = require(path.resolve(__dirname, '..', '..', '..', 'scripts', 'lib', 'telemetry-runner'));
 
-runValidation(async (cwd) => {
-  const configPath = findPath(cwd, 'powerpages.config.json');
-  if (!configPath) approve(); // Not a Power Pages project, skip
+async function main() {
+  return runValidation(async (cwd) => {
+    const configPath = findPath(cwd, 'powerpages.config.json');
+    if (!configPath) approve(); // Not a Power Pages project, skip
 
-  const projectRoot = path.dirname(configPath);
-  const checkScript = path.resolve(__dirname, '../../../scripts/check-activation-status.js');
+    const projectRoot = path.dirname(configPath);
+    const checkScript = path.resolve(__dirname, '../../../scripts/check-activation-status.js');
 
-  let result;
-  try {
-    const output = execSync(`node "${checkScript}" --projectRoot "${projectRoot}"`, {
-      encoding: 'utf8',
-      timeout: 30000,
-    });
-    result = JSON.parse(output);
-  } catch {
-    approve(); // Auth/transient failure — don't block
-  }
+    let result;
+    try {
+      const output = execSync(`node "${checkScript}" --projectRoot "${projectRoot}"`, {
+        encoding: 'utf8',
+        timeout: 30000,
+      });
+      result = JSON.parse(output);
+    } catch {
+      approve(); // Auth/transient failure — don't block
+    }
 
-  if (result.activated === true) {
+    if (result.activated === true) {
+      approve();
+    }
+
+    if (result.activated === false) {
+      block(
+        `Power Pages activation validation failed:\n- Site '${result.siteName || 'unknown'}' is not activated. The site may not have been provisioned successfully.`
+      );
+    }
+
+    // Error or unexpected shape — don't block
     approve();
-  }
+  });
+}
 
-  if (result.activated === false) {
-    block(
-      `Power Pages activation validation failed:\n- Site '${result.siteName || 'unknown'}' is not activated. The site may not have been provisioned successfully.`
-    );
-  }
-
-  // Error or unexpected shape — don't block
-  approve();
+runInstrumented('validate-activate-site', main).catch((err) => {
+  process.stderr.write(String((err && err.stack) || err) + '\n');
+  process.exit(1);
 });

--- a/plugins/power-pages/skills/add-cloud-flow/scripts/validate-cloudflow.js
+++ b/plugins/power-pages/skills/add-cloud-flow/scripts/validate-cloudflow.js
@@ -13,10 +13,12 @@ const {
   findProjectRoot,
   UUID_REGEX,
 } = require('../../../scripts/lib/validation-helpers');
+const { runInstrumented } = require(path.resolve(__dirname, '..', '..', '..', 'scripts', 'lib', 'telemetry-runner'));
 
-runValidation((cwd) => {
-  const projectRoot = findProjectRoot(cwd);
-  if (!projectRoot) return approve();
+async function main() {
+  return runValidation((cwd) => {
+    const projectRoot = findProjectRoot(cwd);
+    if (!projectRoot) return approve();
 
   const cloudFlowDir = path.join(projectRoot, '.powerpages-site', 'cloud-flow-consumer');
   if (!fs.existsSync(cloudFlowDir)) return approve();
@@ -115,9 +117,15 @@ runValidation((cwd) => {
     }
   }
 
-  if (errors.length > 0) {
-    block('Cloud flow consumer validation failed:\n- ' + errors.join('\n- '));
-  }
+    if (errors.length > 0) {
+      block('Cloud flow consumer validation failed:\n- ' + errors.join('\n- '));
+    }
 
-  approve();
+    approve();
+  });
+}
+
+runInstrumented('validate-add-cloud-flow', main).catch((err) => {
+  process.stderr.write(String((err && err.stack) || err) + '\n');
+  process.exit(1);
 });

--- a/plugins/power-pages/skills/add-seo/scripts/validate-seo.js
+++ b/plugins/power-pages/skills/add-seo/scripts/validate-seo.js
@@ -6,58 +6,61 @@
 const fs = require('fs');
 const path = require('path');
 const { approve, block, runValidation, findPath } = require('../../../scripts/lib/validation-helpers');
+const { runInstrumented } = require(path.resolve(__dirname, '..', '..', '..', 'scripts', 'lib', 'telemetry-runner'));
 
-runValidation((cwd) => {
-  const configPath = findPath(cwd, 'powerpages.config.json');
-  if (!configPath) approve(); // Not a Power Pages project, skip
+async function main() {
+  return runValidation((cwd) => {
+    const configPath = findPath(cwd, 'powerpages.config.json');
+    if (!configPath) approve(); // Not a Power Pages project, skip
 
-  const projectRoot = path.dirname(configPath);
-  const publicDir = path.join(projectRoot, 'public');
+    const projectRoot = path.dirname(configPath);
+    const publicDir = path.join(projectRoot, 'public');
 
-  if (!fs.existsSync(publicDir)) approve();
+    if (!fs.existsSync(publicDir)) approve();
 
-  // Check if any SEO file exists — if none, this wasn't an SEO session, skip
-  const hasRobots = fs.existsSync(path.join(publicDir, 'robots.txt'));
-  const hasSitemap = fs.existsSync(path.join(publicDir, 'sitemap.xml'));
-  if (!hasRobots && !hasSitemap) approve();
+    // Check if any SEO file exists — if none, this wasn't an SEO session, skip
+    const hasRobots = fs.existsSync(path.join(publicDir, 'robots.txt'));
+    const hasSitemap = fs.existsSync(path.join(publicDir, 'sitemap.xml'));
+    if (!hasRobots && !hasSitemap) approve();
 
-  const errors = [];
+    const errors = [];
 
-  // 1. robots.txt
-  if (!hasRobots) {
-    errors.push('Missing public/robots.txt');
-  } else {
-    const content = fs.readFileSync(path.join(publicDir, 'robots.txt'), 'utf8');
-    if (!content.includes('User-agent:')) errors.push('robots.txt: missing User-agent directive');
-    if (!content.toLowerCase().includes('sitemap:')) errors.push('robots.txt: missing Sitemap directive');
-  }
-
-  // 2. sitemap.xml
-  if (!hasSitemap) {
-    errors.push('Missing public/sitemap.xml');
-  } else {
-    const content = fs.readFileSync(path.join(publicDir, 'sitemap.xml'), 'utf8');
-    if (!content.includes('<urlset')) errors.push('sitemap.xml: missing <urlset> element');
-    if (!content.includes('<loc>')) errors.push('sitemap.xml: missing <loc> entries');
-    if (content.includes('<PRODUCTION_URL>') || content.includes('<TODAY_DATE>')) {
-      errors.push('sitemap.xml: contains unreplaced template placeholders');
+    // 1. robots.txt
+    if (!hasRobots) {
+      errors.push('Missing public/robots.txt');
+    } else {
+      const content = fs.readFileSync(path.join(publicDir, 'robots.txt'), 'utf8');
+      if (!content.includes('User-agent:')) errors.push('robots.txt: missing User-agent directive');
+      if (!content.toLowerCase().includes('sitemap:')) errors.push('robots.txt: missing Sitemap directive');
     }
-  }
 
-  // 3. Meta tags in index.html
-  const indexPath = findIndexHtml(projectRoot);
-  if (indexPath) {
-    const content = fs.readFileSync(indexPath, 'utf8');
-    if (!content.includes('meta name="description"')) errors.push('index.html: missing meta description tag');
-    if (!content.includes('meta name="viewport"')) errors.push('index.html: missing viewport meta tag');
-  }
+    // 2. sitemap.xml
+    if (!hasSitemap) {
+      errors.push('Missing public/sitemap.xml');
+    } else {
+      const content = fs.readFileSync(path.join(publicDir, 'sitemap.xml'), 'utf8');
+      if (!content.includes('<urlset')) errors.push('sitemap.xml: missing <urlset> element');
+      if (!content.includes('<loc>')) errors.push('sitemap.xml: missing <loc> entries');
+      if (content.includes('<PRODUCTION_URL>') || content.includes('<TODAY_DATE>')) {
+        errors.push('sitemap.xml: contains unreplaced template placeholders');
+      }
+    }
 
-  if (errors.length > 0) {
-    block('SEO validation failed:\n- ' + errors.join('\n- '));
-  }
+    // 3. Meta tags in index.html
+    const indexPath = findIndexHtml(projectRoot);
+    if (indexPath) {
+      const content = fs.readFileSync(indexPath, 'utf8');
+      if (!content.includes('meta name="description"')) errors.push('index.html: missing meta description tag');
+      if (!content.includes('meta name="viewport"')) errors.push('index.html: missing viewport meta tag');
+    }
 
-  approve();
-});
+    if (errors.length > 0) {
+      block('SEO validation failed:\n- ' + errors.join('\n- '));
+    }
+
+    approve();
+  });
+}
 
 function findIndexHtml(projectRoot) {
   const candidates = [
@@ -83,3 +86,8 @@ function findIndexHtml(projectRoot) {
 
   return null;
 }
+
+runInstrumented('validate-add-seo', main).catch((err) => {
+  process.stderr.write(String((err && err.stack) || err) + '\n');
+  process.exit(1);
+});

--- a/plugins/power-pages/skills/add-server-logic/scripts/validate-serverlogic.js
+++ b/plugins/power-pages/skills/add-server-logic/scripts/validate-serverlogic.js
@@ -7,13 +7,15 @@
 const fs = require('fs');
 const path = require('path');
 const { approve, block, runValidation, findProjectRoot, UUID_REGEX } = require('../../../scripts/lib/validation-helpers');
+const { runInstrumented } = require(path.resolve(__dirname, '..', '..', '..', 'scripts', 'lib', 'telemetry-runner'));
 
 const ALLOWED_FUNCTIONS = ['get', 'post', 'put', 'patch', 'del'];
 const BROWSER_APIS = ['XMLHttpRequest', 'document\\.', 'window\\.', 'setTimeout', 'setInterval', 'navigator\\.', 'fetch'];
 
-runValidation((cwd) => {
-  const projectRoot = findProjectRoot(cwd);
-  if (!projectRoot) return approve(); // Not a Power Pages project, skip
+async function main() {
+  return runValidation((cwd) => {
+    const projectRoot = findProjectRoot(cwd);
+    if (!projectRoot) return approve(); // Not a Power Pages project, skip
 
   // Server logic files live inside .powerpages-site/server-logic/
   const serverLogicDir = path.join(projectRoot, '.powerpages-site', 'server-logic');
@@ -222,11 +224,17 @@ runValidation((cwd) => {
     }
   }
 
-  if (errors.length > 0) {
-    block('Server Logic validation failed:\n- ' + errors.join('\n- '));
-  }
+    if (errors.length > 0) {
+      block('Server Logic validation failed:\n- ' + errors.join('\n- '));
+    }
 
-  approve();
+    approve();
+  });
+}
+
+runInstrumented('validate-add-server-logic', main).catch((err) => {
+  process.stderr.write(String((err && err.stack) || err) + '\n');
+  process.exit(1);
 });
 
 function findServerLogicDirs(dir) {
@@ -330,3 +338,12 @@ function findTopLevelFunctions(content) {
   }
   return names;
 }
+
+if (require.main === module) {
+  runInstrumented('validate-add-server-logic', main).catch((err) => {
+    process.stderr.write(String((err && err.stack) || err) + '\n');
+    process.exit(1);
+  });
+}
+
+module.exports = { main };

--- a/plugins/power-pages/skills/audit-permissions/scripts/validate-audit.js
+++ b/plugins/power-pages/skills/audit-permissions/scripts/validate-audit.js
@@ -6,28 +6,36 @@
 const fs = require('fs');
 const path = require('path');
 const { approve, block, runValidation, findPath, findProjectRoot } = require('../../../scripts/lib/validation-helpers');
+const { runInstrumented } = require(path.resolve(__dirname, '..', '..', '..', 'scripts', 'lib', 'telemetry-runner'));
 
-runValidation((cwd) => {
-  const projectRoot = findProjectRoot(cwd);
-  if (!projectRoot) approve(); // Not a Power Pages project — not an audit session
+async function main() {
+  return runValidation((cwd) => {
+    const projectRoot = findProjectRoot(cwd);
+    if (!projectRoot) approve(); // Not a Power Pages project — not an audit session
 
-  // Check if audit report was generated in docs/
-  const docsReport = path.join(projectRoot, 'docs', 'permissions-audit.html');
-  if (fs.existsSync(docsReport)) {
-    const content = fs.readFileSync(docsReport, 'utf8');
-    if (content.includes('__FINDINGS_DATA__') || content.includes('__INVENTORY_DATA__')) {
-      block('Audit report has unreplaced placeholders — data was not populated.');
+    // Check if audit report was generated in docs/
+    const docsReport = path.join(projectRoot, 'docs', 'permissions-audit.html');
+    if (fs.existsSync(docsReport)) {
+      const content = fs.readFileSync(docsReport, 'utf8');
+      if (content.includes('__FINDINGS_DATA__') || content.includes('__INVENTORY_DATA__')) {
+        block('Audit report has unreplaced placeholders — data was not populated.');
+      }
+      approve();
     }
-    approve();
-  }
 
-  // Check temp directory as fallback
-  const tempDir = process.env.TEMP || process.env.TMP || '/tmp';
-  const tempReport = path.join(tempDir, 'permissions-audit.html');
-  if (fs.existsSync(tempReport)) {
-    approve();
-  }
+    // Check temp directory as fallback
+    const tempDir = process.env.TEMP || process.env.TMP || '/tmp';
+    const tempReport = path.join(tempDir, 'permissions-audit.html');
+    if (fs.existsSync(tempReport)) {
+      approve();
+    }
 
-  // No report found — this may not be an audit session, so don't block
-  approve();
+    // No report found — this may not be an audit session, so don't block
+    approve();
+  });
+}
+
+runInstrumented('validate-audit-permissions', main).catch((err) => {
+  process.stderr.write(String((err && err.stack) || err) + '\n');
+  process.exit(1);
 });

--- a/plugins/power-pages/skills/create-site/scripts/validate-site.js
+++ b/plugins/power-pages/skills/create-site/scripts/validate-site.js
@@ -6,13 +6,15 @@
 const fs = require('fs');
 const path = require('path');
 const { approve, block, runValidation, findPath } = require('../../../scripts/lib/validation-helpers');
+const { runInstrumented } = require(path.resolve(__dirname, '..', '..', '..', 'scripts', 'lib', 'telemetry-runner'));
 
-runValidation((cwd) => {
-  const configPath = findPath(cwd, 'powerpages.config.json');
-  if (!configPath) approve(); // Not a Power Pages project, skip
+async function main() {
+  return runValidation((cwd) => {
+    const configPath = findPath(cwd, 'powerpages.config.json');
+    if (!configPath) approve(); // Not a Power Pages project, skip
 
-  const projectRoot = path.dirname(configPath);
-  const errors = [];
+    const projectRoot = path.dirname(configPath);
+    const errors = [];
 
   // 1. Required files
   for (const file of ['package.json', '.gitignore', 'powerpages.config.json']) {
@@ -67,12 +69,13 @@ runValidation((cwd) => {
     errors.push('Missing src/ directory');
   }
 
-  if (errors.length > 0) {
-    block('Power Pages site validation failed:\n- ' + errors.join('\n- '));
-  }
+    if (errors.length > 0) {
+      block('Power Pages site validation failed:\n- ' + errors.join('\n- '));
+    }
 
-  approve();
-});
+    approve();
+  });
+}
 
 const PLACEHOLDER_RE = /__[A-Z][A-Z_]{2,}__/;
 
@@ -103,3 +106,8 @@ function findPlaceholders(dir) {
   } catch {}
   return results;
 }
+
+runInstrumented('validate-create-site', main).catch((err) => {
+  process.stderr.write(String((err && err.stack) || err) + '\n');
+  process.exit(1);
+});

--- a/plugins/power-pages/skills/create-webroles/scripts/validate-webroles.js
+++ b/plugins/power-pages/skills/create-webroles/scripts/validate-webroles.js
@@ -6,23 +6,31 @@
 const path = require('path');
 const { approve, block, runValidation, findPowerPagesSiteDir } = require('../../../scripts/lib/validation-helpers');
 const { validateWebRoles } = require('../../../scripts/lib/web-roles-validator');
+const { runInstrumented } = require(path.resolve(__dirname, '..', '..', '..', 'scripts', 'lib', 'telemetry-runner'));
 
-runValidation((cwd) => {
-  const webRolesDir = findPowerPagesSiteDir(cwd, 'web-roles');
-  if (!webRolesDir) approve(); // No .powerpages-site found — not a web roles session
+async function main() {
+  return runValidation((cwd) => {
+    const webRolesDir = findPowerPagesSiteDir(cwd, 'web-roles');
+    if (!webRolesDir) approve(); // No .powerpages-site found — not a web roles session
 
-  const validation = validateWebRoles(path.resolve(webRolesDir, '..', '..'));
-  const webRoleFiles = validation.webRoles;
-  if (webRoleFiles && webRoleFiles.length === 0) {
-    block('Web roles validation failed:\n- No web role YAML files found in .powerpages-site/web-roles/');
-  }
-  const errors = validation.findings
-    .filter(finding => finding.severity === 'error')
-    .map(finding => finding.filePath ? `${finding.message} (${path.basename(finding.filePath)})` : finding.message);
+    const validation = validateWebRoles(path.resolve(webRolesDir, '..', '..'));
+    const webRoleFiles = validation.webRoles;
+    if (webRoleFiles && webRoleFiles.length === 0) {
+      block('Web roles validation failed:\n- No web role YAML files found in .powerpages-site/web-roles/');
+    }
+    const errors = validation.findings
+      .filter(finding => finding.severity === 'error')
+      .map(finding => finding.filePath ? `${finding.message} (${path.basename(finding.filePath)})` : finding.message);
 
-  if (errors.length > 0) {
-    block('Web roles validation failed:\n- ' + errors.join('\n- '));
-  }
+    if (errors.length > 0) {
+      block('Web roles validation failed:\n- ' + errors.join('\n- '));
+    }
 
-  approve();
+    approve();
+  });
+}
+
+runInstrumented('validate-create-webroles', main).catch((err) => {
+  process.stderr.write(String((err && err.stack) || err) + '\n');
+  process.exit(1);
 });

--- a/plugins/power-pages/skills/integrate-webapi/scripts/validate-webapi-integration.js
+++ b/plugins/power-pages/skills/integrate-webapi/scripts/validate-webapi-integration.js
@@ -7,10 +7,12 @@ const fs = require('fs');
 const path = require('path');
 const { approve, block, runValidation, findProjectRoot } = require('../../../scripts/lib/validation-helpers');
 const { validatePowerPagesSchema } = require('../../../scripts/lib/powerpages-schema-validator');
+const { runInstrumented } = require(path.resolve(__dirname, '..', '..', '..', 'scripts', 'lib', 'telemetry-runner'));
 
-runValidation((cwd) => {
-  const projectRoot = findProjectRoot(cwd);
-  if (!projectRoot) approve(); // Not a Power Pages project, skip
+async function main() {
+  return runValidation((cwd) => {
+    const projectRoot = findProjectRoot(cwd);
+    if (!projectRoot) approve(); // Not a Power Pages project, skip
 
   // Check if any Web API integration files exist — if none, this wasn't an integration session
   const apiClientExists = findApiClient(projectRoot);
@@ -49,11 +51,17 @@ runValidation((cwd) => {
     errors.push('Invalid Power Pages permissions/site-settings schema:\n  - ' + schemaErrors.join('\n  - '));
   }
 
-  if (errors.length > 0) {
-    block('Web API integration validation failed:\n- ' + errors.join('\n- '));
-  }
+    if (errors.length > 0) {
+      block('Web API integration validation failed:\n- ' + errors.join('\n- '));
+    }
 
-  approve();
+    approve();
+  });
+}
+
+runInstrumented('validate-integrate-webapi', main).catch((err) => {
+  process.stderr.write(String((err && err.stack) || err) + '\n');
+  process.exit(1);
 });
 
 function findApiClient(projectRoot) {
@@ -122,3 +130,12 @@ function findTypeFiles(projectRoot) {
 
   return files;
 }
+
+if (require.main === module) {
+  runInstrumented('validate-integrate-webapi', main).catch((err) => {
+    process.stderr.write(String((err && err.stack) || err) + '\n');
+    process.exit(1);
+  });
+}
+
+module.exports = { main };

--- a/plugins/power-pages/skills/setup-auth/scripts/validate-auth.js
+++ b/plugins/power-pages/skills/setup-auth/scripts/validate-auth.js
@@ -6,10 +6,12 @@
 const fs = require('fs');
 const path = require('path');
 const { approve, block, runValidation, findProjectRoot } = require('../../../scripts/lib/validation-helpers');
+const { runInstrumented } = require(path.resolve(__dirname, '..', '..', '..', 'scripts', 'lib', 'telemetry-runner'));
 
-runValidation((cwd) => {
-  const projectRoot = findProjectRoot(cwd);
-  if (!projectRoot) approve(); // Not a Power Pages project, skip
+async function main() {
+  return runValidation((cwd) => {
+    const projectRoot = findProjectRoot(cwd);
+    if (!projectRoot) approve(); // Not a Power Pages project, skip
 
   // Check if any auth files exist — if none, this wasn't an auth session
   const authServiceExists = findAuthService(projectRoot);
@@ -56,11 +58,17 @@ runValidation((cwd) => {
     errors.push('Missing auth UI component (AuthButton or equivalent)');
   }
 
-  if (errors.length > 0) {
-    block('Authentication setup validation failed:\n- ' + errors.join('\n- '));
-  }
+    if (errors.length > 0) {
+      block('Authentication setup validation failed:\n- ' + errors.join('\n- '));
+    }
 
-  approve();
+    approve();
+  });
+}
+
+runInstrumented('validate-setup-auth', main).catch((err) => {
+  process.stderr.write(String((err && err.stack) || err) + '\n');
+  process.exit(1);
 });
 
 function findAuthService(projectRoot) {
@@ -125,3 +133,12 @@ function findAuthComponent(projectRoot) {
 
   return null;
 }
+
+if (require.main === module) {
+  runInstrumented('validate-setup-auth', main).catch((err) => {
+    process.stderr.write(String((err && err.stack) || err) + '\n');
+    process.exit(1);
+  });
+}
+
+module.exports = { main };

--- a/plugins/power-pages/skills/setup-auth/scripts/validate-auth.js
+++ b/plugins/power-pages/skills/setup-auth/scripts/validate-auth.js
@@ -66,11 +66,6 @@ async function main() {
   });
 }
 
-runInstrumented('validate-setup-auth', main).catch((err) => {
-  process.stderr.write(String((err && err.stack) || err) + '\n');
-  process.exit(1);
-});
-
 function findAuthService(projectRoot) {
   const candidates = [
     path.join(projectRoot, 'src', 'services', 'authService.ts'),

--- a/plugins/power-pages/skills/setup-datamodel/scripts/validate-datamodel.js
+++ b/plugins/power-pages/skills/setup-datamodel/scripts/validate-datamodel.js
@@ -8,10 +8,12 @@
 const fs = require('fs');
 const path = require('path');
 const { approve, block, runValidation, findPath, getAuthToken, makeRequest, getEnvironmentUrl } = require('../../../scripts/lib/validation-helpers');
+const { runInstrumented } = require(path.resolve(__dirname, '..', '..', '..', 'scripts', 'lib', 'telemetry-runner'));
 
-runValidation(async (cwd) => {
-  const manifestPath = findPath(cwd, '.datamodel-manifest.json');
-  if (!manifestPath) approve(); // Not a data model session, skip
+async function main() {
+  return runValidation(async (cwd) => {
+    const manifestPath = findPath(cwd, '.datamodel-manifest.json');
+    if (!manifestPath) approve(); // Not a data model session, skip
 
   const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
   if (!manifest.tables || manifest.tables.length === 0) approve();
@@ -41,11 +43,17 @@ runValidation(async (cwd) => {
     }
   }
 
-  if (errors.length > 0) {
-    block('Dataverse data model validation failed:\n- ' + errors.join('\n- '));
-  }
+    if (errors.length > 0) {
+      block('Dataverse data model validation failed:\n- ' + errors.join('\n- '));
+    }
 
-  approve();
+    approve();
+  });
+}
+
+runInstrumented('validate-setup-datamodel', main).catch((err) => {
+  process.stderr.write(String((err && err.stack) || err) + '\n');
+  process.exit(1);
 });
 
 async function checkTableExists(envUrl, token, logicalName) {
@@ -81,3 +89,12 @@ async function getTableColumns(envUrl, token, logicalName) {
     return [];
   }
 }
+
+if (require.main === module) {
+  runInstrumented('validate-setup-datamodel', main).catch((err) => {
+    process.stderr.write(String((err && err.stack) || err) + '\n');
+    process.exit(1);
+  });
+}
+
+module.exports = { main };

--- a/shared/telemetry/README.md
+++ b/shared/telemetry/README.md
@@ -20,7 +20,7 @@ Every event carries a fixed allowlist enforced by `lib/events.js`. Field names m
 
 - `orgId`, `tenantId` — Dataverse org GUID and Entra tenant GUID, read from `pac auth who` if the user is signed in
 - `pacCliVersion` — semver from `pac --version`
-- `aiAgentName`, `aiAgentVersion` — host AI agent detected via env (Claude Code, Copilot CLI). Honors `AI_AGENT_NAME` / `AI_AGENT_VERSION` overrides
+- `aiAgentName`, `aiAgentVersion` — host AI agent detected via env (Claude Code via `CLAUDECODE=1`, GitHub Copilot CLI via `COPILOT_CLI=1` + `COPILOT_CLI_BINARY_VERSION`). Honors `AI_AGENT_NAME` / `AI_AGENT_VERSION` overrides
 
 **Per-event:**
 

--- a/shared/telemetry/ikey.json
+++ b/shared/telemetry/ikey.json
@@ -1,6 +1,6 @@
 {
-  "instrumentationKey": "ffdb4c99ca3a4ad5b8e9ffb08bf7da0d-65357ff3-efcd-47fc-b2fd-ad95a52373f4-7402",
-  "collector_url": "https://self.pipe.aria.int.microsoft.com/OneCollector/1.0/",
+  "instrumentationKey": "PLACEHOLDER_REPLACE_BEFORE_SHIPPING",
+  "collector_url": "",
   "event_stream_name": "PluginEventStreamPlaceholder",
   "disabled": true
 }

--- a/shared/telemetry/lib/agent-info.js
+++ b/shared/telemetry/lib/agent-info.js
@@ -35,8 +35,9 @@ function _resetCache() {
   pacCliVersionCache = undefined;
 }
 
-// Detects the AI agent host. Prefers explicit env vars; falls back to the
-// Claude Code package.json version when CLAUDECODE=1.
+// Detects the AI agent host. Prefers explicit env vars; falls back to
+// built-in detection for Claude Code (CLAUDECODE=1) and GitHub Copilot
+// CLI (COPILOT_CLI=1).
 function readAiAgent(env = process.env) {
   const explicitName = env.AI_AGENT_NAME;
   const explicitVersion = env.AI_AGENT_VERSION;
@@ -59,6 +60,12 @@ function readAiAgent(env = process.env) {
       }
     }
     return { aiAgentName: "Claude Code", aiAgentVersion: version };
+  }
+  if (env.COPILOT_CLI === "1") {
+    return {
+      aiAgentName: "Copilot CLI",
+      aiAgentVersion: env.COPILOT_CLI_BINARY_VERSION || "",
+    };
   }
   return { aiAgentName: "", aiAgentVersion: "" };
 }

--- a/shared/telemetry/tests/agent-info.test.js
+++ b/shared/telemetry/tests/agent-info.test.js
@@ -61,6 +61,41 @@ test("readAiAgent: explicit AI_AGENT_NAME wins over CLAUDECODE", () => {
   assert.deepEqual(result, { aiAgentName: "Custom Agent", aiAgentVersion: "9.9.9" });
 });
 
+test("readAiAgent returns Copilot CLI + version when COPILOT_CLI=1", () => {
+  const result = agentInfo.readAiAgent({
+    COPILOT_CLI: "1",
+    COPILOT_CLI_BINARY_VERSION: "1.0.48-2",
+  });
+  assert.deepEqual(result, {
+    aiAgentName: "Copilot CLI",
+    aiAgentVersion: "1.0.48-2",
+  });
+});
+
+test("readAiAgent returns Copilot CLI with empty version when COPILOT_CLI_BINARY_VERSION missing", () => {
+  const result = agentInfo.readAiAgent({ COPILOT_CLI: "1" });
+  assert.deepEqual(result, { aiAgentName: "Copilot CLI", aiAgentVersion: "" });
+});
+
+test("readAiAgent: explicit AI_AGENT_NAME wins over COPILOT_CLI", () => {
+  const result = agentInfo.readAiAgent({
+    COPILOT_CLI: "1",
+    COPILOT_CLI_BINARY_VERSION: "1.0.48-2",
+    AI_AGENT_NAME: "Custom Agent",
+    AI_AGENT_VERSION: "9.9.9",
+  });
+  assert.deepEqual(result, { aiAgentName: "Custom Agent", aiAgentVersion: "9.9.9" });
+});
+
+test("readAiAgent: CLAUDECODE wins over COPILOT_CLI when both set", () => {
+  const result = agentInfo.readAiAgent({
+    CLAUDECODE: "1",
+    COPILOT_CLI: "1",
+    COPILOT_CLI_BINARY_VERSION: "1.0.48-2",
+  });
+  assert.equal(result.aiAgentName, "Claude Code");
+});
+
 test("readPacCliVersion parses semver from pac --version output", () => {
   agentInfo._resetCache();
   const result = agentInfo.readPacCliVersion({


### PR DESCRIPTION
  Wires the merged shared 1DS telemetry library (PR #142) into power-pages. Adds two Skill-tool hooks, a `runInstrumented()` shim around 10 validators + 4 plugin scripts, and the tenant-team handoff
   annotation.

  **Still cannot emit on merge.** Plugin's `scripts/lib/telemetry/ikey.json` ships with `"disabled": true`. The dispatcher exits before any network or local-log path runs. A separate PR flips the
  flag once the tenant-side Kusto stream is provisioned.

  ## Review focus

  | Priority | Files | What to verify |
  |---|---|---|
  | 🔴 Read carefully | `hooks/run-skill-pretool-telemetry.js`, `hooks/run-skill-posttool-validation.js`, `hooks/hooks.json` | Fire-and-forget; never blocks tool result; PostToolUse preserves
  existing validator exit code; only Skill matcher |
  | 🔴 | `scripts/lib/telemetry/ikey.json` | `disabled: true`, `event_stream_name: "PowerPagesPluginEvent"` |
  | 🔴 | `scripts/lib/telemetry-runner.js` + test | `runInstrumented()` rethrows caller errors unchanged; never alters exit code |
  | 🟡 Scan | 10× `validate-*.js` + 4× plugin scripts (`check-activation-status`, `clear-site-cache`, `render-audit-report`, `verify-dataverse-access`) | Each wrapped in `runInstrumented` only — no
  other behavior change |
  | 🟡 | `plugins/power-pages/scripts/lib/telemetry/**` | Synced copy of shared/telemetry/lib — byte-for-byte from PR #142 |
  | ⚪ Skim | `scripts/tests/telemetry-{hook-pretool,hook-posttool,runner}.test.js` (8 tests) | Hermetic — no network, no PAC; preserves validator semantics |
  | ⚪ | `AGENTS.md`, `README.md`, `docs/superpowers/handoff/PowerPagesPluginEvent-annotation.xml` | Privacy posture + tenant team handoff (EventStreamingAnnotation) |

  ## Not in scope

  - No first-run prompt, no consent file. Single opt-out is `POWER_PLATFORM_SKILLS_TELEMETRY=0` (inherited from PR #142).
  - Slash-command (`UserPromptSubmit`) hook is PR 3.
  - Multi-cloud iKey support is a follow-up PR.