### PR TITLE
Telemetry hardening: prevent test prod-leak and tighten transmission gating

### DIFF
--- a/.github/workflows/power-pages-alm-lint.yml
+++ b/.github/workflows/power-pages-alm-lint.yml
@@ -17,6 +17,12 @@ jobs:
     alm-lint:
         name: alm-lint
         runs-on: ubuntu-latest
+        # Consistency backstop: keep all power-pages CI opted out of telemetry
+        # transmission. This job runs only the linter today (no emission), so the
+        # var is inert here — it guarantees no transmission if an emitting step is
+        # ever added to this workflow.
+        env:
+            POWER_PLATFORM_SKILLS_TELEMETRY_POWER_PAGES_OPTOUT: "1"
         steps:
             - name: checkout
               uses: actions/checkout@v4

--- a/.github/workflows/power-pages-script-tests.yml
+++ b/.github/workflows/power-pages-script-tests.yml
@@ -16,6 +16,14 @@ jobs:
     test-power-pages-scripts:
         name: test-power-pages-scripts (${{ matrix.os }})
         runs-on: ${{ matrix.os }}
+        # Defense-in-depth: opt this CI job out of telemetry transmission so even
+        # a test that forgets to isolate emission (no FAKE_HTTPS probe / temp
+        # ikey) can never POST to the production collector. Honored end-to-end
+        # because emit-spawn forwards this var to the detached dispatcher. The two
+        # positive-emission tests clear it in their own spawn env so they still
+        # exercise the real emit path.
+        env:
+            POWER_PLATFORM_SKILLS_TELEMETRY_POWER_PAGES_OPTOUT: "1"
         strategy:
             fail-fast: false
             matrix:

--- a/plugins/power-pages/scripts/tests/run-user-prompt-telemetry.test.js
+++ b/plugins/power-pages/scripts/tests/run-user-prompt-telemetry.test.js
@@ -26,6 +26,9 @@ function runHook({ prompt, configDir, fakeProbe, ikeyPath }) {
       POWER_PLATFORM_SKILLS_CONFIG_DIR: configDir,
       POWER_PLATFORM_SKILLS_FAKE_HTTPS: fakeProbe || "",
       POWER_PLATFORM_SKILLS_IKEY_JSON: ikeyPath || "",
+      // Clear the workflow-wide opt-out backstop (set in power-pages-script-tests.yml)
+      // so the emit-detection test still exercises the real path to its probe.
+      POWER_PLATFORM_SKILLS_TELEMETRY_POWER_PAGES_OPTOUT: "",
     },
     // The enabled path shells out to `pac auth who` + `pac --version`, each
     // capped at 8s (see lib/pac-auth.js). The hook's documented budget is ~30s;

--- a/plugins/power-pages/scripts/tests/run-user-prompt-telemetry.test.js
+++ b/plugins/power-pages/scripts/tests/run-user-prompt-telemetry.test.js
@@ -53,7 +53,7 @@ function waitForFile(filePath, timeoutMs) {
   return fs.existsSync(filePath);
 }
 
