### PR TITLE
feat(model-apps): confine dialogs/overlays to the page container

### DIFF
--- a/plugins/model-apps/AGENTS.md
+++ b/plugins/model-apps/AGENTS.md
@@ -46,7 +46,7 @@ references/                    ← Shared reference docs
   supported-dependencies.md    ← Versioned package list for generated pages
   troubleshooting.md           ← Deployment/runtime/env issues
   verified-icons.txt           ← ~5000 Fluent UI icon names; Grep-validated by page-builder
-samples/                       ← Example .tsx files (11 samples)
+samples/                       ← Example .tsx files (12 samples)
 scripts/
   launch-playwright-mcp.js     ← Playwright MCP server launcher (detects system browser)
   regenerate-verified-icons.js ← Regenerates references/verified-icons.txt from npm

--- a/plugins/model-apps/CHANGELOG.md
+++ b/plugins/model-apps/CHANGELOG.md
@@ -19,6 +19,13 @@ real and synthetic fixtures. Builds on v2.1; no breaking changes.
 - `scripts/capture-fixture.js` — copies `/genpage` working dirs into
   fixtures and runs both layers.
 - `samples/11-kanban-with-dnd.tsx` — native HTML5 drag-and-drop sample.
+- `samples/12-dialog-form-overlay.tsx` + **Dialogs and Overlays** guidance
+  (rules.md rules 16–18 and Special Patterns section, plus a troubleshooting
+  entry): confine portalled Fluent surfaces (`Dialog`, `Popover`, `Menu`,
+  `Tooltip`, `Combobox`/`Dropdown`) to the page via `mountNode` +
+  `contain: layout`, default dialogs to `modalType="non-modal"`, and never nest
+  dialogs — so a modal can't escape the preview and cover the designer /
+  coding-agent panel.
 
 ### Changed
 - Spec tightening so workflow-logs are command-verbatim and `pageInput`

--- a/plugins/model-apps/agents/genpage-planner.md
+++ b/plugins/model-apps/agents/genpage-planner.md
@@ -392,8 +392,9 @@ to decide whether to load `references/data-caching.md`.
 
 For the `## Relevant Samples` section: pick the most structurally relevant sample
 from `${CLAUDE_PLUGIN_ROOT}/samples/` (e.g., 7-responsive-cards.tsx for card
-layouts, 2-wizard-multi-step.tsx for wizards). Do NOT list reference docs as
-samples — only files under `samples/`.
+layouts, 2-wizard-multi-step.tsx for wizards, 12-dialog-form-overlay.tsx for any
+page with a modal/dialog — create/edit forms, confirm-delete, detail-in-a-dialog).
+Do NOT list reference docs as samples — only files under `samples/`.
 
 ### CRITICAL — Pre-write validation pass
 

