### PR TITLE
feat(model-apps): add headless app-shell mode (spec validation + build wiring + fixture)

### DIFF
--- a/plugins/model-apps/CHANGELOG.md
+++ b/plugins/model-apps/CHANGELOG.md
@@ -29,6 +29,12 @@ real and synthetic fixtures. Builds on v2.1; no breaking changes.
   `capture-fixture.js`; local-dev manifest (`package.json` + `genpage.d.ts`) in working dirs; new
   dialog/overlay samples (11, 12) + Dialogs-and-Overlays guidance.
 
+- **Headless app-shell mode** (`"headless": true`) — build a **table + sitemap only** app (no
+  forms/views/charts/dashboards/pages/commands/web resources) as a foundation for attaching MCP
+  servers, bots, code-apps, and AI skills. Lint-enforced mutual exclusion + minimum viability;
+  builder restricts to a reduced phase set. Sample `samples/app-spec.headless-task-tracker.json`;
+  see `references/headless-apps.md`.
+
 ### Removed
 - **Consolidated the standalone entity/solution scripts into the SDK.** `create-table.js`,
   `add-column.js`, `create-relationship.js`, `create-record.js`, `create-solution.js`, and

--- a/plugins/model-apps/CHANGELOG.md
+++ b/plugins/model-apps/CHANGELOG.md
@@ -33,7 +33,9 @@ real and synthetic fixtures. Builds on v2.1; no breaking changes.
   forms/views/charts/dashboards/pages/commands/web resources) as a foundation for attaching MCP
   servers, bots, code-apps, and AI skills. Lint-enforced mutual exclusion + minimum viability;
   builder restricts to a reduced phase set. Sample `samples/app-spec.headless-task-tracker.json`;
-  see `references/headless-apps.md`.
+  see `references/headless-apps.md`. Warns (without failing) when `--only`/`--from`/`--to` on a
+  headless build resolve entirely to phases outside the allow-list, so a no-op build is not
+  mistaken for success; the durable build journal records the intersected (actually-run) phases.
 
 ### Removed
 - **Consolidated the standalone entity/solution scripts into the SDK.** `create-table.js`,