-test("hook emits PagesPluginEvent with top-level fields for tracked slash command", () => {
+test("hook emits PagesAIPluginEvent with top-level fields for tracked slash command", () => {
   const configDir = mkConfigDir();
   const probePath = path.join(configDir, "probe.json");
   // Point the hook at a temp ikey.json via the override seam instead of
@@ -63,7 +63,7 @@ test("hook emits PagesPluginEvent with top-level fields for tracked slash comman
   fs.writeFileSync(
     ikeyPath,
     JSON.stringify({
-      event_stream_name: "PagesPluginEvent",
+      event_stream_name: "PagesAIPluginEvent",
       disabled: false,
       default_region: "us",
       regions: {
@@ -101,7 +101,7 @@ test("hook emits PagesPluginEvent with top-level fields for tracked slash comman
   assert.ok(probe.body.endsWith("\n"), "body must be newline-terminated");
   const body = JSON.parse(probe.body);
   assert.deepEqual(Object.keys(body).sort(), ["data", "iKey", "name", "time", "ver"]);
-  assert.equal(body.name, "PagesPluginEvent");
+  assert.equal(body.name, "PagesAIPluginEvent");
   assert.equal(body.ver, "4.0");
   assert.match(body.iKey, /^o:/);
   assert.equal(body.data.eventName, "skill_started");

--- a/plugins/power-pages/scripts/tests/telemetry-hook-pretool.test.js
+++ b/plugins/power-pages/scripts/tests/telemetry-hook-pretool.test.js
@@ -22,11 +22,9 @@ function runHook({ input, configDir, ikeyPath, fakeProbe }) {
       ...process.env,
       POWER_PLATFORM_SKILLS_CONFIG_DIR: configDir,
       POWER_PLATFORM_SKILLS_IKEY_JSON: ikeyPath || "",
-      // Route any actual emission to a local probe file instead of POSTing to
-      // the production OneCollector. CRITICAL for the provisioned/enabled path:
-      // the checked-in ikey.json now ships disabled:false + a real instrumentation
-      // key, so a hook test that reaches fireAndForget without a probe would emit
-      // a fake create-site event to prod telemetry on every CI run.
+      // Routes emission to a local probe instead of the real OneCollector.
+      // Without it, the provisioned path (checked-in ikey.json ships enabled +
+      // a real key) would POST a fake event to prod telemetry on every CI run.
       POWER_PLATFORM_SKILLS_FAKE_HTTPS: fakeProbe || "",
     },
     // The provisioned path shells out to `pac auth who` + `pac --version`, each
@@ -41,8 +39,6 @@ function sleep(ms) {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
 }
 
-// Poll for a file up to timeoutMs, sleeping between checks so the test runner
-// stays responsive. Returns whether the file exists at the end.
 function waitForFile(filePath, timeoutMs) {
   const deadline = Date.now() + timeoutMs;
   while (!fs.existsSync(filePath) && Date.now() < deadline) {
@@ -51,11 +47,10 @@ function waitForFile(filePath, timeoutMs) {
   return fs.existsSync(filePath);
 }
 
-// Writes an isolated, fully-provisioned telemetry config (temp ikey.json +
-// resolver.js) into configDir and returns the ikey path. Mirrors the shipped
-// plugin layout: the dispatcher discovers region routing via a resolver.js
-// sibling of ikey.json, so the region isProvisioned() gate runs against a
-// real-shaped (but example.invalid) key rather than the checked-in prod config.
+// Writes an isolated, provisioned telemetry config into configDir (temp
+// ikey.json + a resolver.js sibling — the dispatcher discovers region routing
+// by that convention) so emission runs against an example.invalid key instead
+// of the checked-in prod config. Returns the ikey path.
 function writeProvisionedConfig(configDir) {
   const ikeyPath = path.join(configDir, "ikey.json");
   fs.writeFileSync(
@@ -100,13 +95,9 @@ test("exits 0 when malformed stdin", () => {
 });
 
 test("exits 0 and emits skill_started to probe when skill is tracked (provisioned)", () => {
-  // Regression guard: this test previously ran the real hook with no ikey
-  // override and no FAKE_HTTPS probe. Once the checked-in ikey.json flipped to
-  // disabled:false with a real US instrumentation key, that produced a real
-  // HTTPS POST of a fake `create-site` skill_started event to the production
-  // OneCollector on every CI run (3 OS × every PR). Isolate via the override
-  // seam + a fake probe so the tracked-skill emit path is exercised WITHOUT
-  // touching prod telemetry.
+  // Regression guard: previously ran the real hook with no ikey override and no
+  // probe, so once the checked-in config went live it POSTed a fake create-site
+  // event to prod on every CI run. Override seam + probe keep it isolated.
   const configDir = mkConfigDir();
   const probePath = path.join(configDir, "probe.json");
   const ikeyPath = writeProvisionedConfig(configDir);

--- a/plugins/power-pages/scripts/tests/telemetry-hook-pretool.test.js
+++ b/plugins/power-pages/scripts/tests/telemetry-hook-pretool.test.js
@@ -22,6 +22,9 @@ function runHook({ input, configDir, ikeyPath, fakeProbe }) {
       ...process.env,
       POWER_PLATFORM_SKILLS_CONFIG_DIR: configDir,
       POWER_PLATFORM_SKILLS_IKEY_JSON: ikeyPath || "",
+      // Clear the workflow-wide opt-out backstop (set in power-pages-script-tests.yml)
+      // so the provisioned test still exercises the real emit path to its probe.
+      POWER_PLATFORM_SKILLS_TELEMETRY_POWER_PAGES_OPTOUT: "",
       // Routes emission to a local probe instead of the real OneCollector.
       // Without it, the provisioned path (checked-in ikey.json ships enabled +
       // a real key) would POST a fake event to prod telemetry on every CI run.

--- a/plugins/power-pages/scripts/tests/telemetry-hook-pretool.test.js
+++ b/plugins/power-pages/scripts/tests/telemetry-hook-pretool.test.js
@@ -133,7 +133,7 @@ test("pretool hook exits 0 when ikey.json has regions but default_region entry h
   fs.writeFileSync(
     ikeyPath,
     JSON.stringify({
-      event_stream_name: "PagesPluginEvent",
+      event_stream_name: "PagesAIPluginEvent",
       disabled: false,
       default_region: "us",
       regions: { us: { collector_url: "https://x" } },

--- a/plugins/power-pages/scripts/tests/telemetry-hook-pretool.test.js
+++ b/plugins/power-pages/scripts/tests/telemetry-hook-pretool.test.js
@@ -59,7 +59,9 @@ function writeProvisionedConfig(configDir) {
   fs.writeFileSync(
     ikeyPath,
     JSON.stringify({
-      event_stream_name: "PagesPluginEvent",
+      // Mirror the shipped ikey.json stream name so the asserted envelope name
+      // matches real production behavior (the checked-in config uses this).
+      event_stream_name: "PagesAIPluginEvent",
       disabled: false,
       default_region: "us",
       regions: {
@@ -115,7 +117,7 @@ test("exits 0 and emits skill_started to probe when skill is tracked (provisione
   assert.ok(waitForFile(probePath, 5_000), "dispatcher should have written probe");
   const probe = JSON.parse(fs.readFileSync(probePath, "utf8"));
   const body = JSON.parse(probe.body);
-  assert.equal(body.name, "PagesPluginEvent");
+  assert.equal(body.name, "PagesAIPluginEvent");
   assert.equal(body.data.eventName, "skill_started");
   assert.equal(body.data.pluginName, "power-pages");
   assert.equal(body.data.skillName, "create-site");

--- a/plugins/power-pages/scripts/tests/telemetry-hook-pretool.test.js
+++ b/plugins/power-pages/scripts/tests/telemetry-hook-pretool.test.js
@@ -14,7 +14,7 @@ function mkConfigDir() {
   return fs.mkdtempSync(path.join(os.tmpdir(), "ppskills-ph-"));
 }
 
-function runHook({ input, configDir, ikeyPath }) {
+function runHook({ input, configDir, ikeyPath, fakeProbe }) {
   return spawnSync(process.execPath, [HOOK], {
     input,
     encoding: "utf8",
@@ -22,8 +22,68 @@ function runHook({ input, configDir, ikeyPath }) {
       ...process.env,
       POWER_PLATFORM_SKILLS_CONFIG_DIR: configDir,
       POWER_PLATFORM_SKILLS_IKEY_JSON: ikeyPath || "",
+      // Route any actual emission to a local probe file instead of POSTing to
+      // the production OneCollector. CRITICAL for the provisioned/enabled path:
+      // the checked-in ikey.json now ships disabled:false + a real instrumentation
+      // key, so a hook test that reaches fireAndForget without a probe would emit
+      // a fake create-site event to prod telemetry on every CI run.
+      POWER_PLATFORM_SKILLS_FAKE_HTTPS: fakeProbe || "",
     },
+    // The provisioned path shells out to `pac auth who` + `pac --version`, each
+    // capped at 8s (see lib/pac-auth.js). Match the hook's ~30s budget so the
+    // integration path doesn't flake on pac cold-start when pac is installed.
+    timeout: 30_000,
   });
+}
+
+// Synchronous sleep that parks the thread instead of busy-spinning the CPU.
+function sleep(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+// Poll for a file up to timeoutMs, sleeping between checks so the test runner
+// stays responsive. Returns whether the file exists at the end.
+function waitForFile(filePath, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (!fs.existsSync(filePath) && Date.now() < deadline) {
+    sleep(25);
+  }
+  return fs.existsSync(filePath);
+}
+
+// Writes an isolated, fully-provisioned telemetry config (temp ikey.json +
+// resolver.js) into configDir and returns the ikey path. Mirrors the shipped
+// plugin layout: the dispatcher discovers region routing via a resolver.js
+// sibling of ikey.json, so the region isProvisioned() gate runs against a
+// real-shaped (but example.invalid) key rather than the checked-in prod config.
+function writeProvisionedConfig(configDir) {
+  const ikeyPath = path.join(configDir, "ikey.json");
+  fs.writeFileSync(
+    ikeyPath,
+    JSON.stringify({
+      event_stream_name: "PagesPluginEvent",
+      disabled: false,
+      default_region: "us",
+      regions: {
+        us: {
+          instrumentation_key: "test-ikey-32-chars-minimum-aaaaaaaaaaaaaa",
+          collector_url: "https://example.invalid/OneCollector/1.0/",
+        },
+      },
+    })
+  );
+  const shippedResolver = path.join(
+    PLUGIN_ROOT,
+    "scripts",
+    "lib",
+    "telemetry",
+    "resolver.js"
+  );
+  fs.writeFileSync(
+    path.join(configDir, "resolver.js"),
+    `module.exports = require(${JSON.stringify(shippedResolver)});\n`
+  );
+  return ikeyPath;
 }
 
 test("exits 0 and emits nothing when tool_input has no tracked skill", () => {
@@ -39,12 +99,32 @@ test("exits 0 when malformed stdin", () => {
   assert.equal(status, 0);
 });
 
-test("exits 0 when skill is tracked (placeholder iKey → no-op emit)", () => {
+test("exits 0 and emits skill_started to probe when skill is tracked (provisioned)", () => {
+  // Regression guard: this test previously ran the real hook with no ikey
+  // override and no FAKE_HTTPS probe. Once the checked-in ikey.json flipped to
+  // disabled:false with a real US instrumentation key, that produced a real
+  // HTTPS POST of a fake `create-site` skill_started event to the production
+  // OneCollector on every CI run (3 OS × every PR). Isolate via the override
+  // seam + a fake probe so the tracked-skill emit path is exercised WITHOUT
+  // touching prod telemetry.
+  const configDir = mkConfigDir();
+  const probePath = path.join(configDir, "probe.json");
+  const ikeyPath = writeProvisionedConfig(configDir);
+
   const { status } = runHook({
     input: JSON.stringify({ tool_input: { skill: "create-site" } }),
-    configDir: mkConfigDir(),
+    configDir,
+    ikeyPath,
+    fakeProbe: probePath,
   });
   assert.equal(status, 0);
+  assert.ok(waitForFile(probePath, 5_000), "dispatcher should have written probe");
+  const probe = JSON.parse(fs.readFileSync(probePath, "utf8"));
+  const body = JSON.parse(probe.body);
+  assert.equal(body.name, "PagesPluginEvent");
+  assert.equal(body.data.eventName, "skill_started");
+  assert.equal(body.data.pluginName, "power-pages");
+  assert.equal(body.data.skillName, "create-site");
 });
 
 test("pretool hook exits 0 when ikey.json has regions but default_region entry has no key", () => {

--- a/shared/telemetry/lib/emit-spawn.js
+++ b/shared/telemetry/lib/emit-spawn.js
@@ -48,9 +48,10 @@ function fireAndForget(event, opts = {}) {
           process.env.POWER_PLATFORM_SKILLS_IKEY_JSON || ikeyJsonPath || "",
         // The opt-out is enforced in the detached dispatcher, which reads the
         // child's process.env — so the minimal allowlist must forward this var
-        // explicitly or the highest-precedence opt-out never reaches it. Added
-        // only when set, so it never plants an empty var the dispatcher would
-        // read as "present".
+        // explicitly or the highest-precedence opt-out never reaches it. Forward
+        // only when actually set: an empty/unset value is a no-op for the
+        // dispatcher's check (it trims and matches only "1"/"true"), so there's
+        // no point planting an empty var in the child env.
         ...(optOutVarName && optOutValue
           ? { [optOutVarName]: optOutValue }
           : {}),

--- a/shared/telemetry/lib/emit-spawn.js
+++ b/shared/telemetry/lib/emit-spawn.js
@@ -12,16 +12,6 @@ function fireAndForget(event, opts = {}) {
   const configDir = opts.configDir || "";
   const fakeProbe = opts.fakeProbe || "";
   const cloud = opts.cloud || "";
-  // The per-plugin transmission opt-out env var
-  // (POWER_PLATFORM_SKILLS_TELEMETRY_<PLUGIN>_OPTOUT) is enforced inside the
-  // DETACHED dispatcher child (it suppresses the POST only, after the local
-  // mirror is written — so the hooks deliberately don't short-circuit on it).
-  // The child env below is a deliberate minimal allowlist that drops everything
-  // else, so we must forward this one var explicitly or the documented
-  // highest-precedence opt-out silently never reaches the code that honors it.
-  // Derive the exact var name from the event's pluginName and forward its value
-  // when present; forwarding a single boolean-ish flag preserves the
-  // no-secrets-to-the-child posture.
   const pluginName = event && event.data && event.data.pluginName;
   const optOutVarName = pluginName ? telemetryOptOutEnvVarName(pluginName) : "";
   const optOutValue =
@@ -56,11 +46,11 @@ function fireAndForget(event, opts = {}) {
         // plugin's real config rather than shared/'s placeholder.
         POWER_PLATFORM_SKILLS_IKEY_JSON:
           process.env.POWER_PLATFORM_SKILLS_IKEY_JSON || ikeyJsonPath || "",
-        // Forward the per-plugin opt-out flag under its real var name so the
-        // dispatcher's isTransmissionOptedOut() (which reads the child's
-        // process.env) can honor the env-var opt-out. Only added when actually
-        // set in the parent, so it never re-creates an empty var the dispatcher
-        // would treat as "present".
+        // The opt-out is enforced in the detached dispatcher, which reads the
+        // child's process.env — so the minimal allowlist must forward this var
+        // explicitly or the highest-precedence opt-out never reaches it. Added
+        // only when set, so it never plants an empty var the dispatcher would
+        // read as "present".
         ...(optOutVarName && optOutValue
           ? { [optOutVarName]: optOutValue }
           : {}),

--- a/shared/telemetry/lib/emit-spawn.js
+++ b/shared/telemetry/lib/emit-spawn.js
@@ -2,6 +2,7 @@
 
 const { spawn } = require("node:child_process");
 const path = require("node:path");
+const { telemetryOptOutEnvVarName } = require("./user-config");
 
 const DISPATCHER = path.resolve(__dirname, "emit-dispatcher.js");
 
@@ -11,6 +12,20 @@ function fireAndForget(event, opts = {}) {
   const configDir = opts.configDir || "";
   const fakeProbe = opts.fakeProbe || "";
   const cloud = opts.cloud || "";
+  // The per-plugin transmission opt-out env var
+  // (POWER_PLATFORM_SKILLS_TELEMETRY_<PLUGIN>_OPTOUT) is enforced inside the
+  // DETACHED dispatcher child (it suppresses the POST only, after the local
+  // mirror is written — so the hooks deliberately don't short-circuit on it).
+  // The child env below is a deliberate minimal allowlist that drops everything
+  // else, so we must forward this one var explicitly or the documented
+  // highest-precedence opt-out silently never reaches the code that honors it.
+  // Derive the exact var name from the event's pluginName and forward its value
+  // when present; forwarding a single boolean-ish flag preserves the
+  // no-secrets-to-the-child posture.
+  const pluginName = event && event.data && event.data.pluginName;
+  const optOutVarName = pluginName ? telemetryOptOutEnvVarName(pluginName) : "";
+  const optOutValue =
+    optOutVarName && process.env[optOutVarName] ? process.env[optOutVarName] : "";
   // Absolute path to the CALLING plugin's ikey.json. The dispatcher lives in
   // shared/telemetry/lib (reached via the per-plugin symlink), so its own
   // __dirname-based default would resolve to shared/'s placeholder, not the
@@ -41,6 +56,14 @@ function fireAndForget(event, opts = {}) {
         // plugin's real config rather than shared/'s placeholder.
         POWER_PLATFORM_SKILLS_IKEY_JSON:
           process.env.POWER_PLATFORM_SKILLS_IKEY_JSON || ikeyJsonPath || "",
+        // Forward the per-plugin opt-out flag under its real var name so the
+        // dispatcher's isTransmissionOptedOut() (which reads the child's
+        // process.env) can honor the env-var opt-out. Only added when actually
+        // set in the parent, so it never re-creates an empty var the dispatcher
+        // would treat as "present".
+        ...(optOutVarName && optOutValue
+          ? { [optOutVarName]: optOutValue }
+          : {}),
       },
     });
     try {

--- a/shared/telemetry/tests/emit-spawn.test.js
+++ b/shared/telemetry/tests/emit-spawn.test.js
@@ -118,11 +118,10 @@ test("opts.ikeyJsonPath points the dispatcher at the caller's ikey.json (no env 
 });
 
 test("env-var opt-out suppresses the POST through the real spawn chain (mirror still written)", async () => {
-  // Regression guard for the gap where emit-spawn's minimal child-env allowlist
-  // dropped POWER_PLATFORM_SKILLS_TELEMETRY_<PLUGIN>_OPTOUT, so the dispatcher —
-  // the code that enforces the opt-out — never received it and POSTed anyway.
-  // The dispatcher's own unit test injects the var directly onto the child, which
-  // masked this; only the full fireAndForget → dispatcher chain exposes it.
+  // Regression guard: emit-spawn's minimal child-env allowlist used to drop the
+  // _OPTOUT var, so the dispatcher (which enforces the opt-out) never saw it and
+  // POSTed anyway. The dispatcher's own test injects the var directly, masking
+  // it — only the full fireAndForget → dispatcher chain exposes the gap.
   const tmp = mkTmp();
   const probe = path.join(tmp, "probe.json");
   const ikeyJsonPath = path.join(tmp, "ikey.json");
@@ -173,8 +172,8 @@ test("env-var opt-out suppresses the POST through the real spawn chain (mirror s
     await new Promise((r) => setTimeout(r, 100));
   }
   assert.ok(fs.existsSync(mirror), "local mirror should be written even when opted out");
-  // Opt-out honored → the FAKE_HTTPS probe (which stands in for the real POST)
-  // must NOT exist. The mirror above proves the child ran past the gate.
+  // Probe stands in for the real POST; the mirror above proves the child ran
+  // past the gate, so its absence means the opt-out suppressed transmission.
   assert.ok(!fs.existsSync(probe), "env-var opt-out must suppress the POST/probe");
 });
 

--- a/shared/telemetry/tests/emit-spawn.test.js
+++ b/shared/telemetry/tests/emit-spawn.test.js
@@ -117,6 +117,67 @@ test("opts.ikeyJsonPath points the dispatcher at the caller's ikey.json (no env 
   );
 });
 
+test("env-var opt-out suppresses the POST through the real spawn chain (mirror still written)", async () => {
+  // Regression guard for the gap where emit-spawn's minimal child-env allowlist
+  // dropped POWER_PLATFORM_SKILLS_TELEMETRY_<PLUGIN>_OPTOUT, so the dispatcher —
+  // the code that enforces the opt-out — never received it and POSTed anyway.
+  // The dispatcher's own unit test injects the var directly onto the child, which
+  // masked this; only the full fireAndForget → dispatcher chain exposes it.
+  const tmp = mkTmp();
+  const probe = path.join(tmp, "probe.json");
+  const ikeyJsonPath = path.join(tmp, "ikey.json");
+  fs.writeFileSync(
+    ikeyJsonPath,
+    JSON.stringify({
+      instrumentationKey: "placeholder",
+      collector_url: "https://example.invalid/",
+      event_stream_name: "PowerPagesPluginEvent",
+      disabled: false,
+    })
+  );
+  const optEvent = {
+    name: "PowerPagesPluginEvent",
+    data: {
+      eventName: "skill_started",
+      eventType: "Trace",
+      severity: "Info",
+      pluginName: "power-pages",
+      skillName: "hello",
+    },
+  };
+  const optVar = "POWER_PLATFORM_SKILLS_TELEMETRY_POWER_PAGES_OPTOUT";
+  const prevOpt = process.env[optVar];
+  const prevIkeyJson = process.env.POWER_PLATFORM_SKILLS_IKEY_JSON;
+  process.env[optVar] = "1";
+  delete process.env.POWER_PLATFORM_SKILLS_IKEY_JSON; // exercise opts.ikeyJsonPath path
+  try {
+    fireAndForget(optEvent, {
+      iKey: "real-ikey-32-chars-minimum-aaaaaaaaaaaaaa",
+      collectorUrl: "https://example.invalid/OneCollector/1.0/",
+      configDir: tmp,
+      fakeProbe: probe,
+      ikeyJsonPath,
+    });
+  } finally {
+    if (prevOpt === undefined) delete process.env[optVar];
+    else process.env[optVar] = prevOpt;
+    if (prevIkeyJson === undefined) delete process.env.POWER_PLATFORM_SKILLS_IKEY_JSON;
+    else process.env.POWER_PLATFORM_SKILLS_IKEY_JSON = prevIkeyJson;
+  }
+  // The local mirror is written BEFORE the opt-out gate, so wait on it to know
+  // the detached child actually ran and reached the gate (rather than asserting
+  // absence against a child that simply hadn't started yet).
+  const mirror = path.join(tmp, "events.jsonl");
+  for (let i = 0; i < 30; i++) {
+    if (fs.existsSync(mirror)) break;
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  assert.ok(fs.existsSync(mirror), "local mirror should be written even when opted out");
+  // Opt-out honored → the FAKE_HTTPS probe (which stands in for the real POST)
+  // must NOT exist. The mirror above proves the child ran past the gate.
+  assert.ok(!fs.existsSync(probe), "env-var opt-out must suppress the POST/probe");
+});
+
 test("fireAndForget does not throw on empty-opts invocation", () => {
   fireAndForget({ name: "X", data: {} }, { iKey: "", collectorUrl: "" });
   // No assertion needed: test passes if no throw.


### PR DESCRIPTION
- **Stop a CI test from polluting production telemetry.** A hook test ran the **real** telemetry hook for a tracked skill with no ikey override and no `FAKE_HTTPS` probe. Once the checked-in config flipped to enabled, that fired a fake `skill_started` event to the production collector on every CI run (3 OS × every PR). Isolated it via the override seam + a fake probe like its siblings, and upgraded the stale "exit 0" no-op into a positive assertion that the event lands in the local probe, never in prod.
- **Tighten transmission gating in the emit chain.** Closed a gap where a documented suppression control was not honored end-to-end because of how the detached dispatcher child is spawned. Added a full `fireAndForget → dispatcher` chain test asserting transmission is suppressed while the local diagnostic mirror is still written.