### PR TITLE
Log Entra ID Object Id in Power Pages telemetry eventInfo

### DIFF
--- a/plugins/power-pages/hooks/run-skill-pretool-telemetry.js
+++ b/plugins/power-pages/hooks/run-skill-pretool-telemetry.js
@@ -144,6 +144,7 @@ function readStdin() {
   };
   if (pacAuth && pacAuth.orgId) fields.orgId = pacAuth.orgId;
   if (pacAuth && pacAuth.tenantId) fields.tenantId = pacAuth.tenantId;
+  if (pacAuth && pacAuth.objectId) fields.eventInfo = { aadObjectId: pacAuth.objectId };
   if (agentInfo.aiAgentName) fields.aiAgentName = agentInfo.aiAgentName;
   if (agentInfo.aiAgentVersion) fields.aiAgentVersion = agentInfo.aiAgentVersion;
   if (agentInfo.pacCliVersion) fields.pacCliVersion = agentInfo.pacCliVersion;

--- a/plugins/power-pages/scripts/lib/telemetry/lib/emit-dispatcher.js
+++ b/plugins/power-pages/scripts/lib/telemetry/lib/emit-dispatcher.js
@@ -85,16 +85,28 @@ function sanitizeData(data) {
   return filtered;
 }
 
-// Build the CS4.0 envelope from a pre-sanitized payload + timestamp. Both are
-// computed once in the stdin handler and shared with the local mirror so the
-// on-disk record and the wire envelope carry byte-identical `data` and `time`.
+// Build the CS4.0 envelope from a pre-sanitized payload + timestamp. `sanitized`
+// is shared with the local mirror so the on-disk record and the wire envelope
+// carry byte-identical `data` and `time` for every OTHER field, but `eventInfo`
+// is re-serialized to a JSON string just for the wire: the tenant-side
+// Interchange/LogAnalytics field mapping flattens `data.<key>` to a single
+// `data_<key>` leaf token, and that flattening does not recurse into nested
+// object values, so a raw `eventInfo` object never produces the `data_eventInfo`
+// token the mapping expects. Stringifying keeps `eventInfo` a scalar leaf that
+// matches the existing mapping; the Kusto side reads it back with
+// `parse_json(EventInfo)` / `todynamic(EventInfo)`. The local mirror keeps the
+// real object so `events.jsonl` stays human-readable for local diagnostics.
 function buildEnvelope(eventName, time, sanitized, resolvedIKey, eventStreamName) {
+  const wireData = { ...sanitized };
+  if (wireData.eventInfo !== undefined) {
+    wireData.eventInfo = JSON.stringify(wireData.eventInfo);
+  }
   return {
     ver: "4.0",
     name: eventStreamName || eventName || "",
     time,
     iKey: "o:" + String(resolvedIKey || "").split("-")[0],
-    data: sanitized,
+    data: wireData,
   };
 }
 