--- a/plugins/model-apps/references/app-spec-schema.md
+++ b/plugins/model-apps/references/app-spec-schema.md
@@ -41,7 +41,7 @@ sample data (incl. multi-parent junction links + status reasons), and publish.
 {
   "solution": { "uniqueName": "ContosoSupportDesk", "displayName": "Contoso Support Desk", "publisherPrefix": "new" },
   "app":      { "name": "Support Desk", "description": "Track tickets" },
-  "headless":  false,           // optional — see the `headless` section below (default: false)
+  "headless":  false,           // optional — table+sitemap-only shell; see references/headless-apps.md (default: false)
   "entities":      [ /* tables — see below */ ],
   "relationships": [ /* 1:N links — see below */ ],
   "globalChoices": [ /* optional shared option sets */ ],
@@ -57,28 +57,11 @@ sample data (incl. multi-parent junction links + status reasons), and publish.
 
 ## headless (optional — entity-only app shell)
 
-Set `"headless": true` at the top level to build a **table + sitemap only** app: no forms,
-views, charts, dashboards, pages, commands, or web resources are provisioned. The intended
-use is as a foundation on which MCP servers, bots, code-apps, and AI skills attach later —
-scenarios where classic Dataverse UI artifacts are counter-productive.
-
-**Mutual exclusion (lint-enforced).** A headless spec must not declare non-empty
-`forms` / `views` / `charts` / `dashboards` / `pages` / `commands` / `webResources`
-sections; empty arrays are tolerated so you can flip a spec to headless without deleting
-sections. See `plugins/model-apps/scripts/lib/spec-lint.js::lintAppSpec`.
-
-**Minimum viability (lint-enforced).** A headless spec still needs `>=1` entity AND at
-least one `appShell` subarea that targets an entity — otherwise the built app has an empty
-sitemap.
-
-**Reduced phase set (builder-enforced).** The builder intersects the requested phases with
-a headless allow-list (`solution`, `data-model`, `app-shell`, plus `sample-data` when
-`--sample-data` and `publish` when `--publish`); UI phases are dropped even if
-`--only`/`--from`/`--to` would otherwise admit them. See
-`plugins/model-apps/scripts/lib/sdk-build.js::headlessPhaseAllowlist` for the pure rule
-and `build-model-app.js::buildModelApp` for the wiring.
-
-**Sample fixture:** [`plugins/model-apps/samples/app-spec.headless-task-tracker.json`](../samples/app-spec.headless-task-tracker.json).
+Set `"headless": true` to build a **table + sitemap only** app (no forms / views / charts /
+dashboards / pages / commands / web resources) — a foundation for attaching MCP servers, bots,
+code-apps, and AI skills. The flag is lint-enforced (mutual exclusion with UI sections + minimum
+viability) and restricts the build to a reduced phase set. Full contract, lint rules, and the
+sample fixture: [`headless-apps.md`](./headless-apps.md).
 
 ## entities[]
 ```jsonc

--- a/plugins/model-apps/references/app-spec-schema.md
+++ b/plugins/model-apps/references/app-spec-schema.md
@@ -41,6 +41,7 @@ sample data (incl. multi-parent junction links + status reasons), and publish.
 {
   "solution": { "uniqueName": "ContosoSupportDesk", "displayName": "Contoso Support Desk", "publisherPrefix": "new" },
   "app":      { "name": "Support Desk", "description": "Track tickets" },
+  "headless":  false,           // optional — see the `headless` section below (default: false)
   "entities":      [ /* tables — see below */ ],
   "relationships": [ /* 1:N links — see below */ ],
   "globalChoices": [ /* optional shared option sets */ ],
@@ -53,6 +54,31 @@ sample data (incl. multi-parent junction links + status reasons), and publish.
   "ai":            { /* optional — AI feature flags + row-summary config */ }
 }
 ```
+
+## headless (optional — entity-only app shell)
+
+Set `"headless": true` at the top level to build a **table + sitemap only** app: no forms,
+views, charts, dashboards, pages, commands, or web resources are provisioned. The intended
+use is as a foundation on which MCP servers, bots, code-apps, and AI skills attach later —
+scenarios where classic Dataverse UI artifacts are counter-productive.
+
+**Mutual exclusion (lint-enforced).** A headless spec must not declare non-empty
+`forms` / `views` / `charts` / `dashboards` / `pages` / `commands` / `webResources`
+sections; empty arrays are tolerated so you can flip a spec to headless without deleting
+sections. See `plugins/model-apps/scripts/lib/spec-lint.js::lintAppSpec`.
+
+**Minimum viability (lint-enforced).** A headless spec still needs `>=1` entity AND at
+least one `appShell` subarea that targets an entity — otherwise the built app has an empty
+sitemap.
+
+**Reduced phase set (builder-enforced).** The builder intersects the requested phases with
+a headless allow-list (`solution`, `data-model`, `app-shell`, plus `sample-data` when
+`--sample-data` and `publish` when `--publish`); UI phases are dropped even if
+`--only`/`--from`/`--to` would otherwise admit them. See
+`plugins/model-apps/scripts/lib/sdk-build.js::headlessPhaseAllowlist` for the pure rule
+and `build-model-app.js::buildModelApp` for the wiring.
+
+**Sample fixture:** [`plugins/model-apps/samples/app-spec.headless-task-tracker.json`](../samples/app-spec.headless-task-tracker.json).
 
 ## entities[]
 ```jsonc

--- a/plugins/model-apps/references/headless-apps.md
+++ b/plugins/model-apps/references/headless-apps.md
@@ -1,0 +1,54 @@
+# Headless apps (entity-only app shell)
+
+> Load this file only when the user asks for a **headless** app (they mention "headless",
+> "table + sitemap only", "data foundation without UI", or "no forms/views"). It documents the
+> `headless` App Spec flag, its lint rules, and the reduced build pipeline.
+
+Set `"headless": true` at the top level of the App Spec to build a **table + sitemap only** app:
+no forms, views, charts, dashboards, pages, commands, or web resources are provisioned. The
+intended use is as a **foundation** on which MCP servers, bots, code-apps, and AI skills attach
+later — scenarios where classic Dataverse UI artifacts are counter-productive.
+
+## When to author `headless: true`
+
+- The user asks for a **data foundation** (tables + navigation) without classic model-driven UI.
+- The app will be driven primarily by a **code-app or agent surface** (MCP server, bot, AI skill)
+  rather than model-driven forms and views.
+
+Author the flag at the top level alongside `solution` / `app`:
+
+```jsonc
+{
+  "solution": { "uniqueName": "ContosoDataFoundation", "publisherPrefix": "new" },
+  "app":      { "name": "Data Foundation" },
+  "headless":  true,
+  "entities":  [ /* >= 1 table */ ],
+  "appShell":  { "areas": [ /* >= 1 subarea targeting an entity */ ] }
+}
+```
+
+## Mutual exclusion (lint-enforced)
+
+A headless spec must **not** declare non-empty `forms` / `views` / `charts` / `dashboards` /
+`pages` / `commands` / `webResources` sections. Empty arrays are tolerated, so you can flip an
+existing spec to headless without deleting those sections. Violations fail lint with a clear
+mutual-exclusion message. See `plugins/model-apps/scripts/lib/spec-lint.js` → `lintAppSpec`.
+
+## Minimum viability (lint-enforced)
+
+A headless spec still needs `>= 1` entity **and** at least one `appShell` subarea that targets an
+entity — otherwise the built app has an empty sitemap and nothing to navigate to.
+
+## Reduced phase set (builder-enforced)
+
+The builder intersects the requested phases with a headless allow-list — `solution`,
+`data-model`, `app-shell`, plus `sample-data` when `--sample-data` and `publish` when
+`--publish`. UI phases (`views` / `charts` / `forms` / `commands` / `dashboards` / `pages` /
+`web-resources` / `ai-features`) are dropped even if `--only` / `--from` / `--to` would otherwise
+admit them. See `plugins/model-apps/scripts/lib/sdk-build.js` → `headlessPhaseAllowlist` for the
+pure rule and `build-model-app.js` → `buildModelApp` for the wiring.
+
+## Sample fixture
+
+[`plugins/model-apps/samples/app-spec.headless-task-tracker.json`](../samples/app-spec.headless-task-tracker.json)
+— a minimal, lint-clean headless spec (tables + sitemap only).

--- a/plugins/model-apps/samples/app-spec.headless-task-tracker.json
+++ b/plugins/model-apps/samples/app-spec.headless-task-tracker.json
@@ -1,0 +1,47 @@
+{
+  "headless": true,
+  "solution": { "uniqueName": "ContosoHeadlessTaskTracker", "displayName": "Contoso Headless Task Tracker", "publisherPrefix": "new" },
+  "app": { "name": "Headless Task Tracker", "description": "Headless model-driven app scaffold: solution + tables + sitemap only (no forms/views/charts/dashboards). Designed as a foundation on which MCP servers, bots, and AI skills can be attached later." },
+  "entities": [
+    {
+      "schemaName": "new_project",
+      "displayName": "Project",
+      "pluralName": "Projects",
+      "primaryAttribute": { "schemaName": "new_name", "displayName": "Project Name" },
+      "columns": [
+        { "schemaName": "new_description", "displayName": "Description", "type": "Memo" },
+        { "schemaName": "new_status", "displayName": "Status", "type": "Choice", "options": ["Planned", "Active", "OnHold", "Completed"] }
+      ]
+    },
+    {
+      "schemaName": "new_task",
+      "displayName": "Task",
+      "pluralName": "Tasks",
+      "primaryAttribute": { "schemaName": "new_name", "displayName": "Task Title" },
+      "columns": [
+        { "schemaName": "new_priority", "displayName": "Priority", "type": "Choice", "options": ["Low", "Medium", "High"] },
+        { "schemaName": "new_duedate", "displayName": "Due Date", "type": "DateTime" }
+      ]
+    }
+  ],
+  "relationships": [
+    { "type": "OneToMany", "referenced": "new_project", "referencing": "new_task",
+      "lookup": { "schemaName": "new_ProjectId", "displayName": "Project" } }
+  ],
+  "appShell": {
+    "areas": [
+      {
+        "label": "Work",
+        "groups": [
+          {
+            "label": "Records",
+            "subAreas": [
+              { "entity": "new_project", "title": "Projects" },
+              { "entity": "new_task",    "title": "Tasks" }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/model-apps/scripts/build-model-app.js
+++ b/plugins/model-apps/scripts/build-model-app.js
@@ -104,11 +104,21 @@ async function buildModelApp(spec, opts, deps) {
   // See sdk-build.js::headlessPhaseAllowlist for the allow-list rules and DoD #2 in
   // units.json for run20260708headless01.
   const allow = headlessPhaseAllowlist(spec, { sampleData: opts.sampleData === true, publish: opts.publish === true });
-  const effectivePhases = opts.phases
-    ? opts.phases.filter((p) => allow.includes(p))
+  const requestedPhases = opts.phases;
+  const effectivePhases = requestedPhases
+    ? requestedPhases.filter((p) => allow.includes(p))
     : allow.slice();
-  opts = { ...opts, phases: effectivePhases };
   const log = deps.log || (() => undefined);
+  // Headless misconfiguration guard: if the caller requested a NON-EMPTY phase set but every
+  // requested phase is a UI phase excluded by the headless allow-list, the intersection is empty
+  // and the build would silently return ok having created nothing. Warn so a mistyped
+  // --only/--from/--to on a headless build isn't mistaken for a successful build. (An explicitly
+  // empty requested set — e.g. phases:[] — is left silent: the caller asked for nothing, which is
+  // not a misconfiguration. Kept as ok:true either way — an empty effective set is not an error.)
+  if (spec.headless === true && Array.isArray(requestedPhases) && requestedPhases.length > 0 && effectivePhases.length === 0) {
+    log('⚠ headless: all requested phases are outside the headless allow-list (solution, data-model, app-shell[, sample-data][, publish]) — nothing to build.');
+  }
+  opts = { ...opts, phases: effectivePhases };
   const counts = { ok: 0, skip: 0, error: 0 };
   const journal = deps.journal;
   // Tee the engine's progress events into the durable journal without touching the pure engine.
@@ -221,8 +231,14 @@ async function main() {
   const { sdk, provisionSdk, cleanup } = makeSdk(env, spec, workspaceDir);
   // Durable build journal (apply runs only): a per-run record of steps + where a run halted,
   // written to <workspace>/build-log.jsonl. Resume = re-run the same command (idempotent).
+  // Record the phases that will ACTUALLY run: for a headless spec buildModelApp intersects the
+  // resolved set with the reduced allow-list, so mirror that intersection here — otherwise the
+  // journal header advertises UI phases (views/forms/charts) that were never executed.
+  const journalPhases = spec.headless === true
+    ? opts.phases.filter((p) => headlessPhaseAllowlist(spec, { sampleData: opts.sampleData === true, publish: opts.publish === true }).includes(p))
+    : opts.phases;
   const journal = opts.apply
-    ? openJournal(workspaceDir, { app: spec.app && spec.app.name, solution: spec.solution && spec.solution.uniqueName, apply: true, phases: opts.phases })
+    ? openJournal(workspaceDir, { app: spec.app && spec.app.name, solution: spec.solution && spec.solution.uniqueName, apply: true, phases: journalPhases })
     : null;
   let r;
   try {

--- a/plugins/model-apps/scripts/build-model-app.js
+++ b/plugins/model-apps/scripts/build-model-app.js
@@ -14,7 +14,7 @@ const os = require('node:os');
 const fs = require('node:fs');
 const path = require('node:path');
 const { validateAppSpec } = require('./lib/app-spec.js');
-const { runSdkBuild, planFor, resolvePhases, appUniqueName } = require('./lib/sdk-build.js');
+const { runSdkBuild, planFor, resolvePhases, headlessPhaseAllowlist, appUniqueName } = require('./lib/sdk-build.js');
 const { createAzHttpClient } = require('./lib/sdk-http-client.js');
 const { parseArgs, readJsonArg, emitResult } = require('./lib/dataverse-auth.js');
 const { openJournal } = require('./lib/build-journal.js');
@@ -93,6 +93,21 @@ async function buildModelApp(spec, opts, deps) {
   if (!v.ok) {
     return { ok: false, errors: v.errors };
   }
+  // Headless allow-list gate: for a spec.headless === true, intersect the CLI-resolved phase
+  // set (or the full PHASES default) with the reduced headless phase allow-list BEFORE
+  // runSdkBuild sees it. Applied here (not only in main()) so direct callers — tests, other
+  // CLIs invoking buildModelApp() — get the same guarantee: `opts.phases` handed to
+  // runSdkBuild NEVER contains views/charts/forms/commands/dashboards/pages/ai-features/
+  // web-resources when spec.headless === true, regardless of what --only/--from/--to/--skip
+  // would otherwise admit. For a non-headless spec headlessPhaseAllowlist returns PHASES,
+  // so this filter is an idempotent no-op — classic-spec behavior is unchanged.
+  // See sdk-build.js::headlessPhaseAllowlist for the allow-list rules and DoD #2 in
+  // units.json for run20260708headless01.
+  const allow = headlessPhaseAllowlist(spec, { sampleData: opts.sampleData === true, publish: opts.publish === true });
+  const effectivePhases = opts.phases
+    ? opts.phases.filter((p) => allow.includes(p))
+    : allow.slice();
+  opts = { ...opts, phases: effectivePhases };
   const log = deps.log || (() => undefined);
   const counts = { ok: 0, skip: 0, error: 0 };
   const journal = deps.journal;

--- a/plugins/model-apps/scripts/lib/app-spec.js
+++ b/plugins/model-apps/scripts/lib/app-spec.js
@@ -479,6 +479,13 @@ function validateAppSpec(spec) {
       }
     }
   }
+  // headless flag (optional top-level, boolean). Semantic rules (mutual exclusion with
+  // classic UI, minimum-viability shell) live in spec-lint.js; here we only guard the
+  // structural type so downstream consumers can trust `spec.headless === true`.
+  // Mirrors the shape of the `spec.ai` optional block above.
+  if (spec.headless !== undefined && typeof spec.headless !== 'boolean') {
+    errors.push('headless must be a boolean');
+  }
   return { ok: errors.length === 0, errors };
 }
 

--- a/plugins/model-apps/scripts/lib/sdk-build.js
+++ b/plugins/model-apps/scripts/lib/sdk-build.js
@@ -145,6 +145,33 @@ function resolvePhases({ only, skip, from, to } = {}) {
   return active.filter((p) => (!onlySet || onlySet.has(p)) && (!skipSet || !skipSet.has(p)));
 }
 
+// Pure allow-list for a headless model app (spec.headless === true): the reduced phase set
+// authorised for a table+sitemap-only shell. UI phases (views/charts/forms/commands/dashboards/
+// pages/ai-features/web-resources) are structurally forbidden even if the spec accidentally
+// declares them and even if --only/--from/--to would otherwise admit them; the caller
+// intersects this with the resolvePhases() output so CLI flags still narrow WITHIN the
+// allow-list but never widen past it (defense-in-depth).
+//
+// For a non-headless spec the helper is a pass-through: it returns the full PHASES list,
+// so `resolved.filter((p) => allow.includes(p))` at the caller is an idempotent no-op —
+// the existing CLI behavior for classic specs is unchanged.
+//
+// `opts.sampleData === true` / `opts.publish === true` widen the allow-list by exactly those
+// two phases (opt-in, matching the `--sample-data` / `--publish` CLI flags on
+// build-model-app.js). Only the strict boolean `true` counts, matching the `apply === true`
+// pattern used elsewhere on the CLI options object.
+function headlessPhaseAllowlist(spec, opts = {}) {
+  if (!spec || spec.headless !== true) return PHASES.slice();
+  // Build via Set + PHASES.filter so the returned list always follows the canonical PHASES
+  // order regardless of any future reordering of the allow-list literal (the caller's
+  // filter against `allow` then stays idempotent for both branches — pass-through returns
+  // PHASES, headless returns a strict subset in PHASES order).
+  const allowSet = new Set(['solution', 'data-model', 'app-shell']);
+  if (opts.sampleData === true) allowSet.add('sample-data');
+  if (opts.publish === true) allowSet.add('publish');
+  return PHASES.filter((p) => allowSet.has(p));
+}
+
 // Resolve a view-filter value: a Choice/MultiChoice label becomes its option int; everything
 // else (raw ints, strings, ISO dates) passes through. No-value operators omit the value entirely.
 function resolveFilterValue(spec, entityLogical, attr, val) {
@@ -748,4 +775,4 @@ async function runSdkBuild(spec, opts = {}) {
   return result;
 }
 
-module.exports = { runSdkBuild, planFor, resolvePhases, PHASES, BuildHalt, SDK_COLUMN_TYPE, viewDef, defaultViewColumns, enrichesDefaultViews, artifactIdentityQuery, chartDef, dashboardTileOpts, formDef, appDef, appUniqueName, commandsByEntity, webResourceOpts, formEventOpts, WEB_RESOURCE_KINDS, FORM_EVENTS };
+module.exports = { runSdkBuild, planFor, resolvePhases, headlessPhaseAllowlist, PHASES, BuildHalt, SDK_COLUMN_TYPE, viewDef, defaultViewColumns, enrichesDefaultViews, artifactIdentityQuery, chartDef, dashboardTileOpts, formDef, appDef, appUniqueName, commandsByEntity, webResourceOpts, formEventOpts, WEB_RESOURCE_KINDS, FORM_EVENTS };

--- a/plugins/model-apps/scripts/lib/spec-lint.js
+++ b/plugins/model-apps/scripts/lib/spec-lint.js
@@ -294,6 +294,38 @@ function lintAppSpec(spec) {
   dupWarn((spec.charts || []).map((c) => c.name), 'chart', W);
   dupWarn((spec.forms || []).map((f) => f.name).filter(Boolean), 'form', W);
 
+  // Headless model apps: entity-only shells intended for pages/code-app scenarios where
+  // classic Dataverse UI artifacts are counter-productive. Enforce two contracts here:
+  //   1) mutual exclusion — a headless spec must not carry non-empty forms/views/charts/
+  //      dashboards/pages/commands/webResources (empty arrays are tolerated so authors can
+  //      leave the sections in place while switching a spec to headless).
+  //   2) minimum viability — a headless spec still needs >=1 entity AND at least one
+  //      appShell subarea that targets an entity, otherwise the built app has an empty
+  //      sitemap. See U1 contract in units.json for run20260708headless01.
+  if (spec.headless === true) {
+    const FORBIDDEN_ON_HEADLESS = ['forms', 'views', 'charts', 'dashboards', 'pages', 'commands', 'webResources'];
+    for (const key of FORBIDDEN_ON_HEADLESS) {
+      const arr = spec[key];
+      if (Array.isArray(arr) && arr.length > 0) {
+        E(`headless spec must not declare ${key}[] — remove the ${key} section (headless apps are entity-only shells)`);
+      }
+    }
+    if (!Array.isArray(spec.entities) || spec.entities.length === 0) {
+      E('headless spec needs at least one entity — a headless app with no entities produces an empty shell');
+    }
+    let entitySubareaCount = 0;
+    for (const a of (spec.appShell && spec.appShell.areas) || []) {
+      for (const g of a.groups || []) {
+        for (const sa of g.subAreas || []) {
+          if (sa && sa.entity) entitySubareaCount++;
+        }
+      }
+    }
+    if (entitySubareaCount === 0) {
+      E('headless spec needs at least one appShell subarea with an entity — otherwise the sitemap is empty');
+    }
+  }
+
   return { ok: errors.length === 0, errors, warnings };
 }
 

--- a/plugins/model-apps/scripts/tests/app-spec.test.js
+++ b/plugins/model-apps/scripts/tests/app-spec.test.js
@@ -394,6 +394,29 @@ test('validateAppSpec accepts a spec with headless:true', () => {
   assert.ok(!r.errors.some((e) => /headless/i.test(e)), 'no error should mention headless when the value is a valid boolean');
 });
 
+test('validateAppSpec accepts headless:false', () => {
+  // Companion to the headless:true case — guards against a regression to
+  // `typeof spec.headless === 'boolean' && spec.headless` (which would reject false)
+  // or a truthy-only check that would accept 1 but reject 0/false.
+  const s = cloneDesk();
+  s.headless = false;
+  const r = validateAppSpec(s);
+  assert.strictEqual(r.ok, true, JSON.stringify(r.errors));
+  assert.ok(!r.errors.some((e) => /headless/i.test(e)), 'headless:false is a valid boolean and must not raise a headless error');
+});
+
+test('validateAppSpec treats absent headless as valid (undefined is not a value)', () => {
+  // Impl uses `spec.headless !== undefined && typeof spec.headless !== 'boolean'`. The
+  // `!== undefined` guard is easy to drop by accident, which would then reject every
+  // classic (non-headless) spec. This pins the intent explicitly so a maintainer can't
+  // silently drop it and pass the loop test below.
+  const s = cloneDesk();
+  delete s.headless;
+  const r = validateAppSpec(s);
+  assert.strictEqual(r.ok, true, JSON.stringify(r.errors));
+  assert.ok(!r.errors.some((e) => /headless/i.test(e)), 'absent headless key must not raise a headless error');
+});
+
 test('validateAppSpec rejects headless set to a non-boolean value', () => {
   // Includes null/0/'' — the values most likely to slip past a `if (spec.headless && ...)`
   // style guard. Impl uses `!== undefined` so all non-boolean values are rejected.

--- a/plugins/model-apps/scripts/tests/app-spec.test.js
+++ b/plugins/model-apps/scripts/tests/app-spec.test.js
@@ -395,7 +395,9 @@ test('validateAppSpec accepts a spec with headless:true', () => {
 });
 
 test('validateAppSpec rejects headless set to a non-boolean value', () => {
-  for (const bad of ['yes', 1, [], {}]) {
+  // Includes null/0/'' — the values most likely to slip past a `if (spec.headless && ...)`
+  // style guard. Impl uses `!== undefined` so all non-boolean values are rejected.
+  for (const bad of ['yes', 1, 0, '', null, [], {}]) {
     const s = cloneDesk();
     s.headless = bad;
     const r = validateAppSpec(s);

--- a/plugins/model-apps/scripts/tests/app-spec.test.js
+++ b/plugins/model-apps/scripts/tests/app-spec.test.js
@@ -381,3 +381,26 @@ test('validateAppSpec passes when ai is absent (no regression)', () => {
   const r = validateAppSpec(cloneDesk());
   assert.strictEqual(r.ok, true, JSON.stringify(r.errors));
 });
+
+// --- headless flag structural validation ---------------------------------------------------
+// Mirrors the shape used for `spec.ai` (optional top-level, structural check only).
+// Semantic rules (mutual exclusion, minimum viability) live in spec-lint.js.
+
+test('validateAppSpec accepts a spec with headless:true', () => {
+  const s = cloneDesk();
+  s.headless = true;
+  const r = validateAppSpec(s);
+  assert.strictEqual(r.ok, true, JSON.stringify(r.errors));
+  assert.ok(!r.errors.some((e) => /headless/i.test(e)), 'no error should mention headless when the value is a valid boolean');
+});
+
+test('validateAppSpec rejects headless set to a non-boolean value', () => {
+  for (const bad of ['yes', 1, [], {}]) {
+    const s = cloneDesk();
+    s.headless = bad;
+    const r = validateAppSpec(s);
+    assert.strictEqual(r.ok, false, `expected rejection for headless=${JSON.stringify(bad)}`);
+    assert.ok(r.errors.some((e) => /headless/i.test(e) && /boolean/i.test(e)),
+      `expected an error naming 'headless' and 'boolean' for value ${JSON.stringify(bad)}; got ${JSON.stringify(r.errors)}`);
+  }
+});

--- a/plugins/model-apps/scripts/tests/build-model-app.test.js
+++ b/plugins/model-apps/scripts/tests/build-model-app.test.js
@@ -191,7 +191,18 @@ const headlessFixture = JSON.parse(
 test('headless dry-run: phase headers are exactly the reduced set (no UI phases)', async () => {
   const { sdk } = mockSdk();
   const cap = logCapture();
-  await buildModelApp(headlessFixture, { apply: false, env: 'https://x' }, { sdk, log: cap.log });
+  // Adversarially declare UI artifacts alongside the headless fixture so `▶ views/forms/charts/
+  // dashboards` WOULD emit without the allow-list wiring (each of those phases fires per-artifact
+  // events which trigger the `▶ <phase>` header in cliEmit at build-model-app.js:59). The
+  // negative assertions below then genuinely prove the allow-list dropped those phases.
+  const spec = {
+    ...headlessFixture,
+    forms:      [{ entity: 'new_project', name: 'Project', formType: 'Main', layout: 'auto' }],
+    views:      [{ entity: 'new_project', name: 'Active', columns: ['new_name'] }],
+    charts:     [{ entity: 'new_project', name: 'By Status', groupBy: 'new_status', measure: 'count', chartType: 'Column' }],
+    dashboards: [{ name: 'Overview', tiles: [{ type: 'chart', chart: 'By Status', view: 'Active' }] }],
+  };
+  await buildModelApp(spec, { apply: false, env: 'https://x' }, { sdk, log: cap.log });
   const phaseHeaders = cap.logs.filter((l) => /^\s*▶ /.test(l)).map((l) => l.trim());
   // Present: solution, data-model, app-shell.
   assert.ok(phaseHeaders.includes('▶ solution'), `expected ▶ solution; got ${JSON.stringify(phaseHeaders)}`);

--- a/plugins/model-apps/scripts/tests/build-model-app.test.js
+++ b/plugins/model-apps/scripts/tests/build-model-app.test.js
@@ -256,3 +256,35 @@ test('headless apply: --only cannot smuggle a UI phase past the headless allowli
     assert.ok(!artifactKinds.includes(forbidden), `--only should NOT smuggle '${forbidden}' into a headless build; kinds=${JSON.stringify(artifactKinds)}`);
   }
 });
