### PR TITLE
Use MobileApp type for init command

### DIFF
--- a/plugins/mobile-apps/agents/native-app-planner.md
+++ b/plugins/mobile-apps/agents/native-app-planner.md
@@ -596,7 +596,7 @@ Sections approved:
 Next steps for the orchestrator:
   1. Auth + environment selection
   2. Use the user-prepared fresh template folder materialized from `pa-wrap-tools/templates/expo-app-standalone` with `degit`
-  3. npx power-apps init --display-name <name> --environment-id <environment-id> --non-interactive
+  3. npx power-apps init -t MobileApp --display-name <name> --environment-id <environment-id> --non-interactive
   4. Apply data model via /add-dataverse using the plan
   5. Apply native capabilities via /add-native using the plan
   6. Apply connectors via /add-connector per connector using the plan
@@ -605,6 +605,6 @@ Next steps for the orchestrator:
 
 ## Tool Permissions
 
-You have `Bash` only to run read-only file/HTTP/helper checks such as `node scripts/resolve-environment.js <environment-id-or-url>` when needed for context. You MUST NOT run mutating Power Apps CLI commands such as `npx power-apps init --display-name <name> --environment-id <environment-id> --non-interactive`, `npx power-apps add-data-source ...`, `npx power-apps add-flow --flow-id <flow-guid> --non-interactive`, `npx power-apps push --non-interactive`, `npm install`, or any other mutation command.
+You have `Bash` only to run read-only file/HTTP/helper checks such as `node scripts/resolve-environment.js <environment-id-or-url>` when needed for context. You MUST NOT run mutating Power Apps CLI commands such as `npx power-apps init -t MobileApp --display-name <name> --environment-id <environment-id> --non-interactive`, `npx power-apps add-data-source ...`, `npx power-apps add-flow --flow-id <flow-guid> --non-interactive`, `npx power-apps push --non-interactive`, `npm install`, or any other mutation command.
 
 You have `Write` only to create `native-app-plan.md`. You MUST NOT write any other file in the project.

--- a/plugins/mobile-apps/agents/screen-planner.md
+++ b/plugins/mobile-apps/agents/screen-planner.md
@@ -49,7 +49,7 @@ The orchestrator splits Gate 4 into two cheaper gates so the user can edit the s
 
 **Hard rule — single-write in `phase: specs`.** The previous behaviour of writing both `plan_path` and `_screens_section.md` doubles wall-clock time on Gate 4b (full file rewrite of a ~12 KB plan happens twice for an 8-screen app). The duplicate `_screens_section.md` write is forbidden in `phase: specs` — only the append into `plan_path` is allowed.
 
-**The scaffolded project IS available at `<working_dir>/`.** The orchestrator's Step 2d background pipeline finishes the full template scaffold (clone → fixes → npm install → `npx power-apps init --display-name <name> --environment-id <environment-id> --non-interactive` → schemas → tsc smoke) in parallel with your run. By the time you start, `<working_dir>/` is populated with the complete template tree. Safe to `Glob` and `Read`:
+**The scaffolded project IS available at `<working_dir>/`.** The orchestrator's Step 2d background pipeline finishes the full template scaffold (clone → fixes → npm install → `npx power-apps init -t MobileApp --display-name <name> --environment-id <environment-id> --non-interactive` → schemas → tsc smoke) in parallel with your run. By the time you start, `<working_dir>/` is populated with the complete template tree. Safe to `Glob` and `Read`:
 
 - `<working_dir>/app/index.tsx`, `app/login.tsx`, `app/oauth-callback.tsx`, `app/(app)/_layout.tsx`, `app/(app)/home.tsx` — existing routes
 - `<working_dir>/tamagui.config.ts` — design tokens

