### PR TITLE
Use GitHub App token for repo stats

### DIFF
--- a/.github/workflows/github-repo-stats.yml
+++ b/.github/workflows/github-repo-stats.yml
@@ -12,11 +12,18 @@ jobs:
         name: github-repo-stats
         runs-on: ubuntu-latest
         steps:
+            - name: generate app token
+              id: app-token
+              uses: actions/create-github-app-token@v1
+              with:
+                  app-id: 3189942
+                  private-key: ${{ secrets.POWER_PLATFORM_SKILLS_APP_PRIVATE_KEY }}
+
             - name: run-ghrs
               # Use latest release.
               uses: jgehrcke/github-repo-stats@RELEASE
               with:
                   repository: microsoft/power-platform-skills
-                  ghtoken: ${{ secrets.ghrs_github_api_token }}
+                  ghtoken: ${{ steps.app-token.outputs.token }}
                   databranch: github-repo-stats
                   ghpagesprefix: https://microsoft.github.io/power-platform-skills


### PR DESCRIPTION
GitHub repo stats currently depends on a PAT secret, which is not workable as org policy moves toward one-day token lifetimes.

This updates the scheduled stats workflow to mint a GitHub App installation token at runtime with `actions/create-github-app-token`, reusing the existing Power Platform Skills app private key secret. The generated token is passed to `github-repo-stats`, so the workflow no longer depends on the long-lived `ghrs_github_api_token` PAT.