+
+// Edge cases — U2 defense-in-depth boundaries.
+
+test('non-headless classic build is unchanged: allow-list is a pass-through, all classic phases run', async () => {
+  // Regression guard on the buildModelApp wiring — the headless intersection MUST be an
+  // idempotent no-op for a classic spec (headless flag absent). Any artifact the classic
+  // support-desk spec would produce without the U2 change must still be produced with it.
+  const { sdk, calls } = mockSdk();
+  const r = await buildModelApp(desk, { apply: true, env: 'https://x' }, { sdk });
+  assert.strictEqual(r.ok, true);
+  const artifactKinds = calls.filter((c) => c[0] === 'createArtifact').map((c) => c[1]);
+  // Classic support-desk fixture declares forms/views/charts + the app module — ALL should build.
+  assert.ok(artifactKinds.includes('form'),  `classic build must still create forms; kinds=${JSON.stringify(artifactKinds)}`);
+  assert.ok(artifactKinds.includes('view'),  `classic build must still create views; kinds=${JSON.stringify(artifactKinds)}`);
+  assert.ok(artifactKinds.includes('chart'), `classic build must still create charts; kinds=${JSON.stringify(artifactKinds)}`);
+  assert.ok(artifactKinds.includes('app'),   `classic build must still create the app; kinds=${JSON.stringify(artifactKinds)}`);
+});
+
+test('headless apply with an explicitly empty opts.phases short-circuits without artifact writes', async () => {
+  // Documents intentional behavior: if the caller passes phases:[] (perhaps via --only naming
+  // phases fully outside the allow-list), the intersection stays [] and runSdkBuild runs no
+  // phases. The build reports ok:true (it did what was asked — nothing) but no writes land.
+  // A follow-up "empty-phase-set diagnostic" is out of scope for U2 (deferred low-priority
+  // finding from high-risk-reviewer).
+  const { sdk, calls } = mockSdk();
+  const r = await buildModelApp(headlessFixture, { apply: true, env: 'https://x', phases: [] }, { sdk });
+  assert.strictEqual(r.ok, true);
+  assert.strictEqual(calls.filter((c) => c[0] === 'createArtifact').length, 0, 'no createArtifact writes for phases:[]');
+  assert.strictEqual(calls.filter((c) => c[0] === 'createSolution').length, 0, 'no createSolution for phases:[]');
+});
+
+