--- a/plugins/mobile-apps/hooks/validate-protected-paths.js
+++ b/plugins/mobile-apps/hooks/validate-protected-paths.js
@@ -29,7 +29,7 @@ const PROTECTED = [
   {
     rx: /(^|\/)power\.config\.json$/,
     reason:
-      '`power.config.json` is owned by `npx power-apps init`. Re-run `npx power-apps init --display-name <name> --environment-id <id> --non-interactive` to change environment binding.',
+      '`power.config.json` is owned by `npx power-apps init`. Re-run `npx power-apps init -t MobileApp --display-name <name> --environment-id <id> --non-interactive` to change environment binding.',
   },
   {
     rx: /(^|\/)vendor\/[^/]+\.tgz$/,

--- a/plugins/mobile-apps/shared/preferred-environment.md
+++ b/plugins/mobile-apps/shared/preferred-environment.md
@@ -48,7 +48,7 @@ node scripts/resolve-environment.js <environment-id-or-url>
 
 ## When the active env doesn't match
 
-If `power.config.json` says env A and the user says they intended env B, the project metadata wins for this working directory. Re-run `npx power-apps init --display-name '<name>' --environment-id <env-b-id> --non-interactive` in a separate copy if they want a different environment; do not silently edit `power.config.json`.
+If `power.config.json` says env A and the user says they intended env B, the project metadata wins for this working directory. Re-run `npx power-apps init -t MobileApp --display-name '<name>' --environment-id <env-b-id> --non-interactive` in a separate copy if they want a different environment; do not silently edit `power.config.json`.
 
 If `memory-bank.md` says env A and `power.config.json` says env B, `power.config.json` wins (it's the source of truth that drives `npx power-apps` Code Apps commands). Update the memory bank to match.
 
@@ -57,7 +57,7 @@ If `memory-bank.md` says env A and `power.config.json` says env B, `power.config
 A single working directory belongs to exactly one environment. If the user wants to deploy the same app to a different env (e.g., dev → prod):
 
 1. `cp -r <working_dir> <new_dir>` to clone the project.
-2. In the new dir: `npx power-apps init --display-name '<same name>' --environment-id <new-env-id> --non-interactive` will overwrite `power.config.json`.
+2. In the new dir: `npx power-apps init -t MobileApp --display-name '<same name>' --environment-id <new-env-id> --non-interactive` will overwrite `power.config.json`.
 3. Re-run `/list-connections` to verify connection IDs match the new env (they likely won't).
 4. Re-run `/add-connector` for any connector whose connection ID is missing or wrong.
 

--- a/plugins/mobile-apps/shared/shared-instructions.md
+++ b/plugins/mobile-apps/shared/shared-instructions.md
@@ -134,7 +134,7 @@ Use direct `npx power-apps`, `node`, and `az` commands for the mobile-app plugin
 Typical commands:
 
 ```bash
-npx power-apps init --display-name '<name>' --environment-id <id> --non-interactive
+npx power-apps init -t MobileApp --display-name '<name>' --environment-id <id> --non-interactive
 npx power-apps add-data-source --api-id <api> --connection-id <connection-id>
 npx power-apps create-connection --api-id <api> --json
 npx power-apps list-connection-references --solution-id <solution-id> --json
@@ -195,7 +195,7 @@ Apply these rules whenever an `az`, `npm`, `npx`, or `expo` command exits non-ze
 | Wrong Power Apps CLI user, `Multiple accounts found`, or standalone CLI auth loop | Run `npx power-apps auth-status --json` to see cached accounts. If the right account is cached, run `npx power-apps auth-switch --account <email>`. If not cached, run `npx power-apps login [--account <email>]`. Do not use `az account set` to switch this CLI. |
 | `connectionId not found` or empty `-c` | Create a connection with `npx power-apps create-connection --api-id <api-id> --json`, use a caller-provided existing connection ID, or use `list-connection-references --solution-id <solution-id> --json` and retry with `--connection-ref`. |
 | Missing `orgUrl`, `resourceName`, `apiId`, or `environmentId` | Re-run with the full long-form command for that connector shape; do not fall back to interactive prompts. |
-| `environment not set` | Confirm `power.config.json` has `environmentId`; if missing, rerun `npx power-apps init --display-name '<name>' --environment-id <id> --non-interactive`. |
+| `environment not set` | Confirm `power.config.json` has `environmentId`; if missing, rerun `npx power-apps init -t MobileApp --display-name '<name>' --environment-id <id> --non-interactive`. |
 | Non-zero exit for any other reason | Report exact stderr. STOP. |
 
 ### `npm install` / `npx expo install` failures

--- a/plugins/mobile-apps/skills/create-mobile-app/SKILL.md
+++ b/plugins/mobile-apps/skills/create-mobile-app/SKILL.md
@@ -128,7 +128,7 @@ Capture target Power Platform environment for the remaining flow.
 | 1. User supplies env ID | `scripts/resolve-environment.js <environment-id>` | Ask only if `power.config.json` is missing/empty or user wants a different env |
 | 2. User wants a different account | Follow shared-instructions standalone CLI auth handling | Only if resolution/token acquisition fails or user asks |
 | 3. User wants different env | Ask for another env ID and re-run resolver | Only if user selects "use a different environment" at Step 2 |
-| 4. `npx power-apps init --display-name "$DISPLAY_NAME" --environment-id $ACTIVE_ENV_ID --non-interactive` | Persists choice into `power.config.json` | Only when this skill owns the initial init path |
+| 4. `npx power-apps init -t MobileApp --display-name "$DISPLAY_NAME" --environment-id $ACTIVE_ENV_ID --non-interactive` | Persists choice into `power.config.json` | Only when this skill owns the initial init path |
 
 ```bash
 TARGET_ENV="<environment-id-or-empty>"
@@ -840,11 +840,11 @@ Do not run `npm install` inside Step 5 — in template-only mode dependencies mu
 ### Step 6 — Initialize
 
 **Print before starting:**
-> "→ [Step 6/13] Running `npx power-apps init` to write power.config.json for environment <env-id>. ~15–30 seconds."
+> "→ [Step 6/13] Running `npx power-apps init -t MobileApp` to write power.config.json for environment <env-id>. ~15–30 seconds."
 
 ```bash
 cd <working_dir>
-npx power-apps init --display-name '<displayName>' --environment-id <environment-id> --non-interactive
+npx power-apps init -t MobileApp --display-name '<displayName>' --environment-id <environment-id> --non-interactive
 ```
 
 Verify `power.config.json` was created and `environmentId` matches Step 4. If `npx power-apps init` fails, report the exact error and STOP — do not proceed.

--- a/plugins/mobile-apps/skills/deploy/SKILL.md
+++ b/plugins/mobile-apps/skills/deploy/SKILL.md
@@ -101,7 +101,7 @@ If deploy fails, report the error and STOP — do not retry silently. Common fix
 | Error | Fix |
 |---|---|
 | `npx power-apps push` auth error, wrong user, or multiple accounts | Follow shared-instructions command-failure handling. `az login` / `az account set` does not switch the standalone Power Apps CLI account. |
-| Environment mismatch | Re-run `npx power-apps init --display-name <name> --environment-id <id> --non-interactive` in a fresh/app root for the intended target|
+| Environment mismatch | Re-run `npx power-apps init -t MobileApp --display-name <name> --environment-id <id> --non-interactive` in a fresh/app root for the intended target|
 | `npx power-apps push` not recognised | Run `npm install` in the project so `@microsoft/power-apps` provides the CLI, or install `@microsoft/power-apps-cli` only as a last-resort prerequisite after user confirmation. |
 
 ### Step 4 — Update memory bank


### PR DESCRIPTION
## Summary

- Add `-t MobileApp` to `npx power-apps init` so generated projects are explicitly initialized as mobile apps.
- Update the create flow, planner guidance, shared instructions, environment recovery, and deployment troubleshooting examples to use the same command.
- Update the protected-path hook message to recommend the mobile-specific initialization command.