### PR TITLE
Replace PAT auth in github-repo-stats with GitHub App token

### DIFF
--- a/.github/workflows/github-repo-stats.yml
+++ b/.github/workflows/github-repo-stats.yml
@@ -21,6 +21,8 @@ jobs:
               with:
                   app-id: 3189942
                   private-key: ${{ secrets.POWER_PLATFORM_SKILLS_APP_PRIVATE_KEY }}
+                  permission-administration: read
+                  permission-contents: write
 
             - name: run-ghrs
               # Use latest release.

--- a/.github/workflows/github-repo-stats.yml
+++ b/.github/workflows/github-repo-stats.yml
@@ -7,16 +7,26 @@ on:
         - cron: "0 23 * * *"
     workflow_dispatch: # Allow for running this manually.
 
+permissions:
+    contents: read
+
 jobs:
     j1:
         name: github-repo-stats
         runs-on: ubuntu-latest
         steps:
+            - name: generate app token
+              id: app-token
+              uses: actions/create-github-app-token@v1
+              with:
+                  app-id: 3189942
+                  private-key: ${{ secrets.POWER_PLATFORM_SKILLS_APP_PRIVATE_KEY }}
+
             - name: run-ghrs
               # Use latest release.
               uses: jgehrcke/github-repo-stats@RELEASE
               with:
                   repository: microsoft/power-platform-skills
-                  ghtoken: ${{ secrets.ghrs_github_api_token }}
+                  ghtoken: ${{ steps.app-token.outputs.token }}
                   databranch: github-repo-stats
                   ghpagesprefix: https://microsoft.github.io/power-platform-skills


### PR DESCRIPTION
## Problem

The daily `github-repo-stats` workflow authenticated with a fine-grained PAT (`GHRS_GITHUB_API_TOKEN`). The *Microsoft Open Source* enterprise now forbids fine-grained PATs whose lifetime exceeds 8 days, so the run [now fails](https://github.com/microsoft/power-platform-skills/actions/runs/28482516811/job/84421820942) with a 403 from the traffic fetch. PATs can't be generated via API, so a static PAT secret can't be kept valid.

## Change

Mint a short-lived (~1 hour) GitHub App installation token at run time and pass it to the action instead of the PAT. This reuses the existing Power Platform Skills App (id `3189942`) and `POWER_PLATFORM_SKILLS_APP_PRIVATE_KEY` secret already wired up in `ensure-skill-version-check.yml`. The App's private key doesn't expire and the token is auto-minted per run, so there's no 7-day rotation to maintain.

The default `GITHUB_TOKEN` is set to read-only since all API/git work uses the App token.

## Required before this works

The reused App must grant **Administration: Read** on this repo (required by the repository traffic API for views/clones), in addition to the Contents: Read and write it already uses to push to the `github-repo-stats` data branch. Adding that permission requires a one-time org-owner approval of the pending installation request.

## Cleanup

The old `GHRS_GITHUB_API_TOKEN` PAT secret is now unused and can be deleted.