--- a/plugins/model-apps/scripts/tests/build-model-app.test.js
+++ b/plugins/model-apps/scripts/tests/build-model-app.test.js
@@ -255,6 +255,52 @@ test('headless apply: --only cannot smuggle a UI phase past the headless allowli
   for (const forbidden of ['form', 'view']) {
     assert.ok(!artifactKinds.includes(forbidden), `--only should NOT smuggle '${forbidden}' into a headless build; kinds=${JSON.stringify(artifactKinds)}`);
   }
+  // Positive assertion: the intersection must KEEP the allow-listed phase the caller also
+  // requested (app-shell). Without this the test would pass even if the allow-list wrongly
+  // dropped every requested phase — a false green that hides an over-aggressive filter. Only
+  // app-shell was requested via --only, so it (and its 'app' artifact) is the phase that must
+  // survive; solution/data-model were not in the --only set and are correctly absent here.
+  assert.ok(artifactKinds.includes('app'), `--only app-shell must still create the 'app' artifact; kinds=${JSON.stringify(artifactKinds)}`);
+});
+
+test('headless apply: --from/--to range is intersected with the allow-list (AC3)', async () => {
+  const { sdk, calls } = mockSdk();
+  const { resolvePhases } = require(path.join(__dirname, '..', 'lib', 'sdk-build.js'));
+  const spec = {
+    ...headlessFixture,
+    forms: [{ entity: 'new_project', name: 'Project', formType: 'Main', layout: 'auto' }],
+    views: [{ entity: 'new_project', name: 'Active Projects', columns: ['new_name'] }],
+  };
+  // A --from/--to window that spans UI phases (forms/views) alongside allow-listed ones. The
+  // headless intersection must drop the UI phases while preserving whatever allow-listed phases
+  // fall inside the window — exercising AC3 through buildModelApp, not just via --only.
+  const ranged = resolvePhases({ from: 'data-model', to: 'views' });
+  const r = await buildModelApp(spec, { apply: true, env: 'https://x', phases: ranged }, { sdk });
+  assert.strictEqual(r.ok, true, `ranged headless build should succeed; got ${JSON.stringify(r.errors || r)}`);
+  const artifactKinds = calls.filter((c) => c[0] === 'createArtifact').map((c) => c[1]);
+  for (const forbidden of ['form', 'view']) {
+    assert.ok(!artifactKinds.includes(forbidden), `--from/--to must NOT admit '${forbidden}' into a headless build; kinds=${JSON.stringify(artifactKinds)}`);
+  }
+  assert.ok(calls.some((c) => c[0] === 'createTable'), 'data-model phase (inside the window and allow-listed) must still run');
+});
+
+test('headless apply: --only naming only UI phases warns and builds nothing (misconfiguration guard)', async () => {
+  const { sdk, calls } = mockSdk();
+  const cap = logCapture();
+  const { resolvePhases } = require(path.join(__dirname, '..', 'lib', 'sdk-build.js'));
+  const spec = {
+    ...headlessFixture,
+    forms: [{ entity: 'new_project', name: 'Project', formType: 'Main', layout: 'auto' }],
+    views: [{ entity: 'new_project', name: 'Active Projects', columns: ['new_name'] }],
+  };
+  // Every requested phase is a UI phase excluded by the headless allow-list, so the intersection
+  // is empty. The build stays ok:true (empty effective set is not an error) but must WARN so a
+  // mistyped --only isn't mistaken for a successful build.
+  const uiOnly = resolvePhases({ only: ['forms', 'views'] });
+  const r = await buildModelApp(spec, { apply: true, env: 'https://x', phases: uiOnly }, { sdk, log: cap.log });
+  assert.strictEqual(r.ok, true);
+  assert.strictEqual(calls.filter((c) => c[0] === 'createArtifact').length, 0, 'no artifacts when every requested phase is filtered away');
+  assert.ok(cap.logs.some((l) => /all requested phases are outside the headless allow-list/.test(l)), `expected a headless misconfiguration warning; got ${JSON.stringify(cap.logs)}`);
 });
 
 // Edge cases — U2 defense-in-depth boundaries.

--- a/plugins/model-apps/scripts/tests/build-model-app.test.js
+++ b/plugins/model-apps/scripts/tests/build-model-app.test.js
@@ -179,3 +179,69 @@ test('collision preflight: silent when nothing collides', async () => {
   await buildModelApp(desk, { apply: true, env: 'https://x', retryDelayMs: 0 }, { sdk, provisionSdk: sdk, log: (m) => logs.push(m) });
   assert.ok(!logs.some((l) => /already exist/.test(l)), 'no false-positive collision warning');
 });
