### PR TITLE
Fix Playwright MCP config path quoting

### DIFF
--- a/plugins/power-pages/scripts/launch-playwright-mcp.js
+++ b/plugins/power-pages/scripts/launch-playwright-mcp.js
@@ -9,13 +9,30 @@ const { spawn } = require('child_process');
 const path = require('path');
 const { detectBrowser } = require('./lib/detect-browser');
 
-function buildMcpArgs(browser) {
+function quoteShellArg(value, platform = process.platform) {
+  const argument = String(value);
+
+  if (platform === 'win32') {
+    if (argument.includes('"')) {
+      throw new Error('Cannot quote an argument containing double quotes for cmd.exe.');
+    }
+
+    return `"${argument}"`;
+  }
+
+  return `'${argument.replace(/'/g, "'\\''")}'`;
+}
+
+function buildMcpArgs(browser, {
+  configPath = path.join(__dirname, 'playwright-mcp-fullscreen.config.json'),
+  platform = process.platform,
+} = {}) {
   return [
     '@playwright/mcp@latest',
     '--browser',
     browser,
     '--config',
-    path.join(__dirname, 'playwright-mcp-fullscreen.config.json'),
+    quoteShellArg(configPath, platform),
   ];
 }
 
@@ -33,4 +50,4 @@ if (require.main === module) {
   launch();
 }
 
-module.exports = { buildMcpArgs, launch };
+module.exports = { buildMcpArgs, launch, quoteShellArg };

--- a/plugins/power-pages/scripts/tests/launch-playwright-mcp.test.js
+++ b/plugins/power-pages/scripts/tests/launch-playwright-mcp.test.js
@@ -7,16 +7,28 @@ const { EventEmitter } = require('node:events');
 const {
   buildMcpArgs,
   launch,
+  quoteShellArg,
 } = require('../launch-playwright-mcp');
 
 test('buildMcpArgs launches Playwright MCP with fullscreen config', () => {
   const args = buildMcpArgs('chrome');
   const configIndex = args.indexOf('--config');
+  const quotedConfigPath = args[configIndex + 1];
+  const configPath = quotedConfigPath.slice(1, -1);
 
   assert.deepEqual(args.slice(0, 3), ['@playwright/mcp@latest', '--browser', 'chrome']);
   assert.equal(args.includes('--viewport-size'), false);
   assert.notEqual(configIndex, -1);
-  assert.equal(path.basename(args[configIndex + 1]), 'playwright-mcp-fullscreen.config.json');
+  assert.equal(quotedConfigPath, quoteShellArg(configPath));
+  assert.equal(path.basename(configPath), 'playwright-mcp-fullscreen.config.json');
+});
+
+test('buildMcpArgs quotes Windows config paths containing spaces', () => {
+  const configPath = 'C:\\Users\\Power User\\.claude\\plugins\\power-pages\\scripts\\playwright-mcp-fullscreen.config.json';
+  const args = buildMcpArgs('msedge', { configPath, platform: 'win32' });
+  const configIndex = args.indexOf('--config');
+
+  assert.equal(args[configIndex + 1], `"${configPath}"`);
 });
 
 test('fullscreen config maximizes the browser and uses the real viewport size', () => {

--- a/plugins/power-pages/scripts/tests/launch-playwright-mcp.test.js
+++ b/plugins/power-pages/scripts/tests/launch-playwright-mcp.test.js
@@ -11,16 +11,14 @@ const {
 } = require('../launch-playwright-mcp');
 
 test('buildMcpArgs launches Playwright MCP with fullscreen config', () => {
+  const expectedConfigPath = path.join(__dirname, '..', 'playwright-mcp-fullscreen.config.json');
   const args = buildMcpArgs('chrome');
   const configIndex = args.indexOf('--config');
-  const quotedConfigPath = args[configIndex + 1];
-  const configPath = quotedConfigPath.slice(1, -1);
 
   assert.deepEqual(args.slice(0, 3), ['@playwright/mcp@latest', '--browser', 'chrome']);
   assert.equal(args.includes('--viewport-size'), false);
   assert.notEqual(configIndex, -1);
-  assert.equal(quotedConfigPath, quoteShellArg(configPath));
-  assert.equal(path.basename(configPath), 'playwright-mcp-fullscreen.config.json');
+  assert.equal(args[configIndex + 1], quoteShellArg(expectedConfigPath));
 });
 
 test('buildMcpArgs quotes Windows config paths containing spaces', () => {


### PR DESCRIPTION
The Power Pages Playwright MCP launcher passes its config path through `shell: true`, so plugin install paths containing spaces can be split by the shell before reaching `@playwright/mcp`. This change quotes the generated config path before it is passed to `npx`, preserving it as one argument.

## Changes

- Adds shell argument quoting for the fullscreen config path, including Windows `cmd.exe` handling.
- Lets the launcher test inject a config path/platform and adds regression coverage for Windows paths with spaces.

## Validation

- `node --test plugins/power-pages/scripts/tests/launch-playwright-mcp.test.js`
- `node --test plugins/power-pages/scripts/tests/`

Fixes #186