### PR TITLE
Env var lifecycle: pre-PATCH validate + post-deploy verify + canonical Secret formats

### DIFF
--- a/plugins/power-pages/scripts/lib/validate-deployment-settings.js
+++ b/plugins/power-pages/scripts/lib/validate-deployment-settings.js
@@ -1,0 +1,460 @@
+#!/usr/bin/env node
+
+// Pre-deploy validator for deployment-settings.json. Classifies each
+// EnvironmentVariables[] entry by value format and (when --envUrl is
+// provided) cross-checks the value against the env var's declared type
+// on the dev environment.
+//
+// Why this exists: the Power Platform Pipelines handler validates the
+// `deploymentsettingsjson` PATCH at import time, AFTER the stage run has
+// been queued and potentially after a long wait behind serialized imports.
+// A bad Secret reference value (placeholder like `@KeyVault(vaultName=...)`,
+// raw secret value, malformed URI) fails the import with:
+//
+//   ImportAsHolding failed: The value provided as a secret reference does
+//   not match a valid secret reference format.
+//
+// This can sit in the host's serialized import queue for hours before
+// failing. Catching the bad reference upfront — at Phase 5 before the
+// PATCH — turns a multi-hour wait-then-fail into a sub-second hard stop
+// with a precise remediation pointer.
+//
+// Usage:
+//   node validate-deployment-settings.js
+//          --settingsFile <path>                 (required)
+//          [--envUrl <url>]                      (optional — looks up env var
+//                                                  types on the dev env to
+//                                                  enforce Secret-format
+//                                                  rules; without it, only
+//                                                  structural checks run)
+//          [--stageLabel <label>]                (optional — filters to one
+//                                                  stage in a Stages[]-shaped
+//                                                  file; same semantics as
+//                                                  verify-env-var-values.js)
+//          [--token <bearer>]                    (otherwise acquired via az
+//                                                  CLI for envUrl)
+//
+// Output (JSON to stdout):
+//   {
+//     "ok": true,
+//     "settingsFile": "<path>",
+//     "stageLabel": "<label|null>",
+//     "summary": {
+//       "total": N,
+//       "valid": K,
+//       "invalid": M,
+//       "unknown-type": U,
+//       "skipped": S
+//     },
+//     "findings": [
+//       {
+//         "schemaName": "<name>",
+//         "stageLabel": "<stage|null>",
+//         "value": "<value>",
+//         "type": "Secret" | "String" | "Number" | "Boolean" | "JSON" | "DataSource" | "unknown",
+//         "valueFormat": "kv-uri" | "kv-resource-id" | "kv-placeholder" |
+//                        "empty" | "plain-text" | "invalid-uri" | "non-secret",
+//         "status": "valid" | "invalid" | "unknown-type" | "skipped",
+//         "severity": "error" | "warning" | "info",
+//         "message": "<human-readable explanation>"
+//       },
+//       ...
+//     ]
+//   }
+//
+// Exit codes:
+//   0  Validation ran cleanly. Caller decides whether to block on
+//      `summary.invalid > 0`. The helper does NOT exit 1 for findings —
+//      this preserves the contract used by verify-env-var-values.js and
+//      keeps "run failed" separate from "run found problems."
+//   1  Couldn't read settings file, couldn't parse JSON, or usage error.
+
+'use strict';
+
+const helpers = require('./validation-helpers');
+const { getAuthToken } = helpers;
+const { readSettingsFile } = require('./verify-env-var-values');
+
+// ───────────────────────────────────────────────────────────────────────────
+// Canonical Secret reference format detection
+// ───────────────────────────────────────────────────────────────────────────
+//
+// Three formats Dataverse accepts for a Secret-type env var value:
+//
+//   1. Key Vault Secret Identifier URI
+//      https://<vault>.vault.azure.net/secrets/<name>[/<version>]
+//
+//   2. Azure resource ID
+//      /subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.KeyVault/
+//        vaults/<vault>/secrets/<name>
+//
+//   3. keyVaultReference JSON (less common at the .value level; this validator
+//      treats it as out-of-scope — Phase 5.2 doesn't PATCH JSON envelopes
+//      today)
+//
+// Everything else either fails ImportAsHolding ("invalid secret reference
+// format") or — worse — gets accepted as a literal string and silently
+// stores a placeholder where the maker thought they had a vault reference.
+
+const KV_URI_PATTERN =
+  /^https:\/\/[a-z0-9](?:[a-z0-9-]{1,22}[a-z0-9])?\.vault\.azure\.net\/secrets\/[A-Za-z0-9-]+(?:\/[a-f0-9]{32})?$/i;
+
+const KV_RESOURCE_ID_PATTERN =
+  /^\/subscriptions\/[a-f0-9-]{8,}\/resource[Gg]roups\/[^/]+\/providers\/Microsoft\.KeyVault\/vaults\/[^/]+\/secrets\/[^/]+$/;
+
+// Placeholder patterns we've seen in the wild — surface them with a
+// specific, actionable remediation message rather than the generic
+// "doesn't match a valid Secret reference format." These are NOT
+// recognized by Dataverse / the Pipelines handler.
+const KV_PLACEHOLDER_PATTERNS = [
+  /^@KeyVault\b/i,            // @KeyVault(vaultName=...;secretName=...)
+  /^<.*KEY.*VAULT.*>$/i,      // <KEY_VAULT_URI>, <KeyVault-...>, etc.
+  /^<TODO>$/i,                // explicit TODO placeholder
+  /^<.*PLACEHOLDER.*>$/i,
+  /^\$\{[A-Z_]+\}$/,          // bash-style ${ENV_VAR} expansion (not resolved by handler)
+];
+
+function classifyValueFormat(value) {
+  if (value === null || value === undefined || value === '') return 'empty';
+  const str = String(value);
+  if (KV_URI_PATTERN.test(str)) return 'kv-uri';
+  if (KV_RESOURCE_ID_PATTERN.test(str)) return 'kv-resource-id';
+  for (const p of KV_PLACEHOLDER_PATTERNS) {
+    if (p.test(str)) return 'kv-placeholder';
+  }
+  // Heuristic: if it looks like an HTTPS URL but didn't match the strict
+  // KV-URI pattern, flag specifically as invalid-uri so the user sees
+  // "URI is close but not right" rather than "not a Secret reference at
+  // all." A common case: missing /secrets/ segment, or wrong host suffix.
+  if (/^https:\/\//i.test(str)) return 'invalid-uri';
+  return 'plain-text';
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Per-entry classification
+// ───────────────────────────────────────────────────────────────────────────
+
+function classifyEntry({ schemaName, value, type, stageLabel }) {
+  const valueFormat = classifyValueFormat(value);
+  const base = { schemaName, stageLabel: stageLabel || null, value, type };
+
+  // Empty value is always valid — "use default" or "not set this stage."
+  // Per-stage values can legitimately be empty when the env var has a
+  // sensible default-value baked into the definition (common for Strings).
+  if (valueFormat === 'empty') {
+    return {
+      ...base,
+      valueFormat: 'empty',
+      status: 'valid',
+      severity: 'info',
+      message: 'Empty value — runtime falls back to the env var definition default.',
+    };
+  }
+
+  // Secret type: strict format enforcement.
+  if (type === 'Secret') {
+    if (valueFormat === 'kv-uri') {
+      return {
+        ...base,
+        valueFormat,
+        status: 'valid',
+        severity: 'info',
+        message: 'Valid Key Vault Secret Identifier URI.',
+      };
+    }
+    if (valueFormat === 'kv-resource-id') {
+      return {
+        ...base,
+        valueFormat,
+        status: 'valid',
+        severity: 'info',
+        message: 'Valid Azure Key Vault resource ID.',
+      };
+    }
+    if (valueFormat === 'kv-placeholder') {
+      return {
+        ...base,
+        valueFormat,
+        status: 'invalid',
+        severity: 'error',
+        message:
+          `Secret env var \`${schemaName}\` has a placeholder value. ` +
+          `Dataverse / the Pipelines handler does NOT recognize template patterns like \`@KeyVault(...)\` or \`<KEY_VAULT_URI>\`. ` +
+          `Replace with a Key Vault Secret Identifier URI (e.g. https://<vault>.vault.azure.net/secrets/<name>) ` +
+          `or an Azure resource ID. See configure-env-variables Phase 3.B and add-server-logic Phase 7.2a for the canonical formats.`,
+      };
+    }
+    if (valueFormat === 'invalid-uri') {
+      return {
+        ...base,
+        valueFormat,
+        status: 'invalid',
+        severity: 'error',
+        message:
+          `Secret env var \`${schemaName}\` value looks like an HTTPS URL but is not a valid Key Vault Secret Identifier ` +
+          `(expected shape: https://<vault>.vault.azure.net/secrets/<name>[/<version>], all lowercase host, ` +
+          `optional 32-char hex version suffix). Check the host, the /secrets/ segment, and the version format.`,
+      };
+    }
+    // plain-text — could be a raw secret value that landed here by accident
+    // (typing the actual API key into deployment-settings.json). That's a
+    // security concern AND a deploy failure — Dataverse won't accept it as
+    // a Secret reference. Strong error.
+    return {
+      ...base,
+      valueFormat: 'plain-text',
+      status: 'invalid',
+      severity: 'error',
+      message:
+        `Secret env var \`${schemaName}\` has a plain-text value where a Key Vault reference is expected. ` +
+        `If this is a real secret, REMOVE it from deployment-settings.json (the file is committed to git!) and ` +
+        `store the secret in Azure Key Vault via store-keyvault-secret.js, then use the resulting Secret Identifier URI here. ` +
+        `If you intended plain text, the env var type should be String (100000000), not Secret (100000005).`,
+    };
+  }
+
+  // Unknown type (envUrl not provided or lookup failed): structural-only
+  // check. We can still flag obvious placeholders even without knowing the
+  // type, since `@KeyVault(...)` and friends aren't valid for ANY env var
+  // type — they're not recognized syntax anywhere.
+  if (type === 'unknown') {
+    if (valueFormat === 'kv-placeholder') {
+      return {
+        ...base,
+        valueFormat,
+        status: 'invalid',
+        severity: 'error',
+        message:
+          `\`${schemaName}\` has a placeholder value (\`${value}\`). ` +
+          `This is not a recognized syntax for any env var type. ` +
+          `If it's intended as a Key Vault reference, use the Secret Identifier URI or Azure resource ID format ` +
+          `(see configure-env-variables Phase 3.B). If the env var type is String, write the literal value.`,
+      };
+    }
+    return {
+      ...base,
+      valueFormat,
+      status: 'unknown-type',
+      severity: 'info',
+      message:
+        `Type unknown (envUrl not provided or lookup failed). ` +
+        `Value format is "${valueFormat}". Cannot enforce type-specific rules — re-run with --envUrl for full validation.`,
+    };
+  }
+
+  // String / Number / Boolean / JSON / DataSource: no format constraint we
+  // can validate offline. Anything non-empty is structurally valid.
+  return {
+    ...base,
+    valueFormat: valueFormat === 'plain-text' ? 'non-secret' : valueFormat,
+    status: 'valid',
+    severity: 'info',
+    message: `${type} value — no format constraint enforced.`,
+  };
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Env var type lookup (only used when --envUrl is provided)
+// ───────────────────────────────────────────────────────────────────────────
+
+const TYPE_LABELS = {
+  100000000: 'String',
+  100000001: 'Number',
+  100000002: 'Boolean',
+  100000003: 'JSON',
+  100000004: 'DataSource',
+  100000005: 'Secret',
+};
+
+async function lookupTypes(envUrl, token, schemaNames) {
+  const types = new Map(); // schemaName → 'String' | 'Secret' | ...
+  if (!envUrl || !token || schemaNames.length === 0) return types;
+  const base = envUrl.replace(/\/+$/, '');
+  // Single query per schema is fine for small lists (typical
+  // deployment-settings.json has 1–10 entries). For larger files an
+  // `in` filter or a single startswith would be faster — out of scope.
+  for (const schemaName of schemaNames) {
+    const escaped = String(schemaName).replace(/'/g, "''");
+    const url =
+      `${base}/api/data/v9.2/environmentvariabledefinitions` +
+      `?$filter=schemaname eq '${escaped}'` +
+      `&$select=schemaname,type`;
+    // eslint-disable-next-line no-await-in-loop
+    const res = await helpers.makeRequest({
+      url,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/json',
+        'OData-MaxVersion': '4.0',
+        'OData-Version': '4.0',
+      },
+      timeout: 20000,
+    });
+    if (!res || res.error || res.statusCode !== 200 || !res.body) {
+      // Don't propagate — fall through to "unknown" for this schema only.
+      continue;
+    }
+    let parsed;
+    try {
+      parsed = JSON.parse(res.body);
+    } catch {
+      continue;
+    }
+    const rows = Array.isArray(parsed.value) ? parsed.value : [];
+    if (rows.length > 0) {
+      const code = rows[0].type;
+      const label = TYPE_LABELS[code] || 'unknown';
+      types.set(schemaName, label);
+    }
+  }
+  return types;
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Orchestration
+// ───────────────────────────────────────────────────────────────────────────
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  const out = { settingsFile: null, envUrl: null, stageLabel: null, token: null };
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--settingsFile' && args[i + 1]) out.settingsFile = args[++i];
+    else if (args[i] === '--envUrl' && args[i + 1]) out.envUrl = args[++i];
+    else if (args[i] === '--stageLabel' && args[i + 1]) out.stageLabel = args[++i];
+    else if (args[i] === '--token' && args[i + 1]) out.token = args[++i];
+  }
+  return out;
+}
+
+// Read entries from the settings file, preserving stage attribution so
+// findings can report which stage a bad value lives in (matters in
+// multi-stage files where the same schema may be valid for one stage
+// and broken for another).
+function readEntriesPreservingStage(filePath, stageLabel) {
+  // verify-env-var-values.js exports readSettingsFile, which returns
+  // `[{ schemaName, value }]` after filtering by stageLabel — but loses
+  // the stage attribution. Re-read here so we can tag each finding with
+  // its stage when it came from a Stages[]-shaped file without a filter.
+  const fs = require('fs');
+  let parsed;
+  try {
+    parsed = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch (err) {
+    throw new Error(`could not read --settingsFile ${filePath}: ${err.message}`);
+  }
+  const out = [];
+  if (Array.isArray(parsed.Stages)) {
+    for (const stage of parsed.Stages) {
+      if (stageLabel && (stage.Name || '').toLowerCase() !== stageLabel.toLowerCase()) continue;
+      if (!Array.isArray(stage.EnvironmentVariables)) continue;
+      for (const ev of stage.EnvironmentVariables) {
+        out.push({ schemaName: ev.SchemaName, value: ev.Value, stageLabel: stage.Name || null });
+      }
+    }
+    return out;
+  }
+  if (Array.isArray(parsed.EnvironmentVariables)) {
+    for (const ev of parsed.EnvironmentVariables) {
+      out.push({ schemaName: ev.SchemaName, value: ev.Value, stageLabel: null });
+    }
+    return out;
+  }
+  return [];
+}
+
+async function validateSettings({ settingsFile, envUrl, stageLabel, token }) {
+  if (!settingsFile) throw new Error('--settingsFile is required');
+  const entries = readEntriesPreservingStage(settingsFile, stageLabel);
+
+  // Collect unique schema names for the type lookup pass.
+  const uniqueSchemas = Array.from(new Set(entries.map((e) => e.schemaName).filter(Boolean)));
+
+  let typeMap = new Map();
+  if (envUrl && uniqueSchemas.length > 0) {
+    let bearer = token;
+    if (!bearer) {
+      try {
+        bearer = getAuthToken(envUrl);
+      } catch {
+        // swallow — entries fall through to unknown-type
+      }
+    }
+    if (bearer) {
+      typeMap = await lookupTypes(envUrl, bearer, uniqueSchemas);
+    }
+  }
+
+  const findings = [];
+  for (const e of entries) {
+    if (!e.schemaName) {
+      findings.push({
+        schemaName: null,
+        stageLabel: e.stageLabel,
+        value: e.value,
+        type: 'unknown',
+        valueFormat: 'invalid',
+        status: 'invalid',
+        severity: 'error',
+        message: 'Entry has no SchemaName — missing or empty field in deployment-settings.json.',
+      });
+      continue;
+    }
+    const type = typeMap.get(e.schemaName) || 'unknown';
+    findings.push(
+      classifyEntry({
+        schemaName: e.schemaName,
+        value: e.value,
+        type,
+        stageLabel: e.stageLabel,
+      })
+    );
+  }
+
+  const summary = {
+    total: findings.length,
+    valid: findings.filter((f) => f.status === 'valid').length,
+    invalid: findings.filter((f) => f.status === 'invalid').length,
+    'unknown-type': findings.filter((f) => f.status === 'unknown-type').length,
+    skipped: findings.filter((f) => f.status === 'skipped').length,
+  };
+
+  return {
+    ok: true,
+    settingsFile,
+    stageLabel: stageLabel || null,
+    summary,
+    findings,
+  };
+}
+
+async function main(argv) {
+  const args = parseArgs(argv);
+  if (!args.settingsFile) {
+    process.stderr.write('Error: --settingsFile is required\n');
+    return 1;
+  }
+  try {
+    const result = await validateSettings(args);
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+    return 0;
+  } catch (err) {
+    process.stderr.write(`Validation failed: ${err.message}\n`);
+    return 1;
+  }
+}
+
+if (require.main === module) {
+  main(process.argv).then((code) => process.exit(code));
+}
+
+module.exports = {
+  validateSettings,
+  classifyEntry,
+  classifyValueFormat,
+  lookupTypes,
+  readEntriesPreservingStage,
+  KV_URI_PATTERN,
+  KV_RESOURCE_ID_PATTERN,
+  KV_PLACEHOLDER_PATTERNS,
+  TYPE_LABELS,
+};

--- a/plugins/power-pages/scripts/lib/verify-env-var-values.js
+++ b/plugins/power-pages/scripts/lib/verify-env-var-values.js
@@ -1,0 +1,398 @@
+#!/usr/bin/env node
+
+// Verifies that environment variable VALUE records actually landed on a target
+// environment after deploy, import, or configure. Read-only; no Dataverse
+// writes, no filesystem writes (the caller decides what to do with the JSON
+// result).
+//
+// Why this exists: deploy-pipeline Phase 5.2 PATCHes `deploymentsettingsjson`
+// onto a stage run; the Power Platform Pipelines handler then writes
+// `environmentvariablevalues` records on the target as part of the import.
+// **But** the handler does not always write values for every definition in
+// `deploymentsettingsjson` — definitions that aren't bound to an
+// `mspp_sitesetting` (or another consumer the platform recognizes) can land
+// as zero-value on the target even when the stage run reports success. This
+// helper closes the verification gap.
+//
+// Usage:
+//   node verify-env-var-values.js
+//          --envUrl <target>                          (required — Dataverse target URL)
+//          [--schemaNames <comma-list>]               (verify these schemas; OR --settingsFile)
+//          [--settingsFile <path>]                    (read EnvironmentVariables[] from a
+//                                                       Microsoft-standard deployment-settings.json)
+//          [--stageLabel <label>]                     (when --settingsFile is provided, filter
+//                                                       to this stage's entries — Foundation /
+//                                                       Staging / Production / etc.)
+//          [--expectedValues <json>]                  (optional JSON map { schemaName: value }
+//                                                       — when present, every landed value
+//                                                       must match; mismatches surface as
+//                                                       `status: "value-mismatch"`)
+//          [--token <bearer>]                         (otherwise acquired via Azure CLI for envUrl)
+//
+// Inputs are mutually-exclusive for the schema source: either pass
+// `--schemaNames` directly, or pass `--settingsFile` and we'll read the
+// list. If neither is provided, exit 1 with a usage error.
+//
+// Output (JSON to stdout):
+//   {
+//     "ok": true,
+//     "target": { "envUrl": "<envUrl>", "stageLabel": "<stageLabel|null>" },
+//     "summary": { "total": N, "landed": K, "missing": M, "mismatched": L, "error": E },
+//     "results": [
+//       {
+//         "schemaName": "<name>",
+//         "definitionId": "<guid|null>",
+//         "valueId": "<guid|null>",
+//         "value": "<value|null>",
+//         "expected": "<value|undefined>",            // present only when --expectedValues used
+//         "status": "landed" | "missing-value-record" | "missing-definition" |
+//                   "value-mismatch" | "query-error"
+//       },
+//       ...
+//     ]
+//   }
+//
+// Exit codes:
+//   0  Check ran cleanly (regardless of how many entries missed). The caller
+//      decides whether to block on `summary.missing > 0`.
+//   1  Could not reach the target env, auth failed, or a usage error — the
+//      run is INCONCLUSIVE, not "deploy failed". Surface to the user
+//      accordingly.
+
+'use strict';
+
+const fs = require('fs');
+const helpers = require('./validation-helpers');
+const { getAuthToken } = helpers;
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  const out = {
+    envUrl: null,
+    token: null,
+    schemaNames: null,
+    settingsFile: null,
+    stageLabel: null,
+    expectedValues: null,
+  };
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--envUrl' && args[i + 1]) out.envUrl = args[++i];
+    else if (args[i] === '--token' && args[i + 1]) out.token = args[++i];
+    else if (args[i] === '--schemaNames' && args[i + 1]) out.schemaNames = args[++i];
+    else if (args[i] === '--settingsFile' && args[i + 1]) out.settingsFile = args[++i];
+    else if (args[i] === '--stageLabel' && args[i + 1]) out.stageLabel = args[++i];
+    else if (args[i] === '--expectedValues' && args[i + 1]) out.expectedValues = args[++i];
+  }
+  return out;
+}
+
+// Read EnvironmentVariables[] from a Microsoft-standard deployment-settings.json.
+// Supports two shapes that appear in the wild:
+//   - Top-level `EnvironmentVariables: [{ SchemaName, Value }, ...]` (single-stage file)
+//   - Per-stage `Stages: [{ Name, EnvironmentVariables: [...] }, ...]` (multi-stage file)
+// Returns `[{ schemaName, value }]` filtered to stageLabel when provided.
+function readSettingsFile(filePath, stageLabel) {
+  let raw;
+  try {
+    raw = fs.readFileSync(filePath, 'utf8');
+  } catch (err) {
+    throw new Error(`could not read --settingsFile ${filePath}: ${err.message}`);
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`--settingsFile ${filePath} is not valid JSON: ${err.message}`);
+  }
+
+  // Per-stage shape
+  if (Array.isArray(parsed.Stages)) {
+    if (!stageLabel) {
+      // No filter — flatten all stages
+      const all = [];
+      for (const stage of parsed.Stages) {
+        if (Array.isArray(stage.EnvironmentVariables)) {
+          for (const ev of stage.EnvironmentVariables) {
+            all.push({ schemaName: ev.SchemaName, value: ev.Value });
+          }
+        }
+      }
+      return dedupeBySchemaName(all);
+    }
+    const stage = parsed.Stages.find(
+      (s) => (s.Name || '').toLowerCase() === stageLabel.toLowerCase()
+    );
+    if (!stage || !Array.isArray(stage.EnvironmentVariables)) return [];
+    return stage.EnvironmentVariables.map((ev) => ({
+      schemaName: ev.SchemaName,
+      value: ev.Value,
+    }));
+  }
+
+  // Top-level shape
+  if (Array.isArray(parsed.EnvironmentVariables)) {
+    return parsed.EnvironmentVariables.map((ev) => ({
+      schemaName: ev.SchemaName,
+      value: ev.Value,
+    }));
+  }
+  return [];
+}
+
+function dedupeBySchemaName(entries) {
+  const seen = new Set();
+  const out = [];
+  for (const e of entries) {
+    if (!e.schemaName || seen.has(e.schemaName)) continue;
+    seen.add(e.schemaName);
+    out.push(e);
+  }
+  return out;
+}
+
+async function odataGet(envUrl, token, path) {
+  const base = envUrl.replace(/\/+$/, '');
+  const res = await helpers.makeRequest({
+    url: `${base}${path}`,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/json',
+      'OData-MaxVersion': '4.0',
+      'OData-Version': '4.0',
+    },
+    timeout: 20000,
+  });
+  if (!res || res.error || res.statusCode !== 200 || !res.body) {
+    return { ok: false, error: res && res.error ? res.error : `HTTP ${res && res.statusCode}` };
+  }
+  try {
+    return { ok: true, body: JSON.parse(res.body) };
+  } catch (err) {
+    return { ok: false, error: `JSON parse: ${err.message}` };
+  }
+}
+
+// Encode an OData string literal — escape single-quotes per OData spec by
+// doubling them. Defensive against schema names that pass validation but
+// contain unusual characters in user-coined slugs.
+function odataString(s) {
+  return String(s).replace(/'/g, "''");
+}
+
+async function verifyOne(envUrl, token, schemaName, expectedValue) {
+  // Pass 1 — find the definition by schemaname.
+  const defResp = await odataGet(
+    envUrl,
+    token,
+    `/api/data/v9.2/environmentvariabledefinitions` +
+      `?$filter=schemaname eq '${odataString(schemaName)}'` +
+      `&$select=environmentvariabledefinitionid,schemaname,type`
+  );
+  if (!defResp.ok) {
+    return {
+      schemaName,
+      definitionId: null,
+      valueId: null,
+      value: null,
+      ...(expectedValue !== undefined ? { expected: expectedValue } : {}),
+      status: 'query-error',
+      error: defResp.error,
+    };
+  }
+  const defs = defResp.body && Array.isArray(defResp.body.value) ? defResp.body.value : [];
+  if (defs.length === 0) {
+    return {
+      schemaName,
+      definitionId: null,
+      valueId: null,
+      value: null,
+      ...(expectedValue !== undefined ? { expected: expectedValue } : {}),
+      status: 'missing-definition',
+    };
+  }
+  const definitionId = defs[0].environmentvariabledefinitionid;
+
+  // Pass 2 — find the value record linked to that definition.
+  const valResp = await odataGet(
+    envUrl,
+    token,
+    `/api/data/v9.2/environmentvariablevalues` +
+      `?$filter=_environmentvariabledefinitionid_value eq ${definitionId}` +
+      `&$select=environmentvariablevalueid,value`
+  );
+  if (!valResp.ok) {
+    return {
+      schemaName,
+      definitionId,
+      valueId: null,
+      value: null,
+      ...(expectedValue !== undefined ? { expected: expectedValue } : {}),
+      status: 'query-error',
+      error: valResp.error,
+    };
+  }
+  const vals = valResp.body && Array.isArray(valResp.body.value) ? valResp.body.value : [];
+  if (vals.length === 0) {
+    return {
+      schemaName,
+      definitionId,
+      valueId: null,
+      value: null,
+      ...(expectedValue !== undefined ? { expected: expectedValue } : {}),
+      status: 'missing-value-record',
+    };
+  }
+  const valueRow = vals[0];
+  const result = {
+    schemaName,
+    definitionId,
+    valueId: valueRow.environmentvariablevalueid,
+    value: valueRow.value === undefined ? null : valueRow.value,
+    status: 'landed',
+  };
+  if (expectedValue !== undefined) {
+    result.expected = expectedValue;
+    if (String(result.value) !== String(expectedValue)) {
+      result.status = 'value-mismatch';
+    }
+  }
+  return result;
+}
+
+async function verifyEnvVarValues({ envUrl, token, schemaNames, expectedValuesMap, stageLabel }) {
+  if (!envUrl) throw new Error('--envUrl is required');
+  if (!Array.isArray(schemaNames) || schemaNames.length === 0) {
+    throw new Error('schemaNames must be a non-empty array (use --schemaNames or --settingsFile)');
+  }
+  const results = [];
+  for (const schemaName of schemaNames) {
+    const expected = expectedValuesMap ? expectedValuesMap[schemaName] : undefined;
+    // eslint-disable-next-line no-await-in-loop
+    const r = await verifyOne(envUrl, token, schemaName, expected);
+    results.push(r);
+  }
+  const summary = {
+    total: results.length,
+    landed: results.filter((r) => r.status === 'landed').length,
+    missing: results.filter(
+      (r) => r.status === 'missing-value-record' || r.status === 'missing-definition'
+    ).length,
+    mismatched: results.filter((r) => r.status === 'value-mismatch').length,
+    error: results.filter((r) => r.status === 'query-error').length,
+  };
+  return {
+    ok: true,
+    target: { envUrl, stageLabel: stageLabel || null },
+    summary,
+    results,
+  };
+}
+
+async function main(argv) {
+  let args;
+  try {
+    args = parseArgs(argv);
+  } catch (err) {
+    process.stderr.write(`Error: ${err.message}\n`);
+    return 1;
+  }
+  if (!args.envUrl) {
+    process.stderr.write('Error: --envUrl is required\n');
+    return 1;
+  }
+  if (!args.schemaNames && !args.settingsFile) {
+    process.stderr.write('Error: provide either --schemaNames or --settingsFile\n');
+    return 1;
+  }
+
+  // Resolve schemaNames + optional expectedValues map.
+  let schemaNames = [];
+  let expectedValuesMap = null;
+  if (args.schemaNames) {
+    schemaNames = args.schemaNames
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+  } else {
+    try {
+      const entries = readSettingsFile(args.settingsFile, args.stageLabel);
+      schemaNames = entries.map((e) => e.schemaName).filter(Boolean);
+      // When a settings file provides values, build a default expectedValues map
+      // — callers wanting to disable the value-match check should pass
+      // --schemaNames directly instead.
+      expectedValuesMap = {};
+      for (const e of entries) {
+        if (e.schemaName) expectedValuesMap[e.schemaName] = e.value;
+      }
+    } catch (err) {
+      process.stderr.write(`Error: ${err.message}\n`);
+      return 1;
+    }
+  }
+  if (args.expectedValues) {
+    try {
+      const override = JSON.parse(args.expectedValues);
+      expectedValuesMap = expectedValuesMap || {};
+      Object.assign(expectedValuesMap, override);
+    } catch (err) {
+      process.stderr.write(`Error: --expectedValues is not valid JSON: ${err.message}\n`);
+      return 1;
+    }
+  }
+
+  if (schemaNames.length === 0) {
+    // Nothing to verify — emit an ok-but-empty result instead of failing.
+    // Caller (deploy-pipeline Phase 7.6.5) treats this as "no env vars were
+    // overridden this run, nothing to check".
+    const out = {
+      ok: true,
+      target: { envUrl: args.envUrl, stageLabel: args.stageLabel || null },
+      summary: { total: 0, landed: 0, missing: 0, mismatched: 0, error: 0 },
+      results: [],
+    };
+    process.stdout.write(JSON.stringify(out, null, 2) + '\n');
+    return 0;
+  }
+
+  // Resolve auth token.
+  let token = args.token;
+  if (!token) {
+    try {
+      token = getAuthToken(args.envUrl);
+    } catch (err) {
+      process.stderr.write(`Failed to acquire token for ${args.envUrl}: ${err.message}\n`);
+      return 1;
+    }
+    if (!token) {
+      process.stderr.write(`Failed to acquire token for ${args.envUrl}\n`);
+      return 1;
+    }
+  }
+
+  try {
+    const result = await verifyEnvVarValues({
+      envUrl: args.envUrl,
+      token,
+      schemaNames,
+      expectedValuesMap,
+      stageLabel: args.stageLabel,
+    });
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+    return 0;
+  } catch (err) {
+    process.stderr.write(`Verification failed: ${err.message}\n`);
+    return 1;
+  }
+}
+
+if (require.main === module) {
+  main(process.argv).then((code) => process.exit(code));
+}
+
+module.exports = {
+  verifyEnvVarValues,
+  verifyOne,
+  readSettingsFile,
+  dedupeBySchemaName,
+  odataString,
+};

--- a/plugins/power-pages/scripts/tests/validate-deployment-settings.test.js
+++ b/plugins/power-pages/scripts/tests/validate-deployment-settings.test.js
@@ -1,0 +1,442 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const helpers = require('../lib/validation-helpers');
+const {
+  validateSettings,
+  classifyEntry,
+  classifyValueFormat,
+  readEntriesPreservingStage,
+  KV_URI_PATTERN,
+  KV_RESOURCE_ID_PATTERN,
+} = require('../lib/validate-deployment-settings');
+
+function withTempDir(t) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'validate-settings-'));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  return dir;
+}
+
+function writeSettings(dir, content) {
+  const file = path.join(dir, 'deployment-settings.json');
+  fs.writeFileSync(file, JSON.stringify(content));
+  return file;
+}
+
+function withMockedRequests(t, handler) {
+  const orig = helpers.makeRequest;
+  helpers.makeRequest = async (opts) => handler(opts);
+  t.after(() => {
+    helpers.makeRequest = orig;
+  });
+}
+
+function odataDefRow(schemaName, typeCode) {
+  return {
+    statusCode: 200,
+    body: JSON.stringify({
+      value: [{ schemaname: schemaName, type: typeCode }],
+    }),
+  };
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Pure regex tests (drive the canonical-format coverage)
+// ────────────────────────────────────────────────────────────────────────────
+
+test('KV_URI_PATTERN matches canonical Key Vault Secret Identifier URIs', () => {
+  // Without version
+  assert.match(
+    'https://lakeshore-staging-kv.vault.azure.net/secrets/api-secret',
+    KV_URI_PATTERN
+  );
+  // With 32-char hex version
+  assert.match(
+    'https://lakeshore-staging-kv.vault.azure.net/secrets/api-secret/a1b2c3d4e5f607080910111213141516',
+    KV_URI_PATTERN
+  );
+  // Minimum vault-name length (3 chars per Azure rules — see
+  // https://learn.microsoft.com/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name)
+  assert.match('https://abc.vault.azure.net/secrets/x', KV_URI_PATTERN);
+});
+
+test('KV_URI_PATTERN rejects near-misses', () => {
+  // Wrong host suffix
+  assert.doesNotMatch(
+    'https://lakeshore-staging-kv.vault.azure.com/secrets/api-secret',
+    KV_URI_PATTERN
+  );
+  // Missing /secrets/ segment
+  assert.doesNotMatch(
+    'https://lakeshore-staging-kv.vault.azure.net/api-secret',
+    KV_URI_PATTERN
+  );
+  // HTTP (not HTTPS)
+  assert.doesNotMatch(
+    'http://lakeshore-staging-kv.vault.azure.net/secrets/api-secret',
+    KV_URI_PATTERN
+  );
+  // Short version suffix (not 32 hex)
+  assert.doesNotMatch(
+    'https://lakeshore-staging-kv.vault.azure.net/secrets/api-secret/abc',
+    KV_URI_PATTERN
+  );
+});
+
+test('KV_RESOURCE_ID_PATTERN matches both resourceGroups and resourcegroups casings', () => {
+  assert.match(
+    '/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/my-rg/providers/Microsoft.KeyVault/vaults/my-vault/secrets/my-secret',
+    KV_RESOURCE_ID_PATTERN
+  );
+  assert.match(
+    '/subscriptions/12345678-1234-1234-1234-123456789012/resourcegroups/my-rg/providers/Microsoft.KeyVault/vaults/my-vault/secrets/my-secret',
+    KV_RESOURCE_ID_PATTERN
+  );
+});
+
+test('classifyValueFormat covers all formats', () => {
+  assert.equal(classifyValueFormat(''), 'empty');
+  assert.equal(classifyValueFormat(null), 'empty');
+  assert.equal(classifyValueFormat(undefined), 'empty');
+  // Vault name must be 3-24 chars per Azure rules
+  assert.equal(
+    classifyValueFormat('https://my-vault.vault.azure.net/secrets/x'),
+    'kv-uri'
+  );
+  // 2-char vault name is structurally invalid → classified as invalid-uri,
+  // not kv-uri (regression guard: don't accept Azure-invalid vault names)
+  assert.equal(
+    classifyValueFormat('https://kv.vault.azure.net/secrets/x'),
+    'invalid-uri'
+  );
+  // Subscription ID is a GUID — regex requires 8+ hex chars matching
+  assert.equal(
+    classifyValueFormat(
+      '/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/rg/providers/Microsoft.KeyVault/vaults/v/secrets/s'
+    ),
+    'kv-resource-id'
+  );
+  assert.equal(
+    classifyValueFormat('@KeyVault(vaultName=foo;secretName=bar)'),
+    'kv-placeholder'
+  );
+  assert.equal(classifyValueFormat('<KEY_VAULT_URI>'), 'kv-placeholder');
+  assert.equal(classifyValueFormat('<TODO>'), 'kv-placeholder');
+  assert.equal(classifyValueFormat('${SECRET_VALUE}'), 'kv-placeholder');
+  // Looks like an HTTPS URL but not a canonical KV URI → invalid-uri
+  assert.equal(
+    classifyValueFormat('https://example.com/some/path'),
+    'invalid-uri'
+  );
+  // Plain text — anything else
+  assert.equal(classifyValueFormat('Citizen Services Portal - Staging'), 'plain-text');
+  assert.equal(classifyValueFormat('true'), 'plain-text');
+  assert.equal(classifyValueFormat('42'), 'plain-text');
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// classifyEntry — per-entry decision logic
+// ────────────────────────────────────────────────────────────────────────────
+
+test('classifyEntry: empty Secret value is valid (use default)', () => {
+  const r = classifyEntry({ schemaName: 'foo', value: '', type: 'Secret' });
+  assert.equal(r.status, 'valid');
+  assert.equal(r.valueFormat, 'empty');
+});
+
+test('classifyEntry: Secret with valid KV URI is valid', () => {
+  const r = classifyEntry({
+    schemaName: 'foo',
+    value: 'https://my-vault.vault.azure.net/secrets/api-secret',
+    type: 'Secret',
+  });
+  assert.equal(r.status, 'valid');
+  assert.equal(r.valueFormat, 'kv-uri');
+});
+
+test('classifyEntry: Secret with @KeyVault(...) placeholder is invalid (error)', () => {
+  const r = classifyEntry({
+    schemaName: 'c311_api_secret',
+    value: '@KeyVault(vaultName=lakeshore-staging-kv;secretName=api-secret)',
+    type: 'Secret',
+  });
+  assert.equal(r.status, 'invalid');
+  assert.equal(r.severity, 'error');
+  assert.equal(r.valueFormat, 'kv-placeholder');
+  assert.match(r.message, /placeholder/);
+  assert.match(r.message, /Phase 3\.B|Phase 7\.2a/);
+});
+
+test('classifyEntry: Secret with plain-text value is invalid (security concern)', () => {
+  const r = classifyEntry({
+    schemaName: 'foo',
+    value: 'sk-actual-secret-value-12345',
+    type: 'Secret',
+  });
+  assert.equal(r.status, 'invalid');
+  assert.equal(r.severity, 'error');
+  assert.equal(r.valueFormat, 'plain-text');
+  assert.match(r.message, /plain-text|plain text/);
+  assert.match(r.message, /committed to git|REMOVE/);
+});
+
+test('classifyEntry: Secret with HTTPS URL that misses canonical shape is invalid-uri', () => {
+  const r = classifyEntry({
+    schemaName: 'foo',
+    value: 'https://my-vault.vault.azure.com/secrets/x', // .com not .net
+    type: 'Secret',
+  });
+  assert.equal(r.status, 'invalid');
+  assert.equal(r.valueFormat, 'invalid-uri');
+});
+
+test('classifyEntry: String type with plain-text value is valid (no Secret rules)', () => {
+  const r = classifyEntry({
+    schemaName: 'foo_label',
+    value: 'Citizen Services Portal - Staging',
+    type: 'String',
+  });
+  assert.equal(r.status, 'valid');
+});
+
+test('classifyEntry: unknown type with placeholder still flagged invalid', () => {
+  // Even without knowing the type, @KeyVault(...) is never valid syntax
+  // for any env var type — surface it.
+  const r = classifyEntry({
+    schemaName: 'foo',
+    value: '@KeyVault(vaultName=v;secretName=s)',
+    type: 'unknown',
+  });
+  assert.equal(r.status, 'invalid');
+  assert.equal(r.severity, 'error');
+});
+
+test('classifyEntry: unknown type with regular value falls back to unknown-type', () => {
+  const r = classifyEntry({
+    schemaName: 'foo',
+    value: 'some-value',
+    type: 'unknown',
+  });
+  assert.equal(r.status, 'unknown-type');
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// File parsing — preserving stage attribution
+// ────────────────────────────────────────────────────────────────────────────
+
+test('readEntriesPreservingStage handles top-level shape (no stages)', (t) => {
+  const dir = withTempDir(t);
+  const file = writeSettings(dir, {
+    EnvironmentVariables: [
+      { SchemaName: 'a', Value: 'va' },
+      { SchemaName: 'b', Value: 'vb' },
+    ],
+  });
+  const entries = readEntriesPreservingStage(file);
+  assert.equal(entries.length, 2);
+  assert.equal(entries[0].stageLabel, null);
+});
+
+test('readEntriesPreservingStage preserves stage names in Stages[] shape', (t) => {
+  const dir = withTempDir(t);
+  const file = writeSettings(dir, {
+    Stages: [
+      { Name: 'Staging', EnvironmentVariables: [{ SchemaName: 'a', Value: 'sa' }] },
+      { Name: 'Production', EnvironmentVariables: [{ SchemaName: 'b', Value: 'pb' }] },
+    ],
+  });
+  const entries = readEntriesPreservingStage(file);
+  assert.equal(entries.length, 2);
+  assert.equal(entries[0].stageLabel, 'Staging');
+  assert.equal(entries[1].stageLabel, 'Production');
+});
+
+test('readEntriesPreservingStage filters by stageLabel (case-insensitive)', (t) => {
+  const dir = withTempDir(t);
+  const file = writeSettings(dir, {
+    Stages: [
+      { Name: 'Staging', EnvironmentVariables: [{ SchemaName: 'a', Value: 'sa' }] },
+      { Name: 'Production', EnvironmentVariables: [{ SchemaName: 'b', Value: 'pb' }] },
+    ],
+  });
+  const entries = readEntriesPreservingStage(file, 'production');
+  assert.equal(entries.length, 1);
+  assert.equal(entries[0].schemaName, 'b');
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// validateSettings — end-to-end orchestration
+// ────────────────────────────────────────────────────────────────────────────
+
+test('validateSettings without envUrl: structural-only, all entries unknown-type', async (t) => {
+  const dir = withTempDir(t);
+  const file = writeSettings(dir, {
+    EnvironmentVariables: [
+      { SchemaName: 'a', Value: 'plain-value' },
+      { SchemaName: 'b', Value: '' },
+    ],
+  });
+  const result = await validateSettings({ settingsFile: file });
+  assert.equal(result.summary.total, 2);
+  // 'b' is empty → valid; 'a' is unknown-type (no envUrl to look up)
+  assert.equal(result.summary.valid, 1);
+  assert.equal(result.summary['unknown-type'], 1);
+  assert.equal(result.summary.invalid, 0);
+});
+
+test('validateSettings without envUrl: placeholder still flagged invalid', async (t) => {
+  const dir = withTempDir(t);
+  const file = writeSettings(dir, {
+    EnvironmentVariables: [
+      { SchemaName: 'foo', Value: '@KeyVault(vaultName=v;secretName=s)' },
+    ],
+  });
+  const result = await validateSettings({ settingsFile: file });
+  // No type lookup, but placeholder syntax is invalid for any type.
+  assert.equal(result.summary.invalid, 1);
+  assert.equal(result.findings[0].severity, 'error');
+});
+
+test('validateSettings with envUrl: classifies Secret entries correctly', async (t) => {
+  const dir = withTempDir(t);
+  const file = writeSettings(dir, {
+    EnvironmentVariables: [
+      { SchemaName: 'c311_api_secret', Value: '@KeyVault(vaultName=v;secretName=s)' },
+      { SchemaName: 'c311_feature_label', Value: 'Production' },
+    ],
+  });
+
+  withMockedRequests(t, async (opts) => {
+    if (opts.url.includes("schemaname eq 'c311_api_secret'")) {
+      return odataDefRow('c311_api_secret', 100000005); // Secret
+    }
+    if (opts.url.includes("schemaname eq 'c311_feature_label'")) {
+      return odataDefRow('c311_feature_label', 100000000); // String
+    }
+    return { statusCode: 200, body: JSON.stringify({ value: [] }) };
+  });
+
+  const result = await validateSettings({
+    settingsFile: file,
+    envUrl: 'https://dev.crm.dynamics.com',
+    token: 'mock-token',
+  });
+
+  assert.equal(result.summary.total, 2);
+  // c311_api_secret: Secret type + placeholder → invalid
+  // c311_feature_label: String type + plain text → valid
+  assert.equal(result.summary.invalid, 1);
+  assert.equal(result.summary.valid, 1);
+
+  const secretFinding = result.findings.find((f) => f.schemaName === 'c311_api_secret');
+  assert.equal(secretFinding.type, 'Secret');
+  assert.equal(secretFinding.status, 'invalid');
+  assert.equal(secretFinding.valueFormat, 'kv-placeholder');
+});
+
+test('validateSettings: missing SchemaName flagged as invalid', async (t) => {
+  const dir = withTempDir(t);
+  const file = writeSettings(dir, {
+    EnvironmentVariables: [
+      { Value: 'some-value' }, // no SchemaName
+    ],
+  });
+  const result = await validateSettings({ settingsFile: file });
+  assert.equal(result.summary.invalid, 1);
+  assert.equal(result.findings[0].schemaName, null);
+  assert.match(result.findings[0].message, /no SchemaName|missing or empty/i);
+});
+
+test('validateSettings: stageLabel filtering works end-to-end', async (t) => {
+  const dir = withTempDir(t);
+  const file = writeSettings(dir, {
+    Stages: [
+      {
+        Name: 'Staging',
+        EnvironmentVariables: [
+          { SchemaName: 'foo', Value: '@KeyVault(vaultName=v;secretName=s)' },
+        ],
+      },
+      {
+        Name: 'Production',
+        EnvironmentVariables: [
+          { SchemaName: 'foo', Value: 'https://prod-vault.vault.azure.net/secrets/foo' },
+        ],
+      },
+    ],
+  });
+
+  const stagingResult = await validateSettings({ settingsFile: file, stageLabel: 'Staging' });
+  assert.equal(stagingResult.summary.total, 1);
+  assert.equal(stagingResult.summary.invalid, 1);
+
+  const prodResult = await validateSettings({ settingsFile: file, stageLabel: 'Production' });
+  assert.equal(prodResult.summary.total, 1);
+  // Without envUrl the value is unknown-type, but the URI matches canonical
+  // KV-URI shape — that's a valid KV-URI regardless of type, so we mark
+  // it as valid only when type === Secret. Without type lookup it stays
+  // unknown-type. The contract: validation is conservative without
+  // envUrl. Test for both possibilities.
+  assert.ok(
+    prodResult.summary.valid + prodResult.summary['unknown-type'] === 1,
+    'prod entry should land in valid or unknown-type'
+  );
+});
+
+test('validateSettings: throws on missing file (caller catches → exit 1)', async () => {
+  await assert.rejects(
+    validateSettings({ settingsFile: '/tmp/nonexistent-deployment-settings.json' }),
+    /could not read/
+  );
+});
+
+test('validateSettings: throws on invalid JSON', async (t) => {
+  const dir = withTempDir(t);
+  const file = path.join(dir, 'deployment-settings.json');
+  fs.writeFileSync(file, '{ not valid json');
+  await assert.rejects(validateSettings({ settingsFile: file }), /could not read|Unexpected token|JSON/);
+});
+
+test('validateSettings: empty EnvironmentVariables[] returns clean summary', async (t) => {
+  const dir = withTempDir(t);
+  const file = writeSettings(dir, { EnvironmentVariables: [] });
+  const result = await validateSettings({ settingsFile: file });
+  assert.equal(result.summary.total, 0);
+  assert.equal(result.summary.invalid, 0);
+  assert.equal(result.findings.length, 0);
+});
+
+test('validateSettings: aggregates multiple findings with mixed severities', async (t) => {
+  const dir = withTempDir(t);
+  const file = writeSettings(dir, {
+    EnvironmentVariables: [
+      { SchemaName: 'a', Value: '@KeyVault(...)' },
+      // 8-char vault name → matches canonical KV-URI shape
+      { SchemaName: 'b', Value: 'https://my-vault.vault.azure.net/secrets/x' },
+      { SchemaName: 'c', Value: '' },
+      { SchemaName: 'd', Value: '<TODO>' },
+    ],
+  });
+
+  withMockedRequests(t, async (opts) => {
+    // All four are Secret type
+    const match = opts.url.match(/schemaname eq '([^']+)'/);
+    if (match) return odataDefRow(match[1], 100000005);
+    return { statusCode: 200, body: JSON.stringify({ value: [] }) };
+  });
+
+  const result = await validateSettings({
+    settingsFile: file,
+    envUrl: 'https://dev/',
+    token: 'mock-token',
+  });
+
+  assert.equal(result.summary.total, 4);
+  assert.equal(result.summary.invalid, 2); // a, d (both placeholders)
+  assert.equal(result.summary.valid, 2); // b (kv-uri), c (empty)
+});

--- a/plugins/power-pages/scripts/tests/verify-env-var-values.test.js
+++ b/plugins/power-pages/scripts/tests/verify-env-var-values.test.js
@@ -1,0 +1,416 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const helpers = require('../lib/validation-helpers');
+const {
+  verifyEnvVarValues,
+  verifyOne,
+  readSettingsFile,
+  dedupeBySchemaName,
+  odataString,
+} = require('../lib/verify-env-var-values');
+
+// Mock makeRequest so tests don't talk to a real Dataverse env.
+// Each test installs its own handler keyed off the URL/query.
+function withMockedRequests(t, handler) {
+  const orig = helpers.makeRequest;
+  const calls = [];
+  helpers.makeRequest = async (opts) => {
+    calls.push(opts);
+    return handler(opts, calls.length);
+  };
+  t.after(() => {
+    helpers.makeRequest = orig;
+  });
+  return calls;
+}
+
+function odataResponse(rows) {
+  return { statusCode: 200, body: JSON.stringify({ value: rows }) };
+}
+
+function odataError(statusCode, message) {
+  return { statusCode, body: JSON.stringify({ error: { message } }) };
+}
+
+// Helper: build a route map { '/api/data/...' → response } so each test reads
+// like a table of fixtures rather than nested switch statements.
+function routeHandler(routes) {
+  return async (opts) => {
+    for (const [pattern, response] of Object.entries(routes)) {
+      if (opts.url.includes(pattern)) {
+        return typeof response === 'function' ? response(opts) : response;
+      }
+    }
+    return { statusCode: 404, body: JSON.stringify({ error: { message: 'no route' } }) };
+  };
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Pure-function tests (no network)
+// ──────────────────────────────────────────────────────────────────────────────
+
+test('odataString escapes single quotes per OData spec', () => {
+  assert.equal(odataString('foo'), 'foo');
+  assert.equal(odataString("foo's bar"), "foo''s bar");
+  assert.equal(odataString("'"), "''");
+});
+
+test('dedupeBySchemaName keeps the first occurrence of each schema name', () => {
+  const out = dedupeBySchemaName([
+    { schemaName: 'a', value: '1' },
+    { schemaName: 'b', value: '2' },
+    { schemaName: 'a', value: '3' },
+  ]);
+  assert.equal(out.length, 2);
+  assert.equal(out[0].value, '1');
+  assert.equal(out[1].schemaName, 'b');
+});
+
+test('dedupeBySchemaName drops entries with falsy schemaName', () => {
+  const out = dedupeBySchemaName([
+    { schemaName: '', value: '1' },
+    { schemaName: 'a', value: '2' },
+    { schemaName: null, value: '3' },
+  ]);
+  assert.equal(out.length, 1);
+  assert.equal(out[0].schemaName, 'a');
+});
+
+test('readSettingsFile reads top-level EnvironmentVariables shape', async (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'verify-env-'));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const file = path.join(dir, 'deployment-settings.json');
+  fs.writeFileSync(
+    file,
+    JSON.stringify({
+      EnvironmentVariables: [
+        { SchemaName: 'foo_a', Value: 'a-value' },
+        { SchemaName: 'foo_b', Value: 'b-value' },
+      ],
+    })
+  );
+  const entries = readSettingsFile(file);
+  assert.deepEqual(entries, [
+    { schemaName: 'foo_a', value: 'a-value' },
+    { schemaName: 'foo_b', value: 'b-value' },
+  ]);
+});
+
+test('readSettingsFile filters Stages[] by stageLabel (case-insensitive)', async (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'verify-env-'));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const file = path.join(dir, 'deployment-settings.json');
+  fs.writeFileSync(
+    file,
+    JSON.stringify({
+      Stages: [
+        {
+          Name: 'Staging',
+          EnvironmentVariables: [{ SchemaName: 'foo_a', Value: 'staging-a' }],
+        },
+        {
+          Name: 'Production',
+          EnvironmentVariables: [
+            { SchemaName: 'foo_a', Value: 'prod-a' },
+            { SchemaName: 'foo_b', Value: 'prod-b' },
+          ],
+        },
+      ],
+    })
+  );
+  const stagingEntries = readSettingsFile(file, 'staging');
+  assert.deepEqual(stagingEntries, [{ schemaName: 'foo_a', value: 'staging-a' }]);
+  const prodEntries = readSettingsFile(file, 'Production');
+  assert.equal(prodEntries.length, 2);
+  assert.equal(prodEntries[1].value, 'prod-b');
+});
+
+test('readSettingsFile with no stageLabel flattens Stages[]', async (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'verify-env-'));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const file = path.join(dir, 'deployment-settings.json');
+  fs.writeFileSync(
+    file,
+    JSON.stringify({
+      Stages: [
+        { Name: 'Staging', EnvironmentVariables: [{ SchemaName: 'foo_a', Value: 'staging-a' }] },
+        { Name: 'Production', EnvironmentVariables: [{ SchemaName: 'foo_b', Value: 'prod-b' }] },
+      ],
+    })
+  );
+  const entries = readSettingsFile(file);
+  // Both stages flattened, deduped by schema name (first wins)
+  assert.equal(entries.length, 2);
+  assert.equal(entries[0].schemaName, 'foo_a');
+  assert.equal(entries[1].schemaName, 'foo_b');
+});
+
+test('readSettingsFile throws on missing file', () => {
+  assert.throws(() => readSettingsFile('/tmp/nonexistent-deployment-settings.json'));
+});
+
+test('readSettingsFile throws on invalid JSON', async (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'verify-env-'));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const file = path.join(dir, 'deployment-settings.json');
+  fs.writeFileSync(file, '{ not valid json');
+  assert.throws(() => readSettingsFile(file));
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// verifyOne — single-schema Dataverse query semantics
+// ──────────────────────────────────────────────────────────────────────────────
+
+test('verifyOne returns "landed" when both definition and value exist', async (t) => {
+  withMockedRequests(
+    t,
+    routeHandler({
+      'environmentvariabledefinitions': odataResponse([
+        { environmentvariabledefinitionid: 'def-1', schemaname: 'foo_a', type: 100000000 },
+      ]),
+      'environmentvariablevalues': odataResponse([
+        { environmentvariablevalueid: 'val-1', value: 'expected-value' },
+      ]),
+    })
+  );
+  const r = await verifyOne('https://target/', 'tok', 'foo_a');
+  assert.equal(r.status, 'landed');
+  assert.equal(r.definitionId, 'def-1');
+  assert.equal(r.valueId, 'val-1');
+  assert.equal(r.value, 'expected-value');
+});
+
+test('verifyOne returns "missing-definition" when schema name not found', async (t) => {
+  withMockedRequests(
+    t,
+    routeHandler({
+      'environmentvariabledefinitions': odataResponse([]),
+    })
+  );
+  const r = await verifyOne('https://target/', 'tok', 'foo_a');
+  assert.equal(r.status, 'missing-definition');
+  assert.equal(r.definitionId, null);
+});
+
+test('verifyOne returns "missing-value-record" when definition exists but no value row', async (t) => {
+  withMockedRequests(
+    t,
+    routeHandler({
+      'environmentvariabledefinitions': odataResponse([
+        { environmentvariabledefinitionid: 'def-1', schemaname: 'foo_a' },
+      ]),
+      'environmentvariablevalues': odataResponse([]),
+    })
+  );
+  const r = await verifyOne('https://target/', 'tok', 'foo_a');
+  assert.equal(r.status, 'missing-value-record');
+  assert.equal(r.definitionId, 'def-1');
+  assert.equal(r.valueId, null);
+});
+
+test('verifyOne returns "value-mismatch" when expectedValue does not match landed value', async (t) => {
+  withMockedRequests(
+    t,
+    routeHandler({
+      'environmentvariabledefinitions': odataResponse([
+        { environmentvariabledefinitionid: 'def-1', schemaname: 'foo_a' },
+      ]),
+      'environmentvariablevalues': odataResponse([
+        { environmentvariablevalueid: 'val-1', value: 'actual-value' },
+      ]),
+    })
+  );
+  const r = await verifyOne('https://target/', 'tok', 'foo_a', 'expected-other-value');
+  assert.equal(r.status, 'value-mismatch');
+  assert.equal(r.value, 'actual-value');
+  assert.equal(r.expected, 'expected-other-value');
+});
+
+test('verifyOne returns "landed" when expectedValue matches', async (t) => {
+  withMockedRequests(
+    t,
+    routeHandler({
+      'environmentvariabledefinitions': odataResponse([
+        { environmentvariabledefinitionid: 'def-1', schemaname: 'foo_a' },
+      ]),
+      'environmentvariablevalues': odataResponse([
+        { environmentvariablevalueid: 'val-1', value: 'same-value' },
+      ]),
+    })
+  );
+  const r = await verifyOne('https://target/', 'tok', 'foo_a', 'same-value');
+  assert.equal(r.status, 'landed');
+  assert.equal(r.expected, 'same-value');
+});
+
+test('verifyOne returns "query-error" when definition lookup fails', async (t) => {
+  withMockedRequests(t, async () => odataError(403, 'Forbidden'));
+  const r = await verifyOne('https://target/', 'tok', 'foo_a');
+  assert.equal(r.status, 'query-error');
+  assert.ok(r.error);
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// verifyEnvVarValues — multi-schema aggregation
+// ──────────────────────────────────────────────────────────────────────────────
+
+test('verifyEnvVarValues throws when envUrl missing', async () => {
+  await assert.rejects(
+    verifyEnvVarValues({ schemaNames: ['foo_a'] }),
+    /envUrl is required/
+  );
+});
+
+test('verifyEnvVarValues throws when schemaNames is empty', async () => {
+  await assert.rejects(
+    verifyEnvVarValues({ envUrl: 'https://target/', schemaNames: [] }),
+    /non-empty array/
+  );
+});
+
+test('verifyEnvVarValues aggregates a mixed result (1 landed, 1 missing-value, 1 missing-def)', async (t) => {
+  // Each schema does 2 calls in sequence (def, value). Track which schema by
+  // counting calls — schema 0 = calls 1+2, schema 1 = calls 3+4, schema 2 = call 5.
+  withMockedRequests(t, async (opts, callNum) => {
+    // schema "foo_landed" → both succeed
+    if (callNum === 1) {
+      return odataResponse([
+        { environmentvariabledefinitionid: 'def-1', schemaname: 'foo_landed' },
+      ]);
+    }
+    if (callNum === 2) {
+      return odataResponse([{ environmentvariablevalueid: 'val-1', value: 'v1' }]);
+    }
+    // schema "foo_missing_value" → def exists, no value
+    if (callNum === 3) {
+      return odataResponse([
+        { environmentvariabledefinitionid: 'def-2', schemaname: 'foo_missing_value' },
+      ]);
+    }
+    if (callNum === 4) {
+      return odataResponse([]);
+    }
+    // schema "foo_missing_def" → def doesn't exist (short-circuits, no value call)
+    if (callNum === 5) {
+      return odataResponse([]);
+    }
+    return odataResponse([]);
+  });
+
+  const result = await verifyEnvVarValues({
+    envUrl: 'https://target/',
+    token: 'tok',
+    schemaNames: ['foo_landed', 'foo_missing_value', 'foo_missing_def'],
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.summary.total, 3);
+  assert.equal(result.summary.landed, 1);
+  assert.equal(result.summary.missing, 2); // missing-value + missing-definition
+  assert.equal(result.summary.mismatched, 0);
+  assert.equal(result.summary.error, 0);
+
+  assert.equal(result.results[0].status, 'landed');
+  assert.equal(result.results[1].status, 'missing-value-record');
+  assert.equal(result.results[2].status, 'missing-definition');
+});
+
+test('verifyEnvVarValues populates summary.mismatched when expectedValues used', async (t) => {
+  withMockedRequests(
+    t,
+    routeHandler({
+      'environmentvariabledefinitions': odataResponse([
+        { environmentvariabledefinitionid: 'def-1', schemaname: 'foo_a' },
+      ]),
+      'environmentvariablevalues': odataResponse([
+        { environmentvariablevalueid: 'val-1', value: 'actual' },
+      ]),
+    })
+  );
+  const result = await verifyEnvVarValues({
+    envUrl: 'https://target/',
+    token: 'tok',
+    schemaNames: ['foo_a'],
+    expectedValuesMap: { foo_a: 'expected-different' },
+  });
+  assert.equal(result.summary.mismatched, 1);
+  assert.equal(result.summary.landed, 0);
+  assert.equal(result.results[0].status, 'value-mismatch');
+});
+
+test('verifyEnvVarValues includes stageLabel in target block when provided', async (t) => {
+  withMockedRequests(
+    t,
+    routeHandler({
+      'environmentvariabledefinitions': odataResponse([
+        { environmentvariabledefinitionid: 'def-1', schemaname: 'foo_a' },
+      ]),
+      'environmentvariablevalues': odataResponse([
+        { environmentvariablevalueid: 'val-1', value: 'v' },
+      ]),
+    })
+  );
+  const result = await verifyEnvVarValues({
+    envUrl: 'https://target/',
+    token: 'tok',
+    schemaNames: ['foo_a'],
+    stageLabel: 'Production',
+  });
+  assert.equal(result.target.stageLabel, 'Production');
+});
+
+test("verifyEnvVarValues handles schema names with single quotes (OData escape)", async (t) => {
+  // Defensive: schema names shouldn't have quotes in practice, but if a user
+  // coins a slug that survives validation, the OData literal must escape.
+  const calls = withMockedRequests(
+    t,
+    routeHandler({
+      'environmentvariabledefinitions': odataResponse([]),
+    })
+  );
+  await verifyEnvVarValues({
+    envUrl: 'https://target/',
+    token: 'tok',
+    schemaNames: ["foo's_special"],
+  });
+  // The URL passed to makeRequest should have a doubled single-quote.
+  assert.ok(calls[0].url.includes("foo''s_special"));
+});
+
+test('verifyEnvVarValues records query-error per schema without aborting the run', async (t) => {
+  withMockedRequests(t, async (opts, callNum) => {
+    // First schema: lookup succeeds but value query 403s.
+    if (callNum === 1) {
+      return odataResponse([
+        { environmentvariabledefinitionid: 'def-1', schemaname: 'foo_a' },
+      ]);
+    }
+    if (callNum === 2) {
+      return odataError(403, 'Forbidden');
+    }
+    // Second schema: both succeed.
+    if (callNum === 3) {
+      return odataResponse([
+        { environmentvariabledefinitionid: 'def-2', schemaname: 'foo_b' },
+      ]);
+    }
+    if (callNum === 4) {
+      return odataResponse([{ environmentvariablevalueid: 'val-2', value: 'v2' }]);
+    }
+    return odataResponse([]);
+  });
+  const result = await verifyEnvVarValues({
+    envUrl: 'https://target/',
+    token: 'tok',
+    schemaNames: ['foo_a', 'foo_b'],
+  });
+  assert.equal(result.summary.error, 1);
+  assert.equal(result.summary.landed, 1);
+  assert.equal(result.results[0].status, 'query-error');
+  assert.equal(result.results[1].status, 'landed');
+});

--- a/plugins/power-pages/skills/configure-env-variables/SKILL.md
+++ b/plugins/power-pages/skills/configure-env-variables/SKILL.md
@@ -186,26 +186,26 @@ Setting: Authentication/Registration/LocalLoginEnabled
 
 ## Phase 3 — Create Environment Variable Definitions
 
-For each planned env var:
+For each planned env var, branch on `typeCode`:
 
-**3.1 Check and create if needed** using `create-env-var-definition.js` (the script checks for an existing definition by `schemaName` before posting):
+### 3.A — String env vars (`typeCode = 100000000`)
+
+Definition-only flow — per-stage values come later from `deployment-settings.json` via `deploymentsettingsjson` PATCH at deploy time.
+
+**3.A.1 Check and create if needed** using `create-env-var-definition.js` (the script checks for an existing definition by `schemaName` before posting):
 ```bash
 node "${CLAUDE_PLUGIN_ROOT}/scripts/lib/create-env-var-definition.js" \
   --envUrl "{devEnvUrl}" \
   --token "{TOKEN}" \
   --schemaName "{schemaName}" \
   --displayName "{displayName}" \
-  --type {typeCode} \
+  --type 100000000 \
   --defaultValue "{devValue}"
 ```
 
-Type codes:
-- `100000000` = String (use for all site settings — runtime resolves as string)
-- `100000005` = Secret (for credentials — value stored in Azure Key Vault or encrypted)
-
 Capture output as JSON; extract `.definitionId` (store as `envVarDefId`) and check `.created` (true = newly created, false = already existed). If already existed, confirm the existing definition matches expectations before proceeding.
 
-**3.3 Create the current-environment value** (the live dev value, separate from defaultvalue):
+**3.A.2 Create the current-environment value** (the live dev value, separate from defaultvalue):
 ```
 POST {devEnvUrl}/api/data/v9.2/environmentvariablevalues
 Content-Type: application/json
@@ -217,6 +217,44 @@ Content-Type: application/json
 ```
 
 Response: **HTTP 204**.
+
+### 3.B — Secret env vars (`typeCode = 100000005`) when a Key Vault Secret URI is available
+
+When the user has already stored the secret in Azure Key Vault and has a Secret Identifier URI (shape: `https://<vault>.vault.azure.net/secrets/<name>/<version>`), use the atomic deep-insert path — the same flow `add-server-logic` Phase 7.2a uses:
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/create-environment-variable.js" "{devEnvUrl}" \
+  --schemaName "{schemaName}" \
+  --displayName "{displayName}" \
+  --type secret \
+  --value "{secretUri}"
+```
+
+This script POSTs a single deep-insert that creates the `environmentvariabledefinition` (type 100000005) AND the `environmentvariablevalues` row with the Key Vault URI in `value` — Dataverse resolves the secret at runtime by dereferencing the URI. The script is ALM-aware and adds the new definition to the target solution via `AddSolutionComponent` (same `resolve-target-solution.js` resolution order as the rest of the family).
+
+> **Cross-reference: see `${CLAUDE_PLUGIN_ROOT}/skills/add-server-logic/SKILL.md` Phase 7.2a** for the full Key Vault end-to-end: vault selection (`list-azure-keyvaults.js` / `create-azure-keyvault.js`), secret storage (`store-keyvault-secret.js` with stdin to keep the secret out of the conversation), and the URI handoff back to env-var creation. The implementation is identical; we re-use the same helper scripts.
+
+### 3.C — Secret env vars without a Key Vault URI (legacy / deferred)
+
+When the user has not chosen Key Vault yet or hasn't stored the secret, create the definition with an empty value placeholder and instruct the user to wire the value via Power Platform Admin Center after import:
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/lib/create-env-var-definition.js" \
+  --envUrl "{devEnvUrl}" \
+  --token "{TOKEN}" \
+  --schemaName "{schemaName}" \
+  --displayName "{displayName}" \
+  --type 100000005
+```
+
+(omit `--defaultValue` — Dataverse stores Secret-type definitions with no default until a `environmentvariablevalues` row is added). Tell the user the value must be set per target environment via PPAC → Solutions → Environment Variables → select → set value. This path is the legacy fallback; the dedicated `configure-secrets` skill (queued for a follow-up PR) will eventually orchestrate 3.B for credential-style settings end-to-end.
+
+### Type-code reference
+
+- `100000000` = String — flows via path 3.A.
+- `100000005` = Secret — flows via path 3.B (preferred when Key Vault URI is available) or 3.C (deferred / legacy).
+
+Other canonical types (`100000001` Number, `100000002` Boolean, `100000003` JSON, `100000004` DataSource) follow path 3.A with the appropriate `--type` code.
 
 Track created env var IDs: `{ schemaName, envVarDefId, siteSettingName, devValue, stageValues: { stageName: value } }`.
 
@@ -304,6 +342,16 @@ After upload, check the updated YAML file — it should now contain `source: 1` 
 ```
 GET {devEnvUrl}/api/data/v9.2/solutioncomponents?$filter=_solutionid_value eq {solutionId} and componenttype eq 380
 ```
+
+**7.2b Verify values landed on dev env.** After creating the definitions + values, query the dev env to confirm each `environmentvariablevalues` row exists. The shared helper `scripts/lib/verify-env-var-values.js` does this read-only check:
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/lib/verify-env-var-values.js" \
+  --envUrl "{devEnvUrl}" \
+  --schemaNames "{comma-separated schema names just created}"
+```
+
+Capture stdout as JSON. If `summary.landed === summary.total`, the local definition+value chain is healthy and `deploy-pipeline` Phase 5.2's `deploymentsettingsjson` PATCH will have what it needs. If `summary.missing > 0`, log a one-line warning and recommend re-running configure-env-variables — most likely cause is a transient OData write failure that left a definition without its paired value. The same helper runs at deploy time (deploy-pipeline Phase 7.6.5) against the target env; centralizing the check keeps the diagnostic shape consistent across the dev-side write and the target-side landing.
 
 **7.3 Commit:**
 ```bash

--- a/plugins/power-pages/skills/configure-env-variables/SKILL.md
+++ b/plugins/power-pages/skills/configure-env-variables/SKILL.md
@@ -220,7 +220,37 @@ Response: **HTTP 204**.
 
 ### 3.B — Secret env vars (`typeCode = 100000005`) when a Key Vault Secret URI is available
 
-When the user has already stored the secret in Azure Key Vault and has a Secret Identifier URI (shape: `https://<vault>.vault.azure.net/secrets/<name>/<version>`), use the atomic deep-insert path — the same flow `add-server-logic` Phase 7.2a uses:
+#### Acceptable Secret reference formats
+
+Dataverse / the Power Platform Pipelines handler accept exactly three formats for a Secret-type env var value. Anything else is rejected at import time with *"ImportAsHolding failed: The value provided as a secret reference does not match a valid secret reference format"* — and the rejection can come hours after the deploy queues, since the host serializes imports. The pre-deploy validator (`deploy-pipeline` Phase 5.1b, helper at `scripts/lib/validate-deployment-settings.js`) catches these formats upfront, but they're documented here so SKILL.md authors writing to `deployment-settings.json` use the right shape from the start.
+
+**Accepted:**
+
+1. **Key Vault Secret Identifier URI** — what `store-keyvault-secret.js` emits in its `secretUri` output:
+   ```
+   https://<vault>.vault.azure.net/secrets/<name>
+   https://<vault>.vault.azure.net/secrets/<name>/<32-char-hex-version>
+   ```
+   Vault name must be 3–24 chars, lowercase alphanumeric + hyphens, start with a letter, end with a letter or digit. This is the canonical form and the one `add-server-logic` Phase 7.2a hands back via the user-visible "share the secretUri output" step.
+
+2. **Azure resource ID** — the full ARM-style path, when the maker doesn't have the URI form handy:
+   ```
+   /subscriptions/<subscriptionId>/resourceGroups/<rg>/providers/Microsoft.KeyVault/vaults/<vault>/secrets/<name>
+   ```
+   Both `resourceGroups` and `resourcegroups` casings are accepted by Dataverse.
+
+3. **Empty string `""`** — legitimate when the env var has a sensible default-value baked into the definition. Per-stage `Value: ""` in `deployment-settings.json` means *"use the definition default in this stage."*
+
+**Rejected (validator flags these):**
+
+- `@KeyVault(vaultName=<vault>;secretName=<name>)` — a templating-style placeholder. **NOT recognized by Dataverse.** Real-world failure case from a live session: this exact pattern caused a 4h41m queue wait + ImportAsHolding failure. Replace with form (1) or (2).
+- `<TODO>`, `<KEY_VAULT_URI>`, `<PLACEHOLDER>`, `${ENV_VAR}` — any angle-bracketed or shell-style placeholder. Same story; these are maker conventions Dataverse does not parse.
+- Plain-text secret values — both insecure (the file is committed to git) AND rejected by Dataverse when the env var type is Secret. If the maker intended plain text, the env var type should be String (`100000000`), not Secret (`100000005`).
+- HTTPS URLs that look like Key Vault URIs but miss the canonical shape (`.com` host suffix instead of `.net`, missing `/secrets/` segment, short version suffix). The validator flags these specifically as `invalid-uri` so the maker can fix the typo rather than re-coining the value.
+
+#### Implementation
+
+When the user has already stored the secret in Azure Key Vault and has a Secret Identifier URI in canonical form, use the atomic deep-insert path — the same flow `add-server-logic` Phase 7.2a uses:
 
 ```bash
 node "${CLAUDE_PLUGIN_ROOT}/scripts/create-environment-variable.js" "{devEnvUrl}" \

--- a/plugins/power-pages/skills/deploy-pipeline/SKILL.md
+++ b/plugins/power-pages/skills/deploy-pipeline/SKILL.md
@@ -493,6 +493,41 @@ If Yes: write/update `deployment-settings.json` with the collected values under 
 
 **If all env vars are pre-configured** (or there are none): skip the prompt, use `preconfigured` directly.
 
+**5.1b Pre-PATCH validation of `deployment-settings.json` Secret references.**
+
+> **Why this gate exists.** The Power Platform Pipelines handler validates the `deploymentsettingsjson` PATCH at import time, AFTER the stage run has been queued and potentially after a long wait behind serialized imports. A bad Secret reference value — placeholder syntax like `@KeyVault(vaultName=...;secretName=...)`, raw secret values committed to the file, malformed URIs — fails the import with *"ImportAsHolding failed: The value provided as a secret reference does not match a valid secret reference format."* Live evidence: a 4h41m queue wait + fail in a recent session. Catching the bad reference here turns hours of wasted compute into a sub-second hard stop with a precise remediation pointer.
+
+Skip this step entirely when `ENV_VAR_OVERRIDES` is empty AND `deployment-settings.json` is absent — there's nothing to validate.
+
+Otherwise, run the shared helper:
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/lib/validate-deployment-settings.js" \
+  --settingsFile "./deployment-settings.json" \
+  --envUrl "{sourceEnvUrl}" \
+  --stageLabel "{SELECTED_STAGE.name}"
+```
+
+Capture stdout as JSON. The helper classifies each `EnvironmentVariables[]` entry by `valueFormat` (`kv-uri` / `kv-resource-id` / `kv-placeholder` / `empty` / `plain-text` / `invalid-uri`) and `status` (`valid` / `invalid` / `unknown-type` / `skipped`). When `--envUrl` is provided (as above), Secret-type entries are validated against the canonical Key Vault reference formats; other types are structurally validated.
+
+Branch on `summary`:
+
+- **`summary.invalid === 0`** → all entries valid, proceed to Phase 5.2.
+- **`summary.invalid > 0`** → STOP. Display the invalid `findings[]` to the user with each entry's `schemaName`, `valueFormat`, `value`, and `message`. Then surface a remediation message:
+
+  > "Pre-deploy validation found `{summary.invalid}` invalid env var value(s) in `deployment-settings.json`. The Power Platform Pipelines handler would reject these during import (potentially after a long queue wait). Fix the file before re-running this skill.
+  >
+  > Canonical formats for Secret env vars:
+  >   1. Key Vault Secret Identifier URI: `https://<vault>.vault.azure.net/secrets/<name>[/<version>]`
+  >   2. Azure resource ID: `/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.KeyVault/vaults/<vault>/secrets/<name>`
+  >   3. Empty (use the env var definition's default)
+  >
+  > See `configure-env-variables` Phase 3.B and `add-server-logic` Phase 7.2a for the end-to-end flow (vault selection → secret storage → URI handoff)."
+
+  Do NOT prompt for "proceed anyway" — there's no partial-validity case where forcing the bad PATCH leads to a successful import. The deploy will fail; only the wait time changes.
+
+- **`summary.invalid === 0 && summary.['unknown-type'] > 0`** → log a one-line warning about the schemas whose types couldn't be looked up (probably auth or transient errors) and proceed. The downstream handler will still reject obvious garbage; the pre-PATCH gate is a fast-path, not the only line of defense.
+
 **5.2 PATCH stage run with artifact version, deployment notes, and environment variables** (always run):
 
 First, determine the current solution version in the **source (dev) environment** — this must match exactly:

--- a/plugins/power-pages/skills/deploy-pipeline/SKILL.md
+++ b/plugins/power-pages/skills/deploy-pipeline/SKILL.md
@@ -855,24 +855,29 @@ If **Exit**: stop and present the failure summary above.
 
 **7.6.5 Verify `environmentvariablevalues` landed on the target** (only if deployment **Succeeded** AND `ENV_VAR_OVERRIDES` was non-empty AND `deploymentsettingsjson` was PATCHed in Phase 5.2):
 
-Even when the stage run reports success, the Power Platform Pipelines handler does not always write `environmentvariablevalues` records for every env var definition in `deploymentsettingsjson` — definitions that aren't bound to an `mspp_sitesetting` (or another consumer the platform recognizes) can land as zero-value on the target. See the caveat note above Phase 6 for the live evidence. This step closes the gap.
+Even when the stage run reports success, the Power Platform Pipelines handler does not always write `environmentvariablevalues` records for every env var definition in `deploymentsettingsjson` — definitions that aren't bound to an `mspp_sitesetting` (or another consumer the platform recognizes) can land as zero-value on the target. See the caveat note above Phase 6 for the live evidence. This step closes the gap by querying the target post-deploy and surfacing any missed landings.
 
-For each `SchemaName` in `ENV_VAR_OVERRIDES`:
+Use the shared helper `scripts/lib/verify-env-var-values.js`. It reads schema names + per-stage expected values from `deployment-settings.json` and returns a structured JSON result per schema (`landed` / `missing-value-record` / `missing-definition` / `value-mismatch` / `query-error`):
 
-1. Look up the definition GUID on the target:
-   ```
-   GET {targetEnvUrl}/api/data/v9.2/environmentvariabledefinitions?$filter=schemaname eq '{schemaName}'&$select=environmentvariabledefinitionid
-   ```
-2. Query for a current value record:
-   ```
-   GET {targetEnvUrl}/api/data/v9.2/environmentvariablevalues?$filter=_environmentvariabledefinitionid_value eq '{definitionId}'&$select=value
-   ```
-3. If `value.length === 0` for ANY of the entries that should have landed:
-   - Log a structured warning into `docs/alm/last-deploy.json` under a new `envVarLandingWarnings[]` array — one entry per missed schemaName.
-   - Surface to the user via the deploy summary: *"`{N}` environment variable values from `deploymentsettingsjson` did not land on `{targetEnvName}`. Most likely cause: the definition isn't yet linked to a site setting on the target. Run `/power-pages:configure-env-variables` against `{targetEnvName}` to create the missing values, then re-deploy or set values via Power Platform Admin Center."*
-4. If `value.length >= 1` for all entries: deploy is fully landed; no warning.
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/lib/verify-env-var-values.js" \
+  --envUrl "{targetEnvUrl}" \
+  --settingsFile "./deployment-settings.json" \
+  --stageLabel "{SELECTED_STAGE.name}"
+```
 
-This check uses target-env credentials — PAC CLI is still pointing at the source from the prior phases, so temporarily switch (`pac env select --environment "{targetEnvUrl}"`) then switch back at the end of 7.6.5 so subsequent phases run against the source env by default.
+Capture `stdout` as JSON: `const verifyResult = JSON.parse(output)`. The helper acquires its own token via Azure CLI scoped to `{targetEnvUrl}` — you do NOT need to switch PAC CLI for this call (the helper is fully read-only and bypasses PAC entirely).
+
+Branch on `verifyResult.summary`:
+
+- **`summary.missing === 0 && summary.mismatched === 0`** → all env var values landed cleanly. No warning. Proceed.
+- **`summary.missing > 0` OR `summary.mismatched > 0`** → log a structured warning into `docs/alm/last-deploy.json` under a new `envVarLandingWarnings[]` array. Build the array from the non-`landed` entries in `verifyResult.results` — preserve `schemaName`, `status`, and (when present) `expected` / `value` fields. Then surface to the user via the deploy summary:
+
+  > "`{summary.missing + summary.mismatched}` environment variable value(s) from `deploymentsettingsjson` did not land cleanly on `{targetEnvName}`. Most likely cause for `missing-value-record`: the definition isn't yet linked to a site setting on the target. Most likely cause for `value-mismatch`: the per-stage value in `deployment-settings.json` differs from what's now in the target's `environmentvariablevalues` table (someone may have edited it post-deploy via PPAC). Run `/power-pages:configure-env-variables` against `{targetEnvName}` to reconcile, or set values via Power Platform Admin Center → Solutions → Environment Variables."
+
+- **`summary.error > 0`** (auth, transient, 5xx) → log a one-line note: *"Env var landing check was inconclusive ({summary.error} schema queries errored). Verify manually in PPAC."* Do NOT block the deploy summary on inconclusive results — the deploy itself succeeded.
+
+> **Why the helper instead of inline OData?** The earlier inline-prose version was brittle: each agent run reconstructed the queries by hand, PAC CLI env-switching was manual, and the result-shape was never structured. The helper has 21 tests covering all the result-status branches (`landed` / `missing-value-record` / `missing-definition` / `value-mismatch` / `query-error`), reads `deployment-settings.json` directly to avoid drift between caller and helper, and produces a stable JSON contract callers can persist into `last-deploy.json` without re-parsing prose.
 
 **7.7 Check site activation** (only if deployment **Succeeded** and this is a Power Pages project):
 

--- a/plugins/power-pages/skills/import-solution/SKILL.md
+++ b/plugins/power-pages/skills/import-solution/SKILL.md
@@ -345,6 +345,16 @@ POST {envUrl}/api/data/v9.2/environmentvariablevalues
 If the user skips all values: inform them the site may not function correctly until values are set, and provide the direct Power Platform URL to set them manually:
 `https://{targetEnvHost}/main.aspx?appid=...&etn=environmentvariabledefinition`
 
+**6b.verify — Confirm values landed.** After the per-variable POSTs complete, verify each `environmentvariablevalues` record actually exists on the target. The shared helper `scripts/lib/verify-env-var-values.js` does this read-only check and returns a structured JSON result per schema (`landed` / `missing-value-record` / `missing-definition` / `value-mismatch` / `query-error`):
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/lib/verify-env-var-values.js" \
+  --envUrl "{targetEnvUrl}" \
+  --schemaNames "{comma-separated schema names that the user supplied values for}"
+```
+
+Capture stdout as JSON. If `summary.missing > 0` or `summary.error > 0`, surface a single warning to the user with the affected schema names — but do not block the import summary, the import itself succeeded. The same helper is used at deploy time (deploy-pipeline Phase 7.6.5) and at configure time (configure-env-variables Phase 7); centralizing the check keeps the user-visible message consistent across skills.
+
 ### Phase 6c — Detect Cloud Flows (if any)
 
 After import succeeds, check whether the solution contains cloud flow JSON files. Use the zip path located in Phase 2.


### PR DESCRIPTION
## Summary

Two-layer defense against the env var lifecycle failure modes observed in recent live sessions. Both layers slot in alongside existing helpers without modifying them.

| Failure mode | Layer | Helper |
|---|---|---|
| `@KeyVault(vaultName=...)` placeholder PATCHed into `deploymentsettingsjson` → 4h41m queue wait → `ImportAsHolding failed` | **Pre-PATCH validate** (deploy-pipeline Phase 5.1b) | `scripts/lib/validate-deployment-settings.js` (new) |
| Stage run reports Succeeded but `environmentvariablevalues` records didn't actually land on target (definition not bound to `mspp_sitesetting`) | **Post-deploy verify** (deploy-pipeline Phase 7.6.5, import-solution Phase 6b, configure-env-variables Phase 7.2b) | `scripts/lib/verify-env-var-values.js` (new) |

Both helpers are pure-read (verify) or pure-classify (validate); neither writes Dataverse state. The skills decide what to surface and what to persist into `docs/alm/last-deploy.json`.

## Commits

| SHA | Title |
|---|---|
| `5b810d3` | env-var values: shared verify helper + Secret URI path aligned with add-server-logic |
| `b015d27` | deploy-pipeline: pre-PATCH Secret-reference validation (catches placeholder syntax upfront) |

## What's new

### `scripts/lib/verify-env-var-values.js` (~398 lines, 21 tests)

Read-only post-deploy verification. Reads `deployment-settings.json` (or a bare `--schemaNames` list) and queries the target env's `environmentvariabledefinitions` + `environmentvariablevalues` tables. Per-schema status:

- `landed` — definition + value both exist, optionally matches expected
- `missing-value-record` — definition exists, no value row (the original observed bug)
- `missing-definition` — schema name not found on target
- `value-mismatch` — value present but doesn't match `--expectedValues`
- `query-error` — query failed (auth, transient)

Acquires its own Azure CLI token scoped to the target env URL — no PAC CLI env switching required.

### `scripts/lib/validate-deployment-settings.js` (~460 lines, 24 tests)

Pre-PATCH structural + format validator. Classifies each `EnvironmentVariables[]` entry:

**`valueFormat`** ∈ `kv-uri` / `kv-resource-id` / `kv-placeholder` / `empty` / `plain-text` / `invalid-uri` / `non-secret`

**`status`** ∈ `valid` / `invalid` / `unknown-type` / `skipped`

When `--envUrl` is provided, looks up each schema's env var type on dev and applies type-specific rules:

- **Secret type:** strict format — `kv-uri` / `kv-resource-id` / `empty` are valid; `kv-placeholder` (e.g. `@KeyVault(...)`), `plain-text`, `invalid-uri` are errors with specific remediation messages.
- **String/Number/Boolean/JSON/DataSource:** structural-only — anything non-empty is valid.
- **Unknown type** (no `--envUrl` or lookup failed): falls through to `unknown-type` for non-placeholder values; still flags placeholder syntax since it's never valid for any type.

Canonical Key Vault Secret reference formats (codified in the helper's regex):

1. **Key Vault Secret Identifier URI** — `https://<vault>.vault.azure.net/secrets/<name>[/<32-hex-version>]` (vault name 3–24 chars per Azure rules)
2. **Azure resource ID** — `/subscriptions/<sub>/resource[Gg]roups/<rg>/providers/Microsoft.KeyVault/vaults/<vault>/secrets/<name>`
3. **Empty string `""`** — legitimate "use the definition default for this stage"

Rejected patterns (flagged with specific messages, not the generic Dataverse error):

- `@KeyVault(vaultName=...;secretName=...)` — templating-style placeholder. Real-world failure case driving this work.
- `<TODO>`, `<KEY_VAULT_URI>`, `<PLACEHOLDER>`, `${ENV_VAR}` — angle-bracket / shell-style placeholders.
- Plain-text secret values — security concern + deploy failure (the file is committed to git).
- HTTPS URLs that look like KV URIs but miss canonical shape (host suffix, `/secrets/` segment, version format).

## SKILL.md edits

### `deploy-pipeline`

- **Phase 5.1b** (new) — runs `validate-deployment-settings.js` before Phase 5.2 PATCH. On `summary.invalid > 0`, stops with structured findings + remediation pointer to `configure-env-variables` Phase 3.B and `add-server-logic` Phase 7.2a. No "proceed anyway" prompt — there's no partial-validity case where forcing the bad PATCH succeeds.
- **Phase 7.6.5** — collapsed from ~25 lines of inline OData prose to a single `verify-env-var-values.js` call. Caller still persists `envVarLandingWarnings[]` to `docs/alm/last-deploy.json` and surfaces the per-status message to the user.

### `import-solution`

- **Phase 6b.verify** (new) — calls the verify helper after env-var value-set prompts complete. Warns but does not block import summary (import itself succeeded).

### `configure-env-variables`

- **Phase 3** split into three sub-phases on `typeCode`:
  - **3.A** — String: definition-only via `lib/create-env-var-definition.js` (unchanged from previous behavior).
  - **3.B** — Secret with KV URI: atomic deep-insert via `scripts/create-environment-variable.js --type secret --value <secretUri>` (same path `add-server-logic` Phase 7.2a uses end-to-end). New "Acceptable Secret reference formats" subsection documents the 3 canonical formats + the rejected patterns with the live failure case called out.
  - **3.C** — Secret without URI: legacy fallback, definition only, user wires manually via PPAC until `configure-secrets` ships.
- **Phase 7.2b** (new) — calls the verify helper against the dev env after definition+value creation to catch local write failures (definition created without paired value record).
- Explicit cross-reference to `add-server-logic` Phase 7.2a — stops the two skills looking like parallel implementations.

## What this PR does NOT touch

| File | Status |
|---|---|
| `skills/add-server-logic/SKILL.md` | **Unchanged** — referenced as the canonical implementation we learned from |
| `skills/add-server-logic/scripts/` | **Unchanged** |
| `scripts/create-environment-variable.js` | **Unchanged** — only gets more callers (configure-env-variables Phase 3.B now uses it) |
| `scripts/lib/create-env-var-definition.js` | **Unchanged** — still the canonical definition-only writer for String types |
| `scripts/lib/link-site-setting-to-env-var.js` | **Unchanged** |
| `scripts/lib/discover-env-var-definitions.js` | **Unchanged** |
| All other existing skill scripts and helpers | **Unchanged** |

Scope discipline verified — no add-server-logic edits, no contract changes to existing shared helpers.

## Test coverage

- **+24 new tests** for `validate-deployment-settings.js` covering all format regex hits, status branches per type, file parsing for both top-level and Stages[] shapes, stage-label filtering, missing fields, missing file, invalid JSON, multi-entry aggregation with mixed severities.
- **+21 new tests** for `verify-env-var-values.js` covering all status branches, summary aggregation, settings-file parsing, dedupe semantics, case-insensitive stage matching, OData literal escape, and per-schema graceful error handling.
- **847 / 847 total tests pass** across 3 consecutive runs (802 pre-existing + 45 new).
- `node scripts/lint-skills-alm.js` exits 0 — 49 warnings (all non-ALM, expected per approval-gates catalog §8), 0 errors.

## Real-world failure case driving this work

From an observed live session:

> Foundation deploy attempted as v1.0.0.5, stage run `bbd83c4b-f754`. Failed at 14:07:14 UTC after sitting in the host's serialized import queue for ~4h41m. Failure reason: *"ImportAsHolding failed: The value provided as a secret reference does not match a valid secret reference format."* Root cause: `c311_api_secret` value in `deployment-settings.json` was `@KeyVault(vaultName=lakeshore-staging-kv;secretName=api-secret)` — a placeholder syntax not recognized by Dataverse / the Pipelines handler.

With this PR's pre-PATCH validation, that same session would have stopped at Phase 5.1b in sub-second time with a precise remediation message — the 4h41m queue wait would never have happened.

## Test plan

- [x] `node --test scripts/tests/` → 847 / 847 pass × 3 consecutive runs
- [x] `node scripts/lint-skills-alm.js` → 0 errors, 49 expected warnings
- [x] No edits to `add-server-logic` SKILL.md or scripts (verified via `git diff --name-only`)
- [x] No contract changes to existing shared helpers (`create-env-var-definition.js`, `link-site-setting-to-env-var.js`, `create-environment-variable.js`)
- [ ] Reviewers: walk the new `validate-deployment-settings.js` format regexes against your own env to confirm any custom vault-name or subscription-id patterns aren't unintentionally rejected
- [ ] Reviewers: confirm the "no proceed-anyway prompt" behavior in deploy-pipeline Phase 5.1b is acceptable — the rationale is documented inline (forcing a bad PATCH always fails the import; only the wait time changes), but if you want a soft override path it would be a separate change
- [ ] Live-run validation against IdeaSphere / similar dev tenant after merge (validate ALL ALM skills surface the new gates correctly)

## Follow-up items (out of scope for this PR)

Tracked in catalog §11 / AGENTS.md Planned Skills:

- **`configure-secrets` skill** — `add-server-logic` Phase 7.2a proves the Key Vault end-to-end path works. The reusability plan was scoped in a prior turn but implementation is deferred. With this PR's Phase 3.B branch in place, the foundation is ready.
- **Telemetry persistence during ALM-only sessions** — `update-skill-tracking.js` writes local YAMLs that only sync to Dataverse via `pac pages upload-code-site`. ALM skills don't trigger that upload, so per-skill counters are correct locally but stale in Dataverse until the next `deploy-site`. Optional enhancement: add an `--envUrl` Dataverse-write mode to the tracking script. Out of scope for this PR.
- **Runtime gate-fire telemetry** — still tracked in `approval-gates.md` §11. Lint catches structural absence of markers; only runtime instrumentation can catch a skipped `AskUserQuestion` call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