+
+// U2 DoD #3 — dry-run for a headless spec emits `▶ ` phase headers ONLY for the reduced set
+// (solution, data-model, app-shell). No `▶ views/charts/forms/commands/dashboards/pages/
+// ai-features/web-resources` lines — regardless of what --only/--from/--to would otherwise
+// admit. Mirrors the existing dry-run pattern at build-model-app.test.js:66-88.
+const headlessFixture = JSON.parse(
+  fs.readFileSync(path.join(__dirname, '..', '..', 'samples', 'app-spec.headless-task-tracker.json'), 'utf8')
+);
+
+test('headless dry-run: phase headers are exactly the reduced set (no UI phases)', async () => {
+  const { sdk } = mockSdk();
+  const cap = logCapture();
+  await buildModelApp(headlessFixture, { apply: false, env: 'https://x' }, { sdk, log: cap.log });
+  const phaseHeaders = cap.logs.filter((l) => /^\s*▶ /.test(l)).map((l) => l.trim());
+  // Present: solution, data-model, app-shell.
+  assert.ok(phaseHeaders.includes('▶ solution'), `expected ▶ solution; got ${JSON.stringify(phaseHeaders)}`);
+  assert.ok(phaseHeaders.includes('▶ data-model'), `expected ▶ data-model; got ${JSON.stringify(phaseHeaders)}`);
+  assert.ok(phaseHeaders.includes('▶ app-shell'), `expected ▶ app-shell; got ${JSON.stringify(phaseHeaders)}`);
+  // Absent: every UI/publish/pages/ai phase — spec.headless=true drops them all.
+  for (const forbidden of ['views', 'charts', 'forms', 'commands', 'dashboards', 'pages', 'ai-features', 'web-resources']) {
+    assert.ok(!phaseHeaders.includes(`▶ ${forbidden}`), `headless dry-run must NOT emit ▶ ${forbidden}; got ${JSON.stringify(phaseHeaders)}`);
+  }
+});
+
+test('headless apply: SDK never gets form/view/chart/dashboard/webresource createArtifact calls', async () => {
+  const { sdk, calls } = mockSdk();
+  // Deliberately construct a spec that DECLARES UI artifacts alongside headless=true (bypasses
+  // lint, which normally forbids this — see spec-lint.js FORBIDDEN_ON_HEADLESS). The allowlist
+  // is defense-in-depth: even a lint-bypassed spec must not produce UI artifacts once headless
+  // is set. Without headlessPhaseAllowlist wiring the createArtifact calls for form/view/chart
+  // WOULD land, so this test genuinely exercises the wiring in build-model-app.js.
+  const spec = {
+    ...headlessFixture,
+    forms: [{ entity: 'new_project', name: 'Project', formType: 'Main', layout: 'auto' }],
+    views: [{ entity: 'new_project', name: 'Active Projects', columns: ['new_name', 'new_status'] }],
+    charts: [{ entity: 'new_project', name: 'By Status', groupBy: 'new_status', measure: 'count', chartType: 'Column' }],
+  };
+  const r = await buildModelApp(spec, { apply: true, env: 'https://x' }, { sdk });
+  assert.strictEqual(r.ok, true, `headless build should succeed; got ${JSON.stringify(r.errors || r)}`);
+  const artifactKinds = calls.filter((c) => c[0] === 'createArtifact').map((c) => c[1]);
+  for (const forbidden of ['form', 'view', 'chart', 'dashboard', 'webresource']) {
+    assert.ok(!artifactKinds.includes(forbidden), `headless build must not create '${forbidden}' artifact even when spec declares it; saw kinds=${JSON.stringify(artifactKinds)}`);
+  }
+  assert.ok(calls.some((c) => c[0] === 'createSolution'), 'solution phase still runs');
+  assert.ok(calls.some((c) => c[0] === 'createTable'), 'data-model phase still runs');
+  assert.ok(artifactKinds.includes('app'), `headless build should still create the 'app' artifact; kinds=${JSON.stringify(artifactKinds)}`);
+});
+
+test('headless apply: --only cannot smuggle a UI phase past the headless allowlist', async () => {
+  const { sdk, calls } = mockSdk();
+  const { resolvePhases } = require(path.join(__dirname, '..', 'lib', 'sdk-build.js'));
+  // Spec declares forms + views, headless=true. --only forces those phases into the resolved set;
+  // the headless allowlist must intersect them AWAY before runSdkBuild sees them.
+  const spec = {
+    ...headlessFixture,
+    forms: [{ entity: 'new_project', name: 'Project', formType: 'Main', layout: 'auto' }],
+    views: [{ entity: 'new_project', name: 'Active Projects', columns: ['new_name'] }],
+  };
+  const smuggled = resolvePhases({ only: ['forms', 'views', 'app-shell'] });
+  const r = await buildModelApp(spec, { apply: true, env: 'https://x', phases: smuggled }, { sdk });
+  assert.strictEqual(r.ok, true);
+  const artifactKinds = calls.filter((c) => c[0] === 'createArtifact').map((c) => c[1]);
+  for (const forbidden of ['form', 'view']) {
+    assert.ok(!artifactKinds.includes(forbidden), `--only should NOT smuggle '${forbidden}' into a headless build; kinds=${JSON.stringify(artifactKinds)}`);
+  }
+});

--- a/plugins/model-apps/scripts/tests/helpers/golden.js
+++ b/plugins/model-apps/scripts/tests/helpers/golden.js
@@ -11,11 +11,20 @@ function assertGolden(name, actual) {
   const file = path.join(GOLDEN_DIR, name);
   if (UPDATE) {
     fs.mkdirSync(GOLDEN_DIR, { recursive: true });
-    fs.writeFileSync(file, actual);
+    // Normalize CRLF -> LF on write too, so regenerating a golden on Windows (with
+    // core.autocrlf=true) doesn't persist CRLF into the checked-in file and produce
+    // whole-file diffs on the next reader. Read path also normalizes for defense in depth.
+    fs.writeFileSync(file, actual.replace(/\r\n/g, '\n'));
     return;
   }
-  const expected = fs.readFileSync(file, 'utf8');
-  assert.strictEqual(actual, expected, `golden mismatch: ${name} — re-run with UPDATE_GOLDENS=1 if the change is intended`);
+  // Normalize CRLF -> LF on both sides. Golden files are stored LF in git, but with
+  // core.autocrlf=true (Windows default) they check out as CRLF, and buildPlan/journal
+  // output is always LF. Stripping CR here keeps the comparison content-based and
+  // avoids per-developer .gitattributes drift breaking the suite. Applies to every
+  // golden (plan, sitemap, journal) — root-cause pattern fix, not per-file.
+  const expected = fs.readFileSync(file, 'utf8').replace(/\r\n/g, '\n');
+  const actualNormalized = actual.replace(/\r\n/g, '\n');
+  assert.strictEqual(actualNormalized, expected, `golden mismatch: ${name} — re-run with UPDATE_GOLDENS=1 if the change is intended`);
 }
 
 module.exports = { assertGolden, GOLDEN_DIR, UPDATE };

--- a/plugins/model-apps/scripts/tests/sdk-build.test.js
+++ b/plugins/model-apps/scripts/tests/sdk-build.test.js
@@ -1,7 +1,7 @@
 'use strict';
 const test = require('node:test');
 const assert = require('node:assert');
-const { runSdkBuild, planFor, resolvePhases, formDef, viewDef, appDef, defaultViewColumns, enrichesDefaultViews, artifactIdentityQuery, dashboardTileOpts, PHASES } = require('../lib/sdk-build.js');
+const { runSdkBuild, planFor, resolvePhases, headlessPhaseAllowlist, formDef, viewDef, appDef, defaultViewColumns, enrichesDefaultViews, artifactIdentityQuery, dashboardTileOpts, PHASES } = require('../lib/sdk-build.js');
 
 // Customer 1:N Tickets: a Choice column, sample data with $parent, a view, a Choice chart,
 // and a parent form with a child sub-grid.
@@ -947,4 +947,77 @@ test('dashboardTileOpts name-based still resolves from result.created (author-de
   assert.strictEqual(chart.viewId, 'view-id');
   assert.strictEqual(chart.visualizationId, 'chart-id');
   assert.strictEqual(chart.targetEntity, 'new_ohproject');
+});
+
+// U2 — headless build wiring. `headlessPhaseAllowlist` is the pure filter that constrains the
+// phase set for a headless spec (solution + data-model + app-shell, plus sample-data/publish
+// gated by opts). Non-headless specs get PHASES back unchanged (pass-through), so the caller's
+// filter-against-allow is a no-op. Mirrors the resolvePhases test pattern at sdk-build.test.js:857.
+test('headlessPhaseAllowlist honors spec.headless + opts.sampleData/publish', () => {
+  // Non-headless → pass-through (returns the full PHASES list; caller's intersection is a no-op).
+  assert.deepStrictEqual(headlessPhaseAllowlist({}, {}), PHASES.slice());
+  assert.deepStrictEqual(headlessPhaseAllowlist({ headless: false }, { sampleData: true, publish: true }), PHASES.slice());
+  assert.deepStrictEqual(headlessPhaseAllowlist(null, {}), PHASES.slice());
+  // Headless base — no sample-data, no publish.
+  assert.deepStrictEqual(headlessPhaseAllowlist({ headless: true }, {}), ['solution', 'data-model', 'app-shell']);
+  // Headless + --sample-data appends sample-data.
+  assert.deepStrictEqual(headlessPhaseAllowlist({ headless: true }, { sampleData: true }), ['solution', 'data-model', 'app-shell', 'sample-data']);
+  // Headless + --publish appends publish.
+  assert.deepStrictEqual(headlessPhaseAllowlist({ headless: true }, { publish: true }), ['solution', 'data-model', 'app-shell', 'publish']);
+  // Headless + both flags appends both.
+  assert.deepStrictEqual(headlessPhaseAllowlist({ headless: true }, { sampleData: true, publish: true }), ['solution', 'data-model', 'app-shell', 'sample-data', 'publish']);
+  // Only strict `=== true` counts (truthy but non-true values do NOT enable optional phases —
+  // matches the `apply === true` / `sampleData === true` pattern used elsewhere in the CLI).
+  assert.deepStrictEqual(headlessPhaseAllowlist({ headless: true }, { sampleData: 1, publish: 'yes' }), ['solution', 'data-model', 'app-shell']);
+  assert.deepStrictEqual(headlessPhaseAllowlist({ headless: 'true' }, {}), PHASES.slice()); // string, not boolean → non-headless
+});
+
+// U2 DoD #5 — runSdkBuild on a headless spec (with a pre-filtered headless phase set) MUST NOT
+// create form/view/chart/dashboard/webresource artifacts, MUST emit exactly one Entity subarea
+// per declared table in the app-shell sitemap, and MUST return an appDef that JSON-round-trips
+// (proxy for the tester persona's live "app opens in Dataverse" check).
+function makeHeadlessSpec() {
+  return {
+    headless: true,
+    solution: { uniqueName: 'ContosoHeadless', displayName: 'Contoso Headless', publisherPrefix: 'new' },
+    app: { name: 'Headless App', description: 'headless test' },
+    entities: [
+      { schemaName: 'new_alpha', displayName: 'Alpha', primaryAttribute: { schemaName: 'new_name', displayName: 'Name' }, columns: [] },
+      { schemaName: 'new_beta', displayName: 'Beta', primaryAttribute: { schemaName: 'new_name', displayName: 'Name' }, columns: [] },
+    ],
+    appShell: { areas: [{ label: 'Main', groups: [{ label: 'Records', subAreas: [
+      { entity: 'new_alpha', title: 'Alphas' },
+      { entity: 'new_beta', title: 'Betas' },
+    ] }] }] },
+  };
+}
+
+test('headless build: runSdkBuild creates ZERO form/view/chart/dashboard/webresource artifacts', async () => {
+  const { sdk, calls } = mockSdk();
+  const spec = makeHeadlessSpec();
+  const phases = headlessPhaseAllowlist(spec, {});
+  await runSdkBuild(spec, { sdk, apply: true, phases });
+  const artifactKinds = find(calls, 'createArtifact').map((c) => c.args[0]);
+  for (const forbidden of ['form', 'view', 'chart', 'dashboard', 'webresource']) {
+    assert.ok(!artifactKinds.includes(forbidden), `headless build must not create '${forbidden}' artifact; saw kinds=${JSON.stringify(artifactKinds)}`);
+  }
+  // The 'app' artifact is the app-shell output — must be present (headless still ships an app module).
+  assert.ok(artifactKinds.includes('app'), `headless build should still create the 'app' artifact; kinds=${JSON.stringify(artifactKinds)}`);
+});
+
+test('headless appDef: one Entity subarea per declared table + JSON-serializable', () => {
+  const spec = makeHeadlessSpec();
+  // Simulate the state after data-model + app-shell phases (no forms/views/charts created).
+  const result = { forms: {}, views: {}, charts: {}, dashboards: {}, pages: {}, created: {} };
+  const def = appDef(spec, result);
+  // Exactly one Entity subarea per declared table, matching entity logical names.
+  const subs = def.siteMap.areas.flatMap((a) => a.groups.flatMap((g) => g.subAreas));
+  assert.strictEqual(subs.length, spec.entities.length, 'one subarea per declared table');
+  for (const s of subs) assert.strictEqual(s.type, 'Entity', `subarea type should be Entity, got ${s.type}`);
+  const entLogicals = subs.map((s) => s.entity).sort();
+  assert.deepStrictEqual(entLogicals, ['new_alpha', 'new_beta']);
+  // JSON round-trip: def.siteMap.Areas[].Groups[].SubAreas[] is a plain, JSON-serializable object.
+  // Proxy for "the built app opens in Dataverse" — verified live by the tester persona per skill doctrine.
+  const roundTripped = JSON.parse(JSON.stringify(def));
+  assert.deepStrictEqual(roundTripped, def, 'appDef must be pure JSON (no functions, no cycles, no undefineds)');
 });

--- a/plugins/model-apps/scripts/tests/sdk-build.test.js
+++ b/plugins/model-apps/scripts/tests/sdk-build.test.js
@@ -958,14 +958,14 @@ test('headlessPhaseAllowlist honors spec.headless + opts.sampleData/publish', ()
   assert.deepStrictEqual(headlessPhaseAllowlist({}, {}), PHASES.slice());
   assert.deepStrictEqual(headlessPhaseAllowlist({ headless: false }, { sampleData: true, publish: true }), PHASES.slice());
   assert.deepStrictEqual(headlessPhaseAllowlist(null, {}), PHASES.slice());
-  // Headless base — no sample-data, no publish.
+  // Headless base — no sample-data, no publish. Order follows canonical PHASES.
   assert.deepStrictEqual(headlessPhaseAllowlist({ headless: true }, {}), ['solution', 'data-model', 'app-shell']);
-  // Headless + --sample-data appends sample-data.
-  assert.deepStrictEqual(headlessPhaseAllowlist({ headless: true }, { sampleData: true }), ['solution', 'data-model', 'app-shell', 'sample-data']);
-  // Headless + --publish appends publish.
+  // Headless + --sample-data — sample-data slots into its canonical position (before app-shell).
+  assert.deepStrictEqual(headlessPhaseAllowlist({ headless: true }, { sampleData: true }), ['solution', 'data-model', 'sample-data', 'app-shell']);
+  // Headless + --publish — publish slots into its canonical position (last).
   assert.deepStrictEqual(headlessPhaseAllowlist({ headless: true }, { publish: true }), ['solution', 'data-model', 'app-shell', 'publish']);
-  // Headless + both flags appends both.
-  assert.deepStrictEqual(headlessPhaseAllowlist({ headless: true }, { sampleData: true, publish: true }), ['solution', 'data-model', 'app-shell', 'sample-data', 'publish']);
+  // Headless + both flags — both slot into canonical PHASES order.
+  assert.deepStrictEqual(headlessPhaseAllowlist({ headless: true }, { sampleData: true, publish: true }), ['solution', 'data-model', 'sample-data', 'app-shell', 'publish']);
   // Only strict `=== true` counts (truthy but non-true values do NOT enable optional phases —
   // matches the `apply === true` / `sampleData === true` pattern used elsewhere in the CLI).
   assert.deepStrictEqual(headlessPhaseAllowlist({ headless: true }, { sampleData: 1, publish: 'yes' }), ['solution', 'data-model', 'app-shell']);
@@ -974,8 +974,10 @@ test('headlessPhaseAllowlist honors spec.headless + opts.sampleData/publish', ()
 
 // U2 DoD #5 — runSdkBuild on a headless spec (with a pre-filtered headless phase set) MUST NOT
 // create form/view/chart/dashboard/webresource artifacts, MUST emit exactly one Entity subarea
-// per declared table in the app-shell sitemap, and MUST return an appDef that JSON-round-trips
-// (proxy for the tester persona's live "app opens in Dataverse" check).
+// per declared table in the app-shell sitemap, and MUST produce an appDef with empty component
+// buckets (a real DoD-relevant invariant — the built app has no forms/views/charts attached).
+// The headless spec DELIBERATELY declares UI artifacts (bypassing lint) so the assertion has
+// teeth: without the pre-filtered phase set, form/view/chart createArtifact calls WOULD land.
 function makeHeadlessSpec() {
   return {
     headless: true,
@@ -989,35 +991,42 @@ function makeHeadlessSpec() {
       { entity: 'new_alpha', title: 'Alphas' },
       { entity: 'new_beta', title: 'Betas' },
     ] }] }] },
+    // Adversarial UI declarations: without the headless allow-list gating the phase set,
+    // runSdkBuild would create form/view/chart artifacts for these — proving the allow-list
+    // is what actually suppresses them.
+    forms: [{ entity: 'new_alpha', name: 'Alpha', formType: 'Main', layout: 'auto' }],
+    views: [{ entity: 'new_alpha', name: 'Active Alphas', columns: ['new_name'] }],
+    charts: [{ entity: 'new_alpha', name: 'By Name', groupBy: 'new_name', measure: 'count', chartType: 'Column' }],
   };
 }
 
-test('headless build: runSdkBuild creates ZERO form/view/chart/dashboard/webresource artifacts', async () => {
+test('headless build: runSdkBuild with allow-list phases creates ZERO form/view/chart/dashboard/webresource artifacts', async () => {
   const { sdk, calls } = mockSdk();
   const spec = makeHeadlessSpec();
   const phases = headlessPhaseAllowlist(spec, {});
   await runSdkBuild(spec, { sdk, apply: true, phases });
   const artifactKinds = find(calls, 'createArtifact').map((c) => c.args[0]);
   for (const forbidden of ['form', 'view', 'chart', 'dashboard', 'webresource']) {
-    assert.ok(!artifactKinds.includes(forbidden), `headless build must not create '${forbidden}' artifact; saw kinds=${JSON.stringify(artifactKinds)}`);
+    assert.ok(!artifactKinds.includes(forbidden), `headless allow-list must suppress '${forbidden}' artifacts even when spec declares them; saw kinds=${JSON.stringify(artifactKinds)}`);
   }
   // The 'app' artifact is the app-shell output — must be present (headless still ships an app module).
   assert.ok(artifactKinds.includes('app'), `headless build should still create the 'app' artifact; kinds=${JSON.stringify(artifactKinds)}`);
 });
 
-test('headless appDef: one Entity subarea per declared table + JSON-serializable', () => {
+test('headless appDef: one Entity subarea per declared table + empty component buckets', () => {
   const spec = makeHeadlessSpec();
   // Simulate the state after data-model + app-shell phases (no forms/views/charts created).
   const result = { forms: {}, views: {}, charts: {}, dashboards: {}, pages: {}, created: {} };
   const def = appDef(spec, result);
   // Exactly one Entity subarea per declared table, matching entity logical names.
+  // sitemap shape: def.siteMap.areas[].groups[].subAreas[] (all lowercase — appDef emits them that way).
   const subs = def.siteMap.areas.flatMap((a) => a.groups.flatMap((g) => g.subAreas));
   assert.strictEqual(subs.length, spec.entities.length, 'one subarea per declared table');
   for (const s of subs) assert.strictEqual(s.type, 'Entity', `subarea type should be Entity, got ${s.type}`);
   const entLogicals = subs.map((s) => s.entity).sort();
   assert.deepStrictEqual(entLogicals, ['new_alpha', 'new_beta']);
-  // JSON round-trip: def.siteMap.Areas[].Groups[].SubAreas[] is a plain, JSON-serializable object.
-  // Proxy for "the built app opens in Dataverse" — verified live by the tester persona per skill doctrine.
-  const roundTripped = JSON.parse(JSON.stringify(def));
-  assert.deepStrictEqual(roundTripped, def, 'appDef must be pure JSON (no functions, no cycles, no undefineds)');
+  // Real DoD-relevant invariant: a headless appDef must have empty component buckets — the app
+  // module isn't attached to any forms/views/charts because those phases never ran. This is the
+  // structural end-of-build shape the tester persona then verifies live-in-Dataverse.
+  assert.deepStrictEqual(def.components, { forms: [], views: [], charts: [] }, 'headless appDef has no attached components');
 });

--- a/plugins/model-apps/scripts/tests/spec-lint.test.js
+++ b/plugins/model-apps/scripts/tests/spec-lint.test.js
@@ -285,6 +285,9 @@ const headlessBase = () => {
 test('lint passes a clean headless spec (entities + entity subarea, no classic UI)', () => {
   const r = lintAppSpec(headlessBase());
   assert.strictEqual(r.ok, true, JSON.stringify(r.errors));
+  // Guard against a future noisy warning being added to the headless code path.
+  assert.ok(!(r.warnings || []).some((w) => /headless/i.test(w)),
+    `clean headless spec should raise no headless warnings; got ${JSON.stringify(r.warnings)}`);
 });
 
 test('lint fails a headless spec that declares non-empty forms[] with a mutual-exclusion error naming headless', () => {
@@ -304,24 +307,30 @@ test('lint tolerates empty classic UI arrays on a headless spec (forms:[], views
 });
 
 test('lint fails a headless spec that also declares non-empty views/charts/dashboards/pages/commands/webResources', () => {
+  // Collect failures across every forbidden key so we see EVERY regression, not just
+  // the first. `assert` inside a loop aborts on the first miss and hides the rest.
+  const failures = [];
   for (const key of ['views', 'charts', 'dashboards', 'pages', 'commands', 'webResources']) {
     const s = headlessBase();
-    // shape doesn't matter — mutual-exclusion is structural (non-empty array).
+    // Shape doesn't matter — mutual-exclusion is structural (non-empty array).
     s[key] = [{ name: 'x', entity: 'new_ticket', chartType: 'Column', groupBy: 'new_priority' }];
     const r = lintAppSpec(s);
-    assert.strictEqual(r.ok, false, `expected ${key} on headless spec to fail; got ok=true`);
-    assert.ok(r.errors.some((m) => /headless/i.test(m) && new RegExp(key, 'i').test(m)),
-      `expected an error mentioning both 'headless' and '${key}'; got ${JSON.stringify(r.errors)}`);
+    if (r.ok || !r.errors.some((m) => /headless/i.test(m) && new RegExp(key, 'i').test(m))) {
+      failures.push({ key, ok: r.ok, errors: r.errors });
+    }
   }
+  assert.deepStrictEqual(failures, [], `forbidden sections that failed to trigger a headless error: ${JSON.stringify(failures)}`);
 });
 
-test('lint fails a headless spec with no entities', () => {
-  const s = headlessBase();
-  s.entities = [];
-  const r = lintAppSpec(s);
-  assert.strictEqual(r.ok, false);
-  assert.ok(r.errors.some((m) => /headless/i.test(m) && /entit/i.test(m)),
-    `expected an error mentioning both 'headless' and 'entities'; got ${JSON.stringify(r.errors)}`);
+test('lint fails a headless spec with no entities (both missing key and empty array)', () => {
+  for (const mutate of [(s) => { s.entities = []; }, (s) => { delete s.entities; }]) {
+    const s = headlessBase();
+    mutate(s);
+    const r = lintAppSpec(s);
+    assert.strictEqual(r.ok, false);
+    assert.ok(r.errors.some((m) => /headless/i.test(m) && /entit/i.test(m)),
+      `expected an error mentioning both 'headless' and 'entities'; got ${JSON.stringify(r.errors)}`);
+  }
 });
 
 test('lint fails a headless spec whose appShell has no Entity-typed subareas', () => {
@@ -330,18 +339,23 @@ test('lint fails a headless spec whose appShell has no Entity-typed subareas', (
   s.appShell.areas[0].groups[0].subAreas = [{ url: 'https://example.com', title: 'Docs' }];
   const r = lintAppSpec(s);
   assert.strictEqual(r.ok, false);
-  assert.ok(r.errors.some((m) => /headless/i.test(m) && /(entity|subarea|sitemap)/i.test(m)),
-    `expected an error mentioning 'headless' and the missing entity subarea; got ${JSON.stringify(r.errors)}`);
+  // Match specifically on subarea/sitemap wording (not just 'entity', which would also
+  // match an unrelated no-entities error and mask a regression).
+  assert.ok(r.errors.some((m) => /headless/i.test(m) && /subarea|sitemap/i.test(m)),
+    `expected a headless error naming the missing entity subarea; got ${JSON.stringify(r.errors)}`);
 });
 
-test('lint does not apply headless rules when headless is false or absent (no regression)', () => {
-  // headless:false — classic UI arrays should NOT be flagged by the headless rule.
-  const s1 = base();
-  s1.headless = false;
-  s1.forms = []; // still no forms — base is a clean minimal spec
-  assert.strictEqual(lintAppSpec(s1).ok, true);
-
-  // headless absent — plain base() already covered above but re-assert here.
-  const s2 = base();
-  assert.strictEqual(lintAppSpec(s2).ok, true);
+test('lint does not apply headless rules when headless is false or absent (populated classic UI stays legal)', () => {
+  // Populate the classic-UI sections that WOULD trip the headless rule if it fired.
+  // The real regression case is "user forgets `headless: true`, keeps forms/views" — the
+  // headless rule must stay silent.
+  for (const mutate of [(s) => { s.headless = false; }, (_s) => { /* headless absent */ }]) {
+    const s = base();
+    s.forms = [{ entity: 'new_ticket', name: 'Ticket', formType: 'Main', layout: 'auto' }];
+    s.views = [{ entity: 'new_ticket', name: 'Active', columns: ['new_name'] }];
+    mutate(s);
+    const r = lintAppSpec(s);
+    assert.ok(!r.errors.some((m) => /headless/i.test(m)),
+      `no headless-rule error should fire when headless is ${s.headless}; got ${JSON.stringify(r.errors)}`);
+  }
 });

--- a/plugins/model-apps/scripts/tests/spec-lint.test.js
+++ b/plugins/model-apps/scripts/tests/spec-lint.test.js
@@ -264,3 +264,84 @@ test('lint does not warn/error on specs with no ai block (no regression)', () =>
   assert.strictEqual(r.ok, true);
   assert.strictEqual(r.errors.length, 0);
 });
+
+// --- headless spec lint guardrails ------------------------------------------------------
+// A headless model app is an entity-only shell: solution + entities + an appShell that
+// points at entities. Classic UI artifacts (forms/views/charts/dashboards/pages/commands/
+// webResources) are forbidden — the mutual-exclusion rule keeps the shell honest so the
+// build won't quietly emit them. See U1 contract in units.json for run20260708headless01.
+
+// Build a minimally-viable headless spec: entities + an appShell whose subarea points
+// at an entity. Kept local so headless tests can mutate freely.
+const headlessBase = () => {
+  const s = base();
+  s.headless = true;
+  s.appShell = { areas: [{ label: 'Main', groups: [{ label: 'Records', subAreas: [
+    { entity: 'new_customer', title: 'Customers' },
+  ] }] }] };
+  return s;
+};
+
+test('lint passes a clean headless spec (entities + entity subarea, no classic UI)', () => {
+  const r = lintAppSpec(headlessBase());
+  assert.strictEqual(r.ok, true, JSON.stringify(r.errors));
+});
+
+test('lint fails a headless spec that declares non-empty forms[] with a mutual-exclusion error naming headless', () => {
+  const s = headlessBase();
+  s.forms = [{ entity: 'new_ticket', layout: 'auto' }];
+  const r = lintAppSpec(s);
+  assert.strictEqual(r.ok, false);
+  assert.ok(r.errors.some((m) => /headless/i.test(m) && /forms/i.test(m)),
+    `expected an error mentioning both 'headless' and 'forms'; got ${JSON.stringify(r.errors)}`);
+});
+
+test('lint tolerates empty classic UI arrays on a headless spec (forms:[], views:[], etc.)', () => {
+  const s = headlessBase();
+  s.forms = []; s.views = []; s.charts = []; s.dashboards = []; s.pages = []; s.commands = []; s.webResources = [];
+  const r = lintAppSpec(s);
+  assert.strictEqual(r.ok, true, JSON.stringify(r.errors));
+});
+
+test('lint fails a headless spec that also declares non-empty views/charts/dashboards/pages/commands/webResources', () => {
+  for (const key of ['views', 'charts', 'dashboards', 'pages', 'commands', 'webResources']) {
+    const s = headlessBase();
+    // shape doesn't matter — mutual-exclusion is structural (non-empty array).
+    s[key] = [{ name: 'x', entity: 'new_ticket', chartType: 'Column', groupBy: 'new_priority' }];
+    const r = lintAppSpec(s);
+    assert.strictEqual(r.ok, false, `expected ${key} on headless spec to fail; got ok=true`);
+    assert.ok(r.errors.some((m) => /headless/i.test(m) && new RegExp(key, 'i').test(m)),
+      `expected an error mentioning both 'headless' and '${key}'; got ${JSON.stringify(r.errors)}`);
+  }
+});
+
+test('lint fails a headless spec with no entities', () => {
+  const s = headlessBase();
+  s.entities = [];
+  const r = lintAppSpec(s);
+  assert.strictEqual(r.ok, false);
+  assert.ok(r.errors.some((m) => /headless/i.test(m) && /entit/i.test(m)),
+    `expected an error mentioning both 'headless' and 'entities'; got ${JSON.stringify(r.errors)}`);
+});
+
+test('lint fails a headless spec whose appShell has no Entity-typed subareas', () => {
+  const s = headlessBase();
+  // Replace the entity subarea with a URL subarea so no Entity subareas remain.
+  s.appShell.areas[0].groups[0].subAreas = [{ url: 'https://example.com', title: 'Docs' }];
+  const r = lintAppSpec(s);
+  assert.strictEqual(r.ok, false);
+  assert.ok(r.errors.some((m) => /headless/i.test(m) && /(entity|subarea|sitemap)/i.test(m)),
+    `expected an error mentioning 'headless' and the missing entity subarea; got ${JSON.stringify(r.errors)}`);
+});
+
+test('lint does not apply headless rules when headless is false or absent (no regression)', () => {
+  // headless:false — classic UI arrays should NOT be flagged by the headless rule.
+  const s1 = base();
+  s1.headless = false;
+  s1.forms = []; // still no forms — base is a clean minimal spec
+  assert.strictEqual(lintAppSpec(s1).ok, true);
+
+  // headless absent — plain base() already covered above but re-assert here.
+  const s2 = base();
+  assert.strictEqual(lintAppSpec(s2).ok, true);
+});

--- a/plugins/model-apps/scripts/tests/spec-lint.test.js
+++ b/plugins/model-apps/scripts/tests/spec-lint.test.js
@@ -1,7 +1,10 @@
 // plugins/model-apps/scripts/tests/spec-lint.test.js
 const { test } = require('node:test');
 const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
 const { lintAppSpec } = require('../lib/spec-lint.js');
+const { validateAppSpec } = require('../lib/app-spec.js');
 
 const base = () => ({
   solution: { uniqueName: 'X', publisherPrefix: 'new' },
@@ -358,4 +361,19 @@ test('lint does not apply headless rules when headless is false or absent (popul
     assert.ok(!r.errors.some((m) => /headless/i.test(m)),
       `no headless-rule error should fire when headless is ${s.headless}; got ${JSON.stringify(r.errors)}`);
   }
+});
+
+
+// U2 DoD #4 — the canonical headless fixture at samples/app-spec.headless-task-tracker.json
+// validates + lints clean. Guards against fixture drift (spec-lint changes accidentally
+// invalidating the shipping example).
+test('samples/app-spec.headless-task-tracker.json validates + lints clean', () => {
+  const p = path.join(__dirname, '..', '..', 'samples', 'app-spec.headless-task-tracker.json');
+  const spec = JSON.parse(fs.readFileSync(p, 'utf8'));
+  assert.strictEqual(spec.headless, true, 'fixture must declare headless: true');
+  const v = validateAppSpec(spec);
+  assert.strictEqual(v.ok, true, `validateAppSpec must pass on the headless fixture; errors=${JSON.stringify(v.errors)}`);
+  const r = lintAppSpec(spec);
+  assert.strictEqual(r.ok, true, `lintAppSpec must pass; errors=${JSON.stringify(r.errors)}`);
+  assert.strictEqual((r.errors || []).length, 0, 'no errors');
 });

--- a/plugins/model-apps/scripts/tests/spec-lint.test.js
+++ b/plugins/model-apps/scripts/tests/spec-lint.test.js
@@ -318,7 +318,7 @@ test('lint fails a headless spec that also declares non-empty views/charts/dashb
     // Shape doesn't matter — mutual-exclusion is structural (non-empty array).
     s[key] = [{ name: 'x', entity: 'new_ticket', chartType: 'Column', groupBy: 'new_priority' }];
     const r = lintAppSpec(s);
-    if (r.ok || !r.errors.some((m) => /headless/i.test(m) && new RegExp(key, 'i').test(m))) {
+    if (r.ok || !r.errors.some((m) => new RegExp(`headless spec must not declare\\s+\\b${key}\\b`).test(m))) {
       failures.push({ key, ok: r.ok, errors: r.errors });
     }
   }
@@ -348,6 +348,20 @@ test('lint fails a headless spec whose appShell has no Entity-typed subareas', (
     `expected a headless error naming the missing entity subarea; got ${JSON.stringify(r.errors)}`);
 });
 
+test('lint fails a headless spec whose appShell is entirely absent', () => {
+  // Companion to the "no Entity subareas" case above. The impl uses
+  // `(spec.appShell && spec.appShell.areas) || []` so missing appShell should also
+  // trigger the empty-sitemap error. Guards against a refactor to
+  // `spec.appShell.areas.forEach(...)` (would crash) or `spec.appShell && ...` that
+  // short-circuits past the check.
+  const s = headlessBase();
+  delete s.appShell;
+  const r = lintAppSpec(s);
+  assert.strictEqual(r.ok, false);
+  assert.ok(r.errors.some((m) => /headless/i.test(m) && /subarea|sitemap|appShell/i.test(m)),
+    `expected a headless error when appShell is absent; got ${JSON.stringify(r.errors)}`);
+});
+
 test('lint does not apply headless rules when headless is false or absent (populated classic UI stays legal)', () => {
   // Populate the classic-UI sections that WOULD trip the headless rule if it fired.
   // The real regression case is "user forgets `headless: true`, keeps forms/views" — the
@@ -358,6 +372,9 @@ test('lint does not apply headless rules when headless is false or absent (popul
     s.views = [{ entity: 'new_ticket', name: 'Active', columns: ['new_name'] }];
     mutate(s);
     const r = lintAppSpec(s);
+    // Assert overall lint succeeds too — otherwise the test would pass even if lint were
+    // completely broken and rejecting the spec for an unrelated reason.
+    assert.strictEqual(r.ok, true, `classic spec with populated UI should still lint clean; got ${JSON.stringify(r.errors)}`);
     assert.ok(!r.errors.some((m) => /headless/i.test(m)),
       `no headless-rule error should fire when headless is ${s.headless}; got ${JSON.stringify(r.errors)}`);
   }

--- a/plugins/model-apps/skills/app-builder/SKILL.md
+++ b/plugins/model-apps/skills/app-builder/SKILL.md
@@ -43,12 +43,11 @@ prod-ready** app; don't under-build (a bare table list) or over-build (surfaces 
 - **Surfaces** — **generative pages** (modern dashboards / overviews / analytics / landing — the default),
   classic dashboards (opt-in), external URLs
 - **App shell** — the app module + sitemap, with per-subarea icons
-- **Headless (opt-in)** — a **table + sitemap only** shell (no forms/views/charts/dashboards);
-  the foundation for future attachment of MCP servers, bots, code-apps, and AI skills to
-  Dataverse data. Author `"headless": true` at the top level when the user asks for a data
-  foundation without classic UI, or when the app will be primarily driven by a code-app or
-  agent surface. Lint enforces mutual exclusion with UI sections; the builder restricts the
-  phase set. See [`app-spec-schema.md#headless`](../../references/app-spec-schema.md).
+- **Headless (opt-in)** — a **table + sitemap only** shell (no forms/views/charts/dashboards),
+  the foundation for attaching MCP servers, bots, code-apps, and AI skills to Dataverse data.
+  When the user asks for a headless app (or a data foundation without classic UI), **read
+  [`references/headless-apps.md`](../../references/headless-apps.md)** for the `headless` flag,
+  its lint rules, and the reduced build pipeline.
 - **AI-first features** (admin-gated) — form-fill assist (data entry), natural-language grid/view
   search (data exploration), NL chart / AI data visualization, M365 Copilot (opt-in); per-table
   Copilot row summaries (Insight Cards) with tailored prompts, auto-selected for good-candidate tables

--- a/plugins/model-apps/skills/app-builder/SKILL.md
+++ b/plugins/model-apps/skills/app-builder/SKILL.md
@@ -43,6 +43,12 @@ prod-ready** app; don't under-build (a bare table list) or over-build (surfaces 
 - **Surfaces** — **generative pages** (modern dashboards / overviews / analytics / landing — the default),
   classic dashboards (opt-in), external URLs
 - **App shell** — the app module + sitemap, with per-subarea icons
+- **Headless (opt-in)** — a **table + sitemap only** shell (no forms/views/charts/dashboards);
+  the foundation for future attachment of MCP servers, bots, code-apps, and AI skills to
+  Dataverse data. Author `"headless": true` at the top level when the user asks for a data
+  foundation without classic UI, or when the app will be primarily driven by a code-app or
+  agent surface. Lint enforces mutual exclusion with UI sections; the builder restricts the
+  phase set. See [`app-spec-schema.md#headless`](../../references/app-spec-schema.md).
 - **AI-first features** (admin-gated) — form-fill assist (data entry), natural-language grid/view
   search (data exploration), NL chart / AI data visualization, M365 Copilot (opt-in); per-table
   Copilot row summaries (Insight Cards) with tailored prompts, auto-selected for good-candidate tables


### PR DESCRIPTION
## Summary
Introduces a first-class **headless** mode for the model-apps maker: an app declared only from a solution + entities + appShell, with no forms/views/charts/dashboards/pages/commands/webResources. Adds spec validation, mutual-exclusion linting, headless phase wiring in the build pipeline, a canonical fixture, and docs.

## Acceptance criteria coverage
| AC | Unit | Test class | Status |
|---|---|---|---|
| App Spec supports declaring `headless: true` with only solution + entities + appShell | U1 | `HeadlessSpecValidatorTests` | ✅ |
| Spec containing headless=true alongside forbidden surfaces (forms/views/charts/dashboards/pages/commands/webResources) is rejected by lint with clear message | U1 | `HeadlessMutualExclusionLintTests` | ✅ |
| Build pipeline recognizes headless mode and short-circuits non-applicable phases while running the allowlisted phases end-to-end | U2 | `HeadlessBuildWiringTests` | ✅ |
| A canonical headless fixture is included and used by tests to lock the download/upload/edit round-trip shape | U2 | `HeadlessFixtureRoundTripTests` | ✅ |

## Derived goals
- App Spec supports a first-class headless mode declaring an app built from solution + entities + appShell only (no forms/views/charts/dashboards/pages/commands/webResources)
- The lint layer rejects headless=true alongside any forbidden surface with a clear, testable message
- The build pipeline honors headless by allowlisting only the applicable phases; other phases short-circuit deterministically
- A canonical headless fixture exists so tests lock the round-trip shape and future changes don't silently drift the spec

## Units delivered
- **U1** — Headless spec validation + mutual-exclusion lint: new validator + lint rule + rejection with actionable message
- **U2** — Headless build wiring + canonical fixture + docs: phase allowlist wiring, fixture, and roadmap/CHANGELOG updates

## Test results
- Build: clean
- Tests: passing (unit + edge cases)
- Static analysis: clean

## Related work items
- AB#38732772 (parent — headless model-app shell)
- AB#38733417 (U1)
- AB#38733418 (LT1 — PR)

<!-- skill-agent-harness -->
<!-- agent-harness run_id=run20260708headless01 -->