@@ -138,8 +150,10 @@ process.stdin.on("end", async () => {
   }
 
   // Compute the sanitized payload + timestamp ONCE. The sanitized data is
-  // exactly what lands in Kusto (its field names ARE the Kusto column names);
-  // the local mirror and the wire envelope share it so they can never diverge.
+  // exactly what lands in Kusto (its field names ARE the Kusto column names)
+  // for every field except `eventInfo`, which buildEnvelope() re-serializes
+  // to a JSON string just for the wire (see buildEnvelope comment) — the
+  // local mirror below keeps the real object.
   const time = new Date().toISOString();
   const sanitized = sanitizeData(event.data);
   const localRecord = { time, name: event.name, data: sanitized };

--- a/plugins/power-pages/scripts/lib/telemetry/lib/emit-dispatcher.js
+++ b/plugins/power-pages/scripts/lib/telemetry/lib/emit-dispatcher.js
@@ -86,16 +86,12 @@ function sanitizeData(data) {
 }
 
 // Build the CS4.0 envelope from a pre-sanitized payload + timestamp. `sanitized`
-// is shared with the local mirror so the on-disk record and the wire envelope
-// carry byte-identical `data` and `time` for every OTHER field, but `eventInfo`
-// is re-serialized to a JSON string just for the wire: the tenant-side
-// Interchange/LogAnalytics field mapping flattens `data.<key>` to a single
-// `data_<key>` leaf token, and that flattening does not recurse into nested
-// object values, so a raw `eventInfo` object never produces the `data_eventInfo`
-// token the mapping expects. Stringifying keeps `eventInfo` a scalar leaf that
-// matches the existing mapping; the Kusto side reads it back with
-// `parse_json(EventInfo)` / `todynamic(EventInfo)`. The local mirror keeps the
-// real object so `events.jsonl` stays human-readable for local diagnostics.
+// is shared with the local mirror so `data`/`time` stay byte-identical for
+// every field except `eventInfo`: the tenant-side field mapping flattens
+// `data.<key>` to a single `data_<key>` leaf and doesn't recurse into nested
+// objects, so `eventInfo` is stringified just for the wire to survive that
+// flattening. Kusto reads it back with `parse_json()`/`todynamic()`; the
+// local mirror keeps the real object for human readability.
 function buildEnvelope(eventName, time, sanitized, resolvedIKey, eventStreamName) {
   const wireData = { ...sanitized };
   if (wireData.eventInfo !== undefined) {
@@ -150,10 +146,8 @@ process.stdin.on("end", async () => {
   }
 
   // Compute the sanitized payload + timestamp ONCE. The sanitized data is
-  // exactly what lands in Kusto (its field names ARE the Kusto column names)
-  // for every field except `eventInfo`, which buildEnvelope() re-serializes
-  // to a JSON string just for the wire (see buildEnvelope comment) — the
-  // local mirror below keeps the real object.
+  // exactly what lands in Kusto (its field names ARE the Kusto column names),
+  // except `eventInfo` which buildEnvelope() re-serializes for the wire only.
   const time = new Date().toISOString();
   const sanitized = sanitizeData(event.data);
   const localRecord = { time, name: event.name, data: sanitized };

--- a/plugins/power-pages/scripts/lib/telemetry/lib/emit-from-prompt.js
+++ b/plugins/power-pages/scripts/lib/telemetry/lib/emit-from-prompt.js
@@ -116,6 +116,7 @@ function emitSkillStartedFromPrompt(promptText, opts = {}) {
   };
   if (pacAuth && pacAuth.orgId) fields.orgId = pacAuth.orgId;
   if (pacAuth && pacAuth.tenantId) fields.tenantId = pacAuth.tenantId;
+  if (pacAuth && pacAuth.objectId) fields.eventInfo = { aadObjectId: pacAuth.objectId };
   if (agentInfo.aiAgentName) fields.aiAgentName = agentInfo.aiAgentName;
   if (agentInfo.aiAgentVersion) fields.aiAgentVersion = agentInfo.aiAgentVersion;
   if (agentInfo.pacCliVersion) fields.pacCliVersion = agentInfo.pacCliVersion;

--- a/plugins/power-pages/scripts/lib/telemetry/lib/events.js
+++ b/plugins/power-pages/scripts/lib/telemetry/lib/events.js
@@ -10,7 +10,10 @@
 //                  or negative values clamp to 0. Sent as number, not string.
 //   "object"     — Kusto column type `dynamic` (JSON). Plain objects and
 //                  arrays pass through; primitives, Date, RegExp, etc. are
-//                  dropped to avoid Kusto type confusion.
+//                  dropped to avoid Kusto type confusion. Validated here as a
+//                  real object; emit-dispatcher.js re-serializes it to a JSON
+//                  string just before it hits the wire (see buildEnvelope),
+//                  so the Kusto side must `parse_json()` / `todynamic()` it.
 //   "enum:a|b|c" — Kusto column type `string`. Only the listed values are
 //                  accepted; anything else is dropped.
 //

--- a/plugins/power-pages/scripts/lib/telemetry/lib/pac-auth.js
+++ b/plugins/power-pages/scripts/lib/telemetry/lib/pac-auth.js
@@ -59,6 +59,7 @@ function readPacAuth(opts = {}) {
   const tenantId = pickLine(output, "Tenant Id");
   const orgId = pickLine(output, "Organization Id");
   const cloud = pickLine(output, "Cloud");
+  const objectId = pickLine(output, "Entra ID Object Id");
   if (!tenantId && !orgId) {
     cache = null;
     return null;
@@ -67,6 +68,7 @@ function readPacAuth(opts = {}) {
     orgId: orgId || "",
     tenantId: tenantId || "",
     cloud: cloud || "",
+    objectId: objectId || "",
   };
   return cache;
 }

--- a/plugins/power-pages/scripts/tests/pac-auth.test.js
+++ b/plugins/power-pages/scripts/tests/pac-auth.test.js
@@ -1,0 +1,85 @@
+"use strict";
+
+// Unit coverage for the bundled telemetry pac-auth copy. The plugin ships a
+// physical copy of shared/telemetry/lib/pac-auth.js (no symlink), so this test
+// asserts the copy parses `pac auth who` the same way — including the optional
+// "Entra ID Object Id" line surfaced as `objectId`. The emit-* hook tests are
+// spawn-based integration tests that call real `pac`, so they can't inject a
+// fake object id; this is the deterministic seam for that field.
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const pacAuth = require("../lib/telemetry/lib/pac-auth");
+
+const SAMPLE_OUTPUT = `Type:                Universal
+Cloud:               Public
+Tenant Id:           11111111-1111-1111-1111-111111111111
+Tenant Country:      US
+User:                user@example.com
+Entra ID Object Id:  aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa
+PUID:                10000000ABCDEF01
+User Country/Region: US
+Token Expires:       2026-05-05T18:00:00Z
+Authority:           https://login.microsoftonline.com/...
+Environment Geo:     NorthAmerica
+Environment Id:      22222222-2222-2222-2222-222222222222
+Environment Type:    Sandbox
+Organization Id:     33333333-3333-3333-3333-333333333333
+Organization Unique Name:    contoso
+Organization Friendly Name:  Contoso
+`;
+
+test("parses orgId, tenantId, cloud, and Entra ID objectId", () => {
+  pacAuth._resetCache();
+  const result = pacAuth.readPacAuth({ _exec: () => SAMPLE_OUTPUT });
+  assert.deepEqual(result, {
+    orgId: "33333333-3333-3333-3333-333333333333",
+    tenantId: "11111111-1111-1111-1111-111111111111",
+    cloud: "Public",
+    objectId: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+  });
+});
+
+test("objectId is '' when the Entra ID Object Id line is missing", () => {
+  pacAuth._resetCache();
+  const result = pacAuth.readPacAuth({
+    _exec: () =>
+      "Cloud: Public\n" +
+      "Tenant Id: 11111111-1111-1111-1111-111111111111\n" +
+      "Organization Id: 33333333-3333-3333-3333-333333333333\n",
+  });
+  assert.equal(result.objectId, "");
+});
+
+test("returns null when neither Tenant Id nor Organization Id is found", () => {
+  pacAuth._resetCache();
+  const result = pacAuth.readPacAuth({
+    _exec: () => "Type: Universal\nCloud: Public\n",
+  });
+  assert.equal(result, null);
+});
+
+test("returns null when pac is missing (ENOENT)", () => {
+  pacAuth._resetCache();
+  const result = pacAuth.readPacAuth({
+    _exec: () => {
+      const e = new Error("spawn pac ENOENT");
+      e.code = "ENOENT";
+      throw e;
+    },
+  });
+  assert.equal(result, null);
+});
+
+test("caches result across calls (single fork per process)", () => {
+  pacAuth._resetCache();
+  let calls = 0;
+  const exec = () => {
+    calls++;
+    return SAMPLE_OUTPUT;
+  };
+  pacAuth.readPacAuth({ _exec: exec });
+  pacAuth.readPacAuth({ _exec: exec });
+  assert.equal(calls, 1, "second call should hit cache");
+});

--- a/shared/telemetry/README.md
+++ b/shared/telemetry/README.md
@@ -86,7 +86,7 @@ Every event carries a fixed allowlist enforced by `lib/events.js`. Field names m
 **Per-event:**
 
 - `skillName` (on every event)
-- `eventInfo` — caller-supplied JSON object (dynamic Kusto column). The caller is responsible for not putting PII in this payload. Power Pages populates it with `aadObjectId` (the signed-in user's Entra ID / AAD directory object id, parsed from `pac auth who`) when available; the field is omitted when `pac auth who` doesn't surface an object id.
+- `eventInfo` — caller-supplied JSON object (dynamic Kusto column). The caller is responsible for not putting PII in this payload. Power Pages populates it with `aadObjectId` (the signed-in user's Entra ID / AAD directory object id, parsed from `pac auth who`) when available; the field is omitted when `pac auth who` doesn't surface an object id. On the wire it is sent as a JSON **string** (re-serialized by `emit-dispatcher.js`, not the local mirror) because the tenant-side field mapping flattens `data.<key>` to a single `data_<key>` leaf and does not recurse into nested objects — the Kusto side must `parse_json()` / `todynamic()` it back into a dynamic value.
 
 ## What is NEVER sent
 

--- a/shared/telemetry/README.md
+++ b/shared/telemetry/README.md
@@ -86,7 +86,7 @@ Every event carries a fixed allowlist enforced by `lib/events.js`. Field names m
 **Per-event:**
 
 - `skillName` (on every event)
-- `eventInfo` — caller-supplied JSON object (dynamic Kusto column). The caller is responsible for not putting PII in this payload.
+- `eventInfo` — caller-supplied JSON object (dynamic Kusto column). The caller is responsible for not putting PII in this payload. Power Pages populates it with `aadObjectId` (the signed-in user's Entra ID / AAD directory object id, parsed from `pac auth who`) when available; the field is omitted when `pac auth who` doesn't surface an object id.
 
 ## What is NEVER sent
 

--- a/shared/telemetry/lib/emit-dispatcher.js
+++ b/shared/telemetry/lib/emit-dispatcher.js
@@ -85,16 +85,28 @@ function sanitizeData(data) {
   return filtered;
 }
 
-// Build the CS4.0 envelope from a pre-sanitized payload + timestamp. Both are
-// computed once in the stdin handler and shared with the local mirror so the
-// on-disk record and the wire envelope carry byte-identical `data` and `time`.
+// Build the CS4.0 envelope from a pre-sanitized payload + timestamp. `sanitized`
+// is shared with the local mirror so the on-disk record and the wire envelope
+// carry byte-identical `data` and `time` for every OTHER field, but `eventInfo`
+// is re-serialized to a JSON string just for the wire: the tenant-side
+// Interchange/LogAnalytics field mapping flattens `data.<key>` to a single
+// `data_<key>` leaf token, and that flattening does not recurse into nested
+// object values, so a raw `eventInfo` object never produces the `data_eventInfo`
+// token the mapping expects. Stringifying keeps `eventInfo` a scalar leaf that
+// matches the existing mapping; the Kusto side reads it back with
+// `parse_json(EventInfo)` / `todynamic(EventInfo)`. The local mirror keeps the
+// real object so `events.jsonl` stays human-readable for local diagnostics.
 function buildEnvelope(eventName, time, sanitized, resolvedIKey, eventStreamName) {
+  const wireData = { ...sanitized };
+  if (wireData.eventInfo !== undefined) {
+    wireData.eventInfo = JSON.stringify(wireData.eventInfo);
+  }
   return {
     ver: "4.0",
     name: eventStreamName || eventName || "",
     time,
     iKey: "o:" + String(resolvedIKey || "").split("-")[0],
-    data: sanitized,
+    data: wireData,
   };
 }
 
@@ -138,8 +150,10 @@ process.stdin.on("end", async () => {
   }
 
   // Compute the sanitized payload + timestamp ONCE. The sanitized data is
-  // exactly what lands in Kusto (its field names ARE the Kusto column names);
-  // the local mirror and the wire envelope share it so they can never diverge.
+  // exactly what lands in Kusto (its field names ARE the Kusto column names)
+  // for every field except `eventInfo`, which buildEnvelope() re-serializes
+  // to a JSON string just for the wire (see buildEnvelope comment) — the
+  // local mirror below keeps the real object.
   const time = new Date().toISOString();
   const sanitized = sanitizeData(event.data);
   const localRecord = { time, name: event.name, data: sanitized };

--- a/shared/telemetry/lib/emit-dispatcher.js
+++ b/shared/telemetry/lib/emit-dispatcher.js
@@ -86,16 +86,12 @@ function sanitizeData(data) {
 }
 
 // Build the CS4.0 envelope from a pre-sanitized payload + timestamp. `sanitized`
-// is shared with the local mirror so the on-disk record and the wire envelope
-// carry byte-identical `data` and `time` for every OTHER field, but `eventInfo`
-// is re-serialized to a JSON string just for the wire: the tenant-side
-// Interchange/LogAnalytics field mapping flattens `data.<key>` to a single
-// `data_<key>` leaf token, and that flattening does not recurse into nested
-// object values, so a raw `eventInfo` object never produces the `data_eventInfo`
-// token the mapping expects. Stringifying keeps `eventInfo` a scalar leaf that
-// matches the existing mapping; the Kusto side reads it back with
-// `parse_json(EventInfo)` / `todynamic(EventInfo)`. The local mirror keeps the
-// real object so `events.jsonl` stays human-readable for local diagnostics.
+// is shared with the local mirror so `data`/`time` stay byte-identical for
+// every field except `eventInfo`: the tenant-side field mapping flattens
+// `data.<key>` to a single `data_<key>` leaf and doesn't recurse into nested
+// objects, so `eventInfo` is stringified just for the wire to survive that
+// flattening. Kusto reads it back with `parse_json()`/`todynamic()`; the
+// local mirror keeps the real object for human readability.
 function buildEnvelope(eventName, time, sanitized, resolvedIKey, eventStreamName) {
   const wireData = { ...sanitized };
   if (wireData.eventInfo !== undefined) {
@@ -150,10 +146,8 @@ process.stdin.on("end", async () => {
   }
 
   // Compute the sanitized payload + timestamp ONCE. The sanitized data is
-  // exactly what lands in Kusto (its field names ARE the Kusto column names)
-  // for every field except `eventInfo`, which buildEnvelope() re-serializes
-  // to a JSON string just for the wire (see buildEnvelope comment) — the
-  // local mirror below keeps the real object.
+  // exactly what lands in Kusto (its field names ARE the Kusto column names),
+  // except `eventInfo` which buildEnvelope() re-serializes for the wire only.
   const time = new Date().toISOString();
   const sanitized = sanitizeData(event.data);
   const localRecord = { time, name: event.name, data: sanitized };

--- a/shared/telemetry/lib/emit-from-prompt.js
+++ b/shared/telemetry/lib/emit-from-prompt.js
@@ -116,6 +116,7 @@ function emitSkillStartedFromPrompt(promptText, opts = {}) {
   };
   if (pacAuth && pacAuth.orgId) fields.orgId = pacAuth.orgId;
   if (pacAuth && pacAuth.tenantId) fields.tenantId = pacAuth.tenantId;
+  if (pacAuth && pacAuth.objectId) fields.eventInfo = { aadObjectId: pacAuth.objectId };
   if (agentInfo.aiAgentName) fields.aiAgentName = agentInfo.aiAgentName;
   if (agentInfo.aiAgentVersion) fields.aiAgentVersion = agentInfo.aiAgentVersion;
   if (agentInfo.pacCliVersion) fields.pacCliVersion = agentInfo.pacCliVersion;

--- a/shared/telemetry/lib/events.js
+++ b/shared/telemetry/lib/events.js
@@ -10,7 +10,10 @@
 //                  or negative values clamp to 0. Sent as number, not string.
 //   "object"     — Kusto column type `dynamic` (JSON). Plain objects and
 //                  arrays pass through; primitives, Date, RegExp, etc. are
-//                  dropped to avoid Kusto type confusion.
+//                  dropped to avoid Kusto type confusion. Validated here as a
+//                  real object; emit-dispatcher.js re-serializes it to a JSON
+//                  string just before it hits the wire (see buildEnvelope),
+//                  so the Kusto side must `parse_json()` / `todynamic()` it.
 //   "enum:a|b|c" — Kusto column type `string`. Only the listed values are
 //                  accepted; anything else is dropped.
 //

--- a/shared/telemetry/lib/pac-auth.js
+++ b/shared/telemetry/lib/pac-auth.js
@@ -59,6 +59,7 @@ function readPacAuth(opts = {}) {
   const tenantId = pickLine(output, "Tenant Id");
   const orgId = pickLine(output, "Organization Id");
   const cloud = pickLine(output, "Cloud");
+  const objectId = pickLine(output, "Entra ID Object Id");
   if (!tenantId && !orgId) {
     cache = null;
     return null;
@@ -67,6 +68,7 @@ function readPacAuth(opts = {}) {
     orgId: orgId || "",
     tenantId: tenantId || "",
     cloud: cloud || "",
+    objectId: objectId || "",
   };
   return cache;
 }

--- a/shared/telemetry/tests/emit-dispatcher.test.js
+++ b/shared/telemetry/tests/emit-dispatcher.test.js
@@ -155,6 +155,51 @@ test("dispatcher writes a probe file when fake-https points to one (happy path)"
   assert.deepEqual(body.data, fakeEvent.data);
 });
 
+test("dispatcher stringifies eventInfo on the wire but keeps it an object in the local mirror", () => {
+  const tmp = mkTmp();
+  const probePath = path.join(tmp, "probe.json");
+  const eventWithInfo = {
+    name: "PowerPagesPluginEvent",
+    data: {
+      ...fakeEvent.data,
+      eventInfo: { aadObjectId: "11111111-2222-3333-4444-555555555555" },
+    },
+  };
+  const { status } = runDispatcher({
+    event: eventWithInfo,
+    env: {
+      configDir: tmp,
+      iKey: "real-ikey-32-chars-minimum-aaaaaaaaaaaaaa",
+      collectorUrl: "https://example.invalid/OneCollector/1.0/",
+      fakeProbe: probePath,
+    },
+  });
+  assert.equal(status, 0);
+
+  const probe = JSON.parse(fs.readFileSync(probePath, "utf8"));
+  const body = JSON.parse(probe.body);
+  assert.equal(
+    typeof body.data.eventInfo,
+    "string",
+    "wire envelope must carry eventInfo as a JSON string leaf"
+  );
+  assert.deepEqual(JSON.parse(body.data.eventInfo), eventWithInfo.data.eventInfo);
+
+  const mirrorPath = path.join(tmp, "events.jsonl");
+  const mirrorLine = fs
+    .readFileSync(mirrorPath, "utf8")
+    .trim()
+    .split("\n")
+    .pop();
+  const mirrorRecord = JSON.parse(mirrorLine);
+  assert.equal(
+    typeof mirrorRecord.data.eventInfo,
+    "object",
+    "local mirror must keep eventInfo as a real object"
+  );
+  assert.deepEqual(mirrorRecord.data.eventInfo, eventWithInfo.data.eventInfo);
+});
+
 test("dispatcher strips unknown fields from event.data (defense-in-depth)", () => {
   const tmp = mkTmp();
   const probePath = path.join(tmp, "probe.json");

--- a/shared/telemetry/tests/emit-from-prompt.test.js
+++ b/shared/telemetry/tests/emit-from-prompt.test.js
@@ -141,6 +141,48 @@ test("populates orgId/tenantId when PAC auth is present", () => {
   assert.equal(captured.event.data.tenantId, "11111111-1111-1111-1111-111111111111");
 });
 
+test("puts the Entra objectId into eventInfo.aadObjectId when present", () => {
+  const telemetryDir = mkTelemetryDir({
+    instrumentationKey: "x",
+    collectorUrl: "https://x",
+    eventStreamName: "PowerPagesPluginEvent",
+  });
+  const captured = {};
+  callWithStub({
+    promptText: "/power-pages:add-seo",
+    telemetryDir,
+    captured,
+    pacAuth: {
+      orgId: "22222222-2222-2222-2222-222222222222",
+      tenantId: "11111111-1111-1111-1111-111111111111",
+      objectId: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+    },
+  });
+  assert.deepEqual(captured.event.data.eventInfo, {
+    aadObjectId: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+  });
+});
+
+test("omits eventInfo when the Entra objectId is absent", () => {
+  const telemetryDir = mkTelemetryDir({
+    instrumentationKey: "x",
+    collectorUrl: "https://x",
+    eventStreamName: "PowerPagesPluginEvent",
+  });
+  const captured = {};
+  callWithStub({
+    promptText: "/power-pages:add-seo",
+    telemetryDir,
+    captured,
+    pacAuth: {
+      orgId: "22222222-2222-2222-2222-222222222222",
+      tenantId: "11111111-1111-1111-1111-111111111111",
+      objectId: "",
+    },
+  });
+  assert.equal(captured.event.data.eventInfo, undefined);
+});
+
 test("populates aiAgentName/aiAgentVersion/pacCliVersion when agentInfo is present", () => {
   const telemetryDir = mkTelemetryDir({
     instrumentationKey: "x",

--- a/shared/telemetry/tests/pac-auth.test.js
+++ b/shared/telemetry/tests/pac-auth.test.js
@@ -30,7 +30,19 @@ test("returns { orgId, tenantId } parsed from `pac auth who` output", () => {
     orgId: "33333333-3333-3333-3333-333333333333",
     tenantId: "11111111-1111-1111-1111-111111111111",
     cloud: "Public",
+    objectId: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
   });
+});
+
+test("returns objectId: '' when the Entra ID Object Id line is missing", () => {
+  pacAuth._resetCache();
+  const result = pacAuth.readPacAuth({
+    _exec: () =>
+      "Cloud: Public\n" +
+      "Tenant Id: 11111111-1111-1111-1111-111111111111\n" +
+      "Organization Id: 33333333-3333-3333-3333-333333333333\n",
+  });
+  assert.equal(result.objectId, "");
 });
 
 test("returns { orgId: '', tenantId } when only Tenant Id line present", () => {
@@ -43,6 +55,7 @@ test("returns { orgId: '', tenantId } when only Tenant Id line present", () => {
     orgId: "",
     tenantId: "11111111-1111-1111-1111-111111111111",
     cloud: "Public",
+    objectId: "",
   });
 });
 
@@ -56,6 +69,7 @@ test("returns { tenantId: '', orgId } when only Organization Id line present", (
     orgId: "33333333-3333-3333-3333-333333333333",
     tenantId: "",
     cloud: "Public",
+    objectId: "",
   });
 });
 
@@ -143,6 +157,7 @@ test("parses values with extra whitespace and mixed casing in label", () => {
     orgId: "33333333-3333-3333-3333-333333333333",
     tenantId: "11111111-1111-1111-1111-111111111111",
     cloud: "",
+    objectId: "",
   });
 });
 


### PR DESCRIPTION
## Summary
- Adds the Entra ID Object Id (parsed from `pac auth who`) to the Power Pages telemetry `eventInfo` dynamic field as `aadObjectId`.
- Stringifies `eventInfo` on the wire (only) in `emit-dispatcher.js`'s `buildEnvelope()`, since the tenant's Interchange/LogAnalytics field mapping flattens `data.<key>` to a single `data_<key>` leaf and does not recurse into nested objects — a raw `eventInfo` object never produced the `data_eventInfo` leaf the mapping expects. The local diagnostic mirror (`events.jsonl`) keeps `eventInfo` as a real object for readability; only the wire envelope sends a JSON string, which Kusto reads back with `parse_json()`/`todynamic()`.

## Changes
- `shared/telemetry/lib/pac-auth.js` (+ plugin bundled copy): parse `Entra ID Object Id` from `pac auth who` output.
- `shared/telemetry/lib/run-skill-pretool-telemetry.js`, `emit-from-prompt.js` (+ plugin copies): populate `eventInfo.aadObjectId` when available.
- `shared/telemetry/lib/emit-dispatcher.js` (+ plugin copy): `buildEnvelope()` now stringifies `eventInfo` for the wire only.
- `shared/telemetry/lib/events.js` (+ plugin copy): comment update noting the wire-level re-serialization happens downstream.
- Tests added/updated in `shared/telemetry/tests/` and `plugins/power-pages/scripts/tests/` covering both the new field and the stringify behavior.
- `shared/telemetry/README.md` updated to document `aadObjectId` and the wire-level JSON-string encoding for `eventInfo`.

## Verification
- Ran full test suites: 180/180 shared tests pass, 1286/1286 plugin tests pass.
- Verified locally via `~/.power-platform-skills/events.jsonl` that `eventInfo.aadObjectId` is populated.
- User confirmed the field is now appearing correctly in Kusto/Log Analytics after the stringify fix.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>