--- a/plugins/model-apps/references/rules.md
+++ b/plugins/model-apps/references/rules.md
@@ -260,16 +260,18 @@ Three rules prevent it:
 
 ```typescript
 const GeneratedComponent = (props: GeneratedComponentProps) => {
-    const containerRef = useRef<HTMLDivElement>(null);
     const [mountNode, setMountNode] = useState<HTMLElement | null>(null);
-    // mountNode confines every portalled overlay to this page's container
-    useEffect(() => { if (containerRef.current) setMountNode(containerRef.current); }, []);
+    // Callback ref captures the container the instant it mounts (before paint), so
+    // mountNode is set before any user-opened dialog renders — no window where the
+    // portal falls back to the designer's document.body. (Prefer this over a useEffect,
+    // whose first-paint gap leaves mountNode null if a dialog opens immediately.)
+    const setContainer = useCallback((node: HTMLDivElement | null) => setMountNode(node), []);
 
     const [open, setOpen] = useState(false);
 
     return (
         // contain: 'layout' makes this div the containing block for any fixed-position overlay
-        <div ref={containerRef} style={{ position: "relative", contain: "layout", height: "100%", overflow: "hidden" }}>
+        <div ref={setContainer} style={{ position: "relative", contain: "layout", height: "100%", overflow: "hidden" }}>
             {/* ...page content... */}
 
             {/* Sibling dialog at top level — NOT nested inside another Dialog */}

--- a/plugins/model-apps/references/rules.md
+++ b/plugins/model-apps/references/rules.md
@@ -21,6 +21,9 @@ Comprehensive rules for generating generative page code. Read this file during c
 13. **Navigation**: Use the `Xrm.Navigation.navigateTo` API for all in-app navigation. Never construct raw URLs or manipulate `window.location` — see **Special Patterns > Generative Page Navigation**.
 14. **Batched async state — no intermediate renders**: React 17 does NOT batch `setState` calls inside async functions. Every separate `setState` triggers its own render. When a component fetches multiple pieces of data (e.g., a record plus related records), use a **single state object** and a **single `setData(...)` call** at the end: `const [{ record, related, loading, error }, setData] = useState({...})`. For multi-entity fetches, use `Promise.all` or `Promise.allSettled` so one `setData` completes the entire load. Never call `setLoading(false)` in a `finally` block when the data setters are in the `try` block — this always produces an intermediate render. **PageInput exception:** initial `useState({ loading: !!recordId, ... })` (PageInput rendering pattern) does NOT violate this rule — that's a synchronous initial value, not a separate `setState` call after fetch. The rule is per-effect: independent effects (e.g., usersettings fetch + record fetch) can each have their own single batched `setData`.
 15. **Data fetching — inline IIFE + cache guard (Dataverse list/detail pages)**: For pages where the user navigates away and returns (list paired with detail, tabbed UIs), use the module-level `window` cache + inline async IIFE pattern documented in `references/data-caching.md`. Never use `useCallback` for data-fetching functions — `dataApi` gets a new object reference after the initial render, so a `useCallback` recreates, re-fires the effect, and any `setData(loading: true)` call resets the spinner causing flicker. The cache guard (`if (cache.has(key)) return`) is the fix. **Do NOT apply this pattern to forms, single-visit dashboards, or mock-data pages.** See the reference for the full pattern.
+16. **Overlays must be confined to the page container (`mountNode`)**: The generated page shares the DOM with the genpage *designer* — the preview is NOT an isolated iframe. Every Fluent surface that renders through a portal (`Dialog` via `DialogSurface`, `Popover`, `Menu`, `Tooltip`, `Combobox`/`Dropdown` listbox, `DatePicker`, `TimePicker`) defaults to portalling to `document.body` of the **designer**, so without a `mountNode` it escapes the preview and can cover the designer chrome — including the coding-agent panel. Establish a single `containerRef`/`mountNode` on the page root and thread it to every overlay. See **Special Patterns > Dialogs and Overlays**.
+17. **No full-viewport modal scrims; prefer non-modal or in-page panels**: A default `<Dialog>` is `modalType="modal"` — it draws a `position: fixed` backdrop and traps focus across the whole window, which in the designer blankets the agent panel and locks the user out (they can't even ask the agent to remove it). Default dialogs to `modalType="non-modal"` **and** pass `mountNode`, or use an in-page absolutely-positioned panel. The page root must establish a containing block (`position: relative` + `contain: layout`) so even a fixed-position overlay is clipped to the page. Never size overlays to the viewport. See **Special Patterns > Dialogs and Overlays**.
+18. **Never nest a `<Dialog>` inside another `<Dialog>`**: Stacked modal scrims and nested focus traps make dialogs impossible to dismiss reliably. Render sibling dialogs as separate top-level surfaces switched by state, never one `<Dialog>` as a child of another's JSX.
 
 ---
 
@@ -90,7 +93,7 @@ export default GeneratedComponent;
 - Use relative units (%, rem, em); avoid fixed widths
 - Root container is flex column; use flex properties to fill space
 - `boxSizing: border-box`; images: `max-width: 100%, height: auto`
-- NEVER use `100vh`/`100vw`
+- NEVER use `100vh`/`100vw` — the page is hosted inside the designer, not the full window; viewport units (and `position: fixed` overlays) size to the whole designer and bleed over the agent panel
 - **Media queries go INSIDE the slot they modify** — never as a top-level
   `makeStyles` key. Griffel compiles each top-level key as an independent
   class, so a top-level `'@media (...)'` slot generates an unused class
@@ -244,6 +247,52 @@ const [lng] = useState(toNumberOrDefault(pageInput?.data?.longitude, 0));
 ---
 
 ## Special Patterns
+
+### Dialogs and Overlays
+
+**Why this matters:** the generated page renders into the **same document as the genpage designer** — the preview is not a sandboxed iframe. Any Fluent component that renders through a portal (`Dialog`, `Popover`, `Menu`, `Tooltip`, `Combobox`/`Dropdown` listbox, `DatePicker`, `TimePicker`) defaults to portalling to `document.body`. In a normal app that's the page; in the designer that's the **whole tool**. A default `<Dialog>` (`modalType="modal"`) additionally paints a `position: fixed` backdrop and traps focus across the entire window. The result is the #1 reported genpage failure: a modal that **covers the designer and the coding-agent panel on the left, and can't be dismissed** — the user is locked out and can't even ask the agent to remove it.
+
+Three rules prevent it:
+
+1. **Thread a `mountNode` to every overlay** so the portal stays inside the page's own container.
+2. **Make the page root a containing block** (`position: relative` + `contain: layout`) so any `position: fixed` descendant is clipped to the page, never the designer.
+3. **Default dialogs to `modalType="non-modal"`** (no blocking scrim), or use an in-page panel. Never nest a `<Dialog>` inside another `<Dialog>`.
+
+```typescript
+const GeneratedComponent = (props: GeneratedComponentProps) => {
+    const containerRef = useRef<HTMLDivElement>(null);
+    const [mountNode, setMountNode] = useState<HTMLElement | null>(null);
+    // mountNode confines every portalled overlay to this page's container
+    useEffect(() => { if (containerRef.current) setMountNode(containerRef.current); }, []);
+
+    const [open, setOpen] = useState(false);
+
+    return (
+        // contain: 'layout' makes this div the containing block for any fixed-position overlay
+        <div ref={containerRef} style={{ position: "relative", contain: "layout", height: "100%", overflow: "hidden" }}>
+            {/* ...page content... */}
+
+            {/* Sibling dialog at top level — NOT nested inside another Dialog */}
+            <Dialog open={open} onOpenChange={(_, d) => setOpen(d.open)} modalType="non-modal">
+                <DialogSurface mountNode={mountNode}>
+                    <DialogBody>
+                        <DialogTitle>Edit item</DialogTitle>
+                        {/* ...fields... */}
+                        <DialogActions>
+                            <Button appearance="secondary" onClick={() => setOpen(false)}>Cancel</Button>
+                            <Button appearance="primary" onClick={() => setOpen(false)}>Save</Button>
+                        </DialogActions>
+                    </DialogBody>
+                </DialogSurface>
+            </Dialog>
+        </div>
+    );
+};
+```
+
+- `mountNode` goes on **`DialogSurface`** (not `Dialog`). For `Popover`/`Menu`/`Tooltip` pass `mountNode` to the component; for `Combobox`/`Dropdown` use the same `mountNode`; for `DatePicker`/`TimePicker` the `mountNode` prop is already required (see sample 6).
+- If a dialog genuinely must block the page (rare), keep `modalType="modal"` **but still** pass `mountNode` and rely on the `contain: layout` root so the scrim is clipped to the page, not the designer.
+- **Multiple dialogs:** declare each as a separate top-level `<Dialog>` switched by its own state flag. Never render one `<Dialog>` inside another's JSX tree.
 
 ### Generative Page Navigation
 

--- a/plugins/model-apps/references/troubleshooting.md
+++ b/plugins/model-apps/references/troubleshooting.md
@@ -72,6 +72,30 @@ This plugin creates **pages within existing** model-driven apps — it cannot cr
 
 ---
 
+## Modal Dialog Covers the Designer / Blocks the Coding Agent
+
+**Symptom:** a generated page opens a dialog that overlays the whole designer — the
+backdrop covers the coding-agent panel on the left, and the user can't dismiss it or
+interact with the agent. Often reported as "a modal keeps appearing regardless of my
+actions."
+
+**Cause:** the page used a Fluent `<Dialog>` with the default `modalType="modal"` and
+**no `mountNode`**. The preview shares the DOM with the designer (it is not a sandboxed
+iframe), so the dialog's portal mounts to the designer's `document.body` and its
+`position: fixed` backdrop + focus trap cover the entire tool. Using `100vh`/`100vw` or
+`position: fixed` overlays sized to the viewport, or nesting one `<Dialog>` inside
+another, makes it worse.
+
+**Fix (regenerate the page per `rules.md` → Special Patterns > Dialogs and Overlays):**
+- Add a `containerRef` + `mountNode` on the page root and pass `mountNode` to every
+  `DialogSurface` (and to `Popover`/`Menu`/`Tooltip`/`Combobox`/`Dropdown`).
+- Make the root a containing block: `position: relative; contain: layout`.
+- Default dialogs to `modalType="non-modal"`, or use an in-page panel.
+- Remove `100vh`/`100vw`; never use viewport-fixed overlays.
+- Never nest a `<Dialog>` inside another `<Dialog>` — use sibling dialogs switched by state.
+
+---
+
 ## Playwright Browser Verification Issues
 
 - "Target page, context or browser has been closed" → retry the navigation; Playwright sessions can expire

--- a/plugins/model-apps/references/troubleshooting.md
+++ b/plugins/model-apps/references/troubleshooting.md
@@ -79,20 +79,14 @@ backdrop covers the coding-agent panel on the left, and the user can't dismiss i
 interact with the agent. Often reported as "a modal keeps appearing regardless of my
 actions."
 
-**Cause:** the page used a Fluent `<Dialog>` with the default `modalType="modal"` and
-**no `mountNode`**. The preview shares the DOM with the designer (it is not a sandboxed
-iframe), so the dialog's portal mounts to the designer's `document.body` and its
-`position: fixed` backdrop + focus trap cover the entire tool. Using `100vh`/`100vw` or
-`position: fixed` overlays sized to the viewport, or nesting one `<Dialog>` inside
-another, makes it worse.
+**Cause:** a Fluent `<Dialog>` with the default `modalType="modal"` and **no
+`mountNode`**. The preview shares the DOM with the designer (it is not a sandboxed
+iframe), so the dialog's portal + `position: fixed` backdrop mount to the designer's
+`document.body` and cover the entire tool.
 
-**Fix (regenerate the page per `rules.md` → Special Patterns > Dialogs and Overlays):**
-- Add a `containerRef` + `mountNode` on the page root and pass `mountNode` to every
-  `DialogSurface` (and to `Popover`/`Menu`/`Tooltip`/`Combobox`/`Dropdown`).
-- Make the root a containing block: `position: relative; contain: layout`.
-- Default dialogs to `modalType="non-modal"`, or use an in-page panel.
-- Remove `100vh`/`100vw`; never use viewport-fixed overlays.
-- Never nest a `<Dialog>` inside another `<Dialog>` — use sibling dialogs switched by state.
+**Fix:** regenerate per `rules.md` → **Special Patterns > Dialogs and Overlays** (thread
+`mountNode` to every overlay, make the root a `contain: layout` containing block, default
+dialogs to `modalType="non-modal"`, no `100vh`/`100vw`, never nest `<Dialog>`s).
 
 ---
 

--- a/plugins/model-apps/samples/12-dialog-form-overlay.tsx
+++ b/plugins/model-apps/samples/12-dialog-form-overlay.tsx
@@ -163,7 +163,7 @@ function ConfirmDeleteDialog({
                 <DialogBody>
                     <DialogTitle>Delete project</DialogTitle>
                     <DialogContent>
-                        <Text>Are you sure you want to delete “{projectName}”? This can’t be undone.</Text>
+                        <Text>Are you sure you want to delete "{projectName}"? This can't be undone.</Text>
                     </DialogContent>
                     <DialogActions>
                         <Button appearance="secondary" onClick={onClose}>Cancel</Button>

--- a/plugins/model-apps/samples/12-dialog-form-overlay.tsx
+++ b/plugins/model-apps/samples/12-dialog-form-overlay.tsx
@@ -17,7 +17,7 @@
 //
 // Mock data only — no RuntimeTypes / dataApi — so the pattern stays the focus.
 
-import React, { useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import {
     Button,
     Dialog,
@@ -175,15 +175,21 @@ function ConfirmDeleteDialog({
     );
 }
 
-const GeneratedComponent: React.FC = () => {
+// Mock page: no RuntimeTypes import (not generated for mock pages). Standard props
+// signature so the sample is copy/paste-safe for real /genpage output.
+type Props = { dataApi?: unknown; pageInput?: { id?: string } };
+
+const GeneratedComponent = (props: Props) => {
+    const { pageInput } = props; // always destructure pageInput, even when unused
+    void pageInput;
     const styles = useStyles();
 
-    // One containerRef + mountNode for the whole page; thread it to every overlay.
-    const containerRef = useRef<HTMLDivElement>(null);
+    // One mountNode for the whole page; thread it to every overlay. A callback ref
+    // captures the container the instant it mounts (before paint), so mountNode is set
+    // before any user-opened dialog renders — no window where the portal falls back
+    // to the designer's document.body.
     const [mountNode, setMountNode] = useState<HTMLElement | null>(null);
-    useEffect(() => {
-        if (containerRef.current) setMountNode(containerRef.current);
-    }, []);
+    const setContainer = useCallback((node: HTMLDivElement | null) => setMountNode(node), []);
 
     const [projects, setProjects] = useState<Project[]>([
         { id: "1", name: "Website redesign", owner: "Avery" },
@@ -214,7 +220,7 @@ const GeneratedComponent: React.FC = () => {
     };
 
     return (
-        <div ref={containerRef} className={styles.root}>
+        <div ref={setContainer} className={styles.root}>
             <div className={styles.header}>
                 <Text as="h1" size={600} weight="semibold">Projects</Text>
                 <Button appearance="primary" icon={<AddRegular />} onClick={openCreate}>New project</Button>

--- a/plugins/model-apps/samples/12-dialog-form-overlay.tsx
+++ b/plugins/model-apps/samples/12-dialog-form-overlay.tsx
@@ -1,0 +1,261 @@
+// Sample 12 — Dialogs done right inside a generative page.
+//
+// A generative page renders into the SAME document as the genpage designer — the
+// preview is not a sandboxed iframe. Every portalled Fluent surface (Dialog, Popover,
+// Menu, Tooltip, Combobox/Dropdown listbox, DatePicker, TimePicker) defaults to
+// portalling to `document.body` of the DESIGNER. A default `<Dialog>` is also
+// `modalType="modal"`, which paints a `position: fixed` backdrop and traps focus across
+// the whole window. The result is the #1 reported genpage bug: a modal that covers the
+// designer (including the coding-agent panel) and can't be dismissed.
+//
+// This sample shows the three fixes (see rules.md → Special Patterns > Dialogs and Overlays):
+//   1. Thread a `mountNode` (the page's own container ref) to every `DialogSurface`.
+//   2. Make the page root a containing block (`position: relative` + `contain: layout`)
+//      so any fixed-position overlay is clipped to the page, never the designer.
+//   3. Use `modalType="non-modal"` (no blocking scrim) and keep multiple dialogs as
+//      SIBLINGS switched by state — never nest one <Dialog> inside another.
+//
+// Mock data only — no RuntimeTypes / dataApi — so the pattern stays the focus.
+
+import React, { useEffect, useRef, useState } from "react";
+import {
+    Button,
+    Dialog,
+    DialogSurface,
+    DialogBody,
+    DialogTitle,
+    DialogContent,
+    DialogActions,
+    Field,
+    Input,
+    Text,
+    Card,
+    makeStyles,
+    tokens,
+    shorthands,
+} from "@fluentui/react-components";
+import { AddRegular, EditRegular, DeleteRegular, DismissRegular } from "@fluentui/react-icons";
+
+interface Project {
+    id: string;
+    name: string;
+    owner: string;
+}
+
+const useStyles = makeStyles({
+    // Root establishes a containing block: `contain: layout` clips any fixed-position
+    // overlay (e.g. a modal scrim) to this element instead of the whole designer.
+    root: {
+        position: "relative",
+        ...shorthands.overflow("hidden"),
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        contain: "layout",
+        backgroundColor: tokens.colorNeutralBackground2,
+    },
+    header: {
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        ...shorthands.padding(tokens.spacingVerticalL, tokens.spacingHorizontalL),
+        ...shorthands.gap(tokens.spacingHorizontalM),
+    },
+    list: {
+        flexGrow: 1,
+        minHeight: 0,
+        overflowY: "auto",
+        ...shorthands.padding(0, tokens.spacingHorizontalL, tokens.spacingVerticalL),
+        display: "flex",
+        flexDirection: "column",
+        ...shorthands.gap(tokens.spacingVerticalS),
+    },
+    row: {
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        ...shorthands.padding(tokens.spacingVerticalM, tokens.spacingHorizontalL),
+        ...shorthands.gap(tokens.spacingHorizontalM),
+    },
+    rowText: { display: "flex", flexDirection: "column", minWidth: 0 },
+    rowActions: { display: "flex", ...shorthands.gap(tokens.spacingHorizontalS) },
+    fields: { display: "flex", flexDirection: "column", ...shorthands.gap(tokens.spacingVerticalM) },
+});
+
+// --- Create/Edit dialog — a separate top-level component, rendered as a sibling ---
+function ProjectFormDialog({
+    open,
+    initial,
+    mountNode,
+    onSave,
+    onClose,
+}: {
+    open: boolean;
+    initial: Project | null;
+    mountNode: HTMLElement | null;
+    onSave: (p: { name: string; owner: string }) => void;
+    onClose: () => void;
+}) {
+    const styles = useStyles();
+    const [name, setName] = useState("");
+    const [owner, setOwner] = useState("");
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        if (open) {
+            setName(initial?.name ?? "");
+            setOwner(initial?.owner ?? "");
+            setError(null);
+        }
+    }, [open, initial]);
+
+    const handleSave = () => {
+        if (!name.trim()) {
+            setError("Name is required");
+            return;
+        }
+        onSave({ name: name.trim(), owner: owner.trim() });
+    };
+
+    return (
+        // non-modal: no blocking scrim. mountNode: surface stays inside the page container.
+        <Dialog open={open} onOpenChange={(_, d) => { if (!d.open) onClose(); }} modalType="non-modal">
+            <DialogSurface mountNode={mountNode}>
+                <DialogBody>
+                    <DialogTitle>{initial ? "Edit project" : "New project"}</DialogTitle>
+                    <DialogContent>
+                        <div className={styles.fields}>
+                            <Field label="Name" required validationState={error ? "error" : "none"} validationMessage={error ?? undefined}>
+                                <Input value={name} onChange={(_, d) => setName(d.value)} placeholder="Project name" />
+                            </Field>
+                            <Field label="Owner">
+                                <Input value={owner} onChange={(_, d) => setOwner(d.value)} placeholder="Owner name" />
+                            </Field>
+                        </div>
+                    </DialogContent>
+                    <DialogActions>
+                        <Button appearance="secondary" icon={<DismissRegular />} onClick={onClose}>Cancel</Button>
+                        <Button appearance="primary" onClick={handleSave}>{initial ? "Save" : "Create"}</Button>
+                    </DialogActions>
+                </DialogBody>
+            </DialogSurface>
+        </Dialog>
+    );
+}
+
+// --- Confirm-delete dialog — a SECOND sibling dialog, not nested in the form dialog ---
+function ConfirmDeleteDialog({
+    open,
+    projectName,
+    mountNode,
+    onConfirm,
+    onClose,
+}: {
+    open: boolean;
+    projectName: string;
+    mountNode: HTMLElement | null;
+    onConfirm: () => void;
+    onClose: () => void;
+}) {
+    return (
+        <Dialog open={open} onOpenChange={(_, d) => { if (!d.open) onClose(); }} modalType="non-modal">
+            <DialogSurface mountNode={mountNode}>
+                <DialogBody>
+                    <DialogTitle>Delete project</DialogTitle>
+                    <DialogContent>
+                        <Text>Are you sure you want to delete “{projectName}”? This can’t be undone.</Text>
+                    </DialogContent>
+                    <DialogActions>
+                        <Button appearance="secondary" onClick={onClose}>Cancel</Button>
+                        <Button appearance="primary" onClick={onConfirm}>Delete</Button>
+                    </DialogActions>
+                </DialogBody>
+            </DialogSurface>
+        </Dialog>
+    );
+}
+
+const GeneratedComponent: React.FC = () => {
+    const styles = useStyles();
+
+    // One containerRef + mountNode for the whole page; thread it to every overlay.
+    const containerRef = useRef<HTMLDivElement>(null);
+    const [mountNode, setMountNode] = useState<HTMLElement | null>(null);
+    useEffect(() => {
+        if (containerRef.current) setMountNode(containerRef.current);
+    }, []);
+
+    const [projects, setProjects] = useState<Project[]>([
+        { id: "1", name: "Website redesign", owner: "Avery" },
+        { id: "2", name: "Mobile app", owner: "Jordan" },
+    ]);
+
+    // Each dialog has its own independent open flag — siblings, never nested.
+    const [formOpen, setFormOpen] = useState(false);
+    const [editing, setEditing] = useState<Project | null>(null);
+    const [deleting, setDeleting] = useState<Project | null>(null);
+
+    const openCreate = () => { setEditing(null); setFormOpen(true); };
+    const openEdit = (p: Project) => { setEditing(p); setFormOpen(true); };
+
+    const handleSave = (data: { name: string; owner: string }) => {
+        if (editing) {
+            setProjects((prev) => prev.map((p) => (p.id === editing.id ? { ...p, ...data } : p)));
+        } else {
+            setProjects((prev) => [...prev, { id: Math.random().toString(36).slice(2), ...data }]);
+        }
+        setFormOpen(false);
+        setEditing(null);
+    };
+
+    const handleDelete = () => {
+        if (deleting) setProjects((prev) => prev.filter((p) => p.id !== deleting.id));
+        setDeleting(null);
+    };
+
+    return (
+        <div ref={containerRef} className={styles.root}>
+            <div className={styles.header}>
+                <Text as="h1" size={600} weight="semibold">Projects</Text>
+                <Button appearance="primary" icon={<AddRegular />} onClick={openCreate}>New project</Button>
+            </div>
+
+            <div className={styles.list}>
+                {projects.length === 0 ? (
+                    <Text>No projects yet.</Text>
+                ) : (
+                    projects.map((p) => (
+                        <Card key={p.id} className={styles.row}>
+                            <div className={styles.rowText}>
+                                <Text weight="semibold" truncate block>{p.name}</Text>
+                                <Text size={200} style={{ color: tokens.colorNeutralForeground3 }}>{p.owner || "Unassigned"}</Text>
+                            </div>
+                            <div className={styles.rowActions}>
+                                <Button appearance="subtle" icon={<EditRegular />} aria-label={`Edit ${p.name}`} onClick={() => openEdit(p)} />
+                                <Button appearance="subtle" icon={<DeleteRegular />} aria-label={`Delete ${p.name}`} onClick={() => setDeleting(p)} />
+                            </div>
+                        </Card>
+                    ))
+                )}
+            </div>
+
+            {/* Both dialogs are siblings at the page root, confined via mountNode. */}
+            <ProjectFormDialog
+                open={formOpen}
+                initial={editing}
+                mountNode={mountNode}
+                onSave={handleSave}
+                onClose={() => { setFormOpen(false); setEditing(null); }}
+            />
+            <ConfirmDeleteDialog
+                open={deleting !== null}
+                projectName={deleting?.name ?? ""}
+                mountNode={mountNode}
+                onConfirm={handleDelete}
+                onClose={() => setDeleting(null)}
+            />
+        </div>
+    );
+};
+
+export default GeneratedComponent;


### PR DESCRIPTION
Generative pages render into the same DOM as the genpage designer (the preview is not a sandboxed iframe), so a default Fluent <Dialog> (modalType="modal") portals its fixed-position scrim + focus trap to the designer's document.body and covers the designer — including the coding-agent panel — with no way to dismiss.

Adds defensive guidance and a worked sample:
- rules.md: rules 16-18 (mountNode confinement; non-modal + contain:layout containing block; no nested dialogs) + a "Dialogs and Overlays" Special Patterns section; sharpen the 100vh/100vw rule with the why.
- troubleshooting.md: "Modal Dialog Covers the Designer" symptom/cause/fix.
- samples/12-dialog-form-overlay.tsx: create/edit + confirm-delete dialogs done right (sibling dialogs, mountNode threaded, contain:layout root).
- genpage-planner.md: reference the new sample for modal/dialog pages.

Migrated from fix/modal-fixes; renumbered the sample 11->12 (11 was taken by the kanban sample already on main) and logged it in CHANGELOG + AGENTS sample count.