### PR TITLE
Fix report-issue workflow bundling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,14 +53,15 @@ Skills are defined in `SKILL.md` files with YAML frontmatter (name, description,
 
 ## Cross-Plugin Shared Skills
 
-Skills that apply to all plugins live in `shared/skills/<skill-name>/`. The workflow logic is written once in a shared `.md` file, and each plugin has a thin `skills/<skill-name>/SKILL.md` that contains only the YAML frontmatter and a reference to the shared workflow file.
+Skills that apply to all plugins live in `shared/skills/<skill-name>/`. The workflow logic is written once in a shared `.md` file, and each plugin has a thin `skills/<skill-name>/SKILL.md` that contains only the YAML frontmatter and a reference to the workflow path bundled inside that plugin at install time.
 
 **Pattern:**
 - `shared/skills/<skill-name>/<workflow>.md` — Full workflow (phases, instructions, field definitions)
 - `shared/skills/<skill-name>/SKILL.template.md` — Template SKILL.md (frontmatter + reference to workflow); supports `{{PLUGIN_NAME}}` placeholder
 - `plugins/<plugin>/skills/<skill-name>/SKILL.md` — Per-plugin wrapper generated from the template above
+- `plugins/<plugin>/skills/<skill-name>/<workflow>.md` — Symlink to the shared workflow when the plugin must work after installing only its own plugin directory
 
-This keeps the skill discoverable in each plugin while avoiding content duplication. When updating a shared skill, edit the workflow file and/or `SKILL.template.md` in `shared/`, then update the per-plugin wrappers (frontmatter + reference pointing to the shared workflow, with `{{PLUGIN_NAME}}` substituted) and commit them alongside the shared change.
+This keeps the skill discoverable in each plugin while preserving install-time portability. Marketplace installs copy only the plugin directory, so per-plugin wrappers must not reference repo-root `shared/` paths at runtime. Instead, point the wrapper at `${CLAUDE_PLUGIN_ROOT}/skills/<skill-name>/<workflow>.md` and keep a symlink from that per-plugin path to the repo-root shared workflow; marketplace installers dereference same-marketplace symlinks into the installed plugin cache. When updating a shared skill, edit the workflow file and/or `SKILL.template.md` in `shared/`, then update the per-plugin wrappers (frontmatter + bundled workflow reference, with `{{PLUGIN_NAME}}` substituted) and ensure any per-plugin symlinks still resolve under `plugins/<plugin>/skills/<skill-name>/`. Commit the shared source and per-plugin symlinks together.
 
 ## Code Conventions
 

--- a/plugins/canvas-apps/skills/report-issue/SKILL.md
+++ b/plugins/canvas-apps/skills/report-issue/SKILL.md
@@ -10,4 +10,4 @@ allowed-tools: Read, Bash, Glob, Grep, AskUserQuestion, TaskCreate, TaskUpdate, 
 model: sonnet
 ---
 
-**Shared workflow: [report-issue-workflow.md](${CLAUDE_PLUGIN_ROOT}/../../shared/skills/report-issue/report-issue-workflow.md)** — Read and follow all phases defined in that file.
+**Workflow: [report-issue-workflow.md](${CLAUDE_PLUGIN_ROOT}/skills/report-issue/report-issue-workflow.md)** — Read and follow all phases defined in that bundled file.

--- a/plugins/canvas-apps/skills/report-issue/report-issue-workflow.md
+++ b/plugins/canvas-apps/skills/report-issue/report-issue-workflow.md
@@ -1,0 +1,1 @@
+../../../../shared/skills/report-issue/report-issue-workflow.md

--- a/plugins/code-apps/skills/report-issue/SKILL.md
+++ b/plugins/code-apps/skills/report-issue/SKILL.md
@@ -10,4 +10,4 @@ allowed-tools: Read, Bash, Glob, Grep, AskUserQuestion, TaskCreate, TaskUpdate, 
 model: sonnet
 ---
 
-**Shared workflow: [report-issue-workflow.md](${CLAUDE_PLUGIN_ROOT}/../../shared/skills/report-issue/report-issue-workflow.md)** — Read and follow all phases defined in that file.
+**Workflow: [report-issue-workflow.md](${CLAUDE_PLUGIN_ROOT}/skills/report-issue/report-issue-workflow.md)** — Read and follow all phases defined in that bundled file.

--- a/plugins/code-apps/skills/report-issue/report-issue-workflow.md
+++ b/plugins/code-apps/skills/report-issue/report-issue-workflow.md
@@ -1,0 +1,1 @@
+../../../../shared/skills/report-issue/report-issue-workflow.md

--- a/plugins/mcp-apps/skills/report-issue/SKILL.md
+++ b/plugins/mcp-apps/skills/report-issue/SKILL.md
@@ -10,4 +10,4 @@ allowed-tools: Read, Bash, Glob, Grep, AskUserQuestion, TaskCreate, TaskUpdate, 
 model: sonnet
 ---
 
-**Shared workflow: [report-issue-workflow.md](${CLAUDE_PLUGIN_ROOT}/../../shared/skills/report-issue/report-issue-workflow.md)** — Read and follow all phases defined in that file.
+**Workflow: [report-issue-workflow.md](${CLAUDE_PLUGIN_ROOT}/skills/report-issue/report-issue-workflow.md)** — Read and follow all phases defined in that bundled file.

--- a/plugins/mcp-apps/skills/report-issue/report-issue-workflow.md
+++ b/plugins/mcp-apps/skills/report-issue/report-issue-workflow.md
@@ -1,0 +1,1 @@
+../../../../shared/skills/report-issue/report-issue-workflow.md

--- a/plugins/model-apps/skills/report-issue/SKILL.md
+++ b/plugins/model-apps/skills/report-issue/SKILL.md
@@ -10,4 +10,4 @@ allowed-tools: Read, Bash, Glob, Grep, AskUserQuestion, TaskCreate, TaskUpdate, 
 model: sonnet
 ---
 
-**Shared workflow: [report-issue-workflow.md](${CLAUDE_PLUGIN_ROOT}/../../shared/skills/report-issue/report-issue-workflow.md)** — Read and follow all phases defined in that file.
+**Workflow: [report-issue-workflow.md](${CLAUDE_PLUGIN_ROOT}/skills/report-issue/report-issue-workflow.md)** — Read and follow all phases defined in that bundled file.

--- a/plugins/model-apps/skills/report-issue/report-issue-workflow.md
+++ b/plugins/model-apps/skills/report-issue/report-issue-workflow.md
@@ -1,0 +1,1 @@
+../../../../shared/skills/report-issue/report-issue-workflow.md

--- a/plugins/power-pages/skills/report-issue/SKILL.md
+++ b/plugins/power-pages/skills/report-issue/SKILL.md
@@ -12,4 +12,4 @@ model: sonnet
 
 > **Plugin check**: Run `node "${CLAUDE_PLUGIN_ROOT}/scripts/check-version.js"` — if it outputs a message, show it to the user before proceeding.
 
-**Shared workflow: [report-issue-workflow.md](${CLAUDE_PLUGIN_ROOT}/../../shared/skills/report-issue/report-issue-workflow.md)** — Read and follow all phases defined in that file.
+**Workflow: [report-issue-workflow.md](${CLAUDE_PLUGIN_ROOT}/skills/report-issue/report-issue-workflow.md)** — Read and follow all phases defined in that bundled file.

--- a/plugins/power-pages/skills/report-issue/report-issue-workflow.md
+++ b/plugins/power-pages/skills/report-issue/report-issue-workflow.md
@@ -1,0 +1,1 @@
+../../../../shared/skills/report-issue/report-issue-workflow.md

--- a/shared/skills/report-issue/SKILL.template.md
+++ b/shared/skills/report-issue/SKILL.template.md
@@ -10,4 +10,4 @@ allowed-tools: Read, Bash, Glob, Grep, AskUserQuestion, TaskCreate, TaskUpdate, 
 model: sonnet
 ---
 
-**Shared workflow: [report-issue-workflow.md](${CLAUDE_PLUGIN_ROOT}/../../shared/skills/report-issue/report-issue-workflow.md)** — Read and follow all phases defined in that file.
+**Workflow: [report-issue-workflow.md](${CLAUDE_PLUGIN_ROOT}/skills/report-issue/report-issue-workflow.md)** — Read and follow all phases defined in that bundled file.


### PR DESCRIPTION
The report-issue skill was broken after marketplace installation because each plugin wrapper pointed at a repo-root `shared/` path that is not available from the installed plugin root.

This updates the wrappers to load the workflow from the plugin-local `${CLAUDE_PLUGIN_ROOT}/skills/report-issue/report-issue-workflow.md` path and adds same-marketplace symlinks from each plugin back to the shared workflow source. Marketplace installers dereference these symlinks into the plugin cache, keeping the installed layout portable without duplicating the workflow content in source.

Also updates the shared skill template and repository guidance so future cross-plugin shared skills use the same install-safe pattern.

Validation:
- Verified each report-issue symlink resolves to the shared workflow.
- Verified each plugin wrapper's runtime path resolves inside its plugin root.
- Ran `node scripts/validate-skill-descriptions.js`.
- Ran `node scripts/validate-plugin-names.js`.

Tested with both Claude Code and GitHub Copilot CLI.

<img width="3438" height="1918" alt="image" src="https://github.com/user-attachments/assets/55edb17e-63e1-40c0-a9e0-da7293c6d168" />



Fixes #180