### PR TITLE
fix(power-automate): resilient MCP bootstrap for Copilot CLI

### DIFF
--- a/plugins/power-automate/.mcp.json
+++ b/plugins/power-automate/.mcp.json
@@ -4,7 +4,7 @@
       "command": "node",
       "args": [
         "-e",
-        "const p=require('node:path'),fs=require('node:fs');const r=process.env.PLUGIN_ROOT||process.env.CLAUDE_PLUGIN_ROOT||process.cwd();const mjs=p.resolve(r,'server','mcp.mjs');if(!fs.existsSync(mjs)){console.error('FlowAgent MCP not found at '+mjs+'. Neither PLUGIN_ROOT nor CLAUDE_PLUGIN_ROOT is set and cwd does not contain server/mcp.mjs. Run /setup to fix.');process.exit(1);}(async()=>{try{await import(require('node:url').pathToFileURL(mjs).href)}catch(e){console.error(e);process.exit(1)}})();"
+        "const p=require('node:path'),fs=require('node:fs');const r=process.env.PLUGIN_ROOT||process.env.CLAUDE_PLUGIN_ROOT||process.cwd();const src=process.env.PLUGIN_ROOT?'PLUGIN_ROOT':process.env.CLAUDE_PLUGIN_ROOT?'CLAUDE_PLUGIN_ROOT':'cwd';const mjs=p.resolve(r,'server','mcp.mjs');if(!fs.existsSync(mjs)){console.error('FlowAgent MCP not found at '+mjs+' (resolved via '+src+'='+r+'). Run /setup to fix.');process.exit(1);}(async()=>{try{await import(require('node:url').pathToFileURL(mjs).href)}catch(e){console.error(e);process.exit(1)}})();"
       ]
     }
   }

--- a/plugins/power-automate/.mcp.json
+++ b/plugins/power-automate/.mcp.json
@@ -4,7 +4,7 @@
       "command": "node",
       "args": [
         "-e",
-        "const p=require('node:path');const r=process.env.PLUGIN_ROOT||process.env.CLAUDE_PLUGIN_ROOT;if(!r){console.error('Neither PLUGIN_ROOT nor CLAUDE_PLUGIN_ROOT is set');process.exit(1);}(async()=>{try{await import(require('node:url').pathToFileURL(p.resolve(r,'server','mcp.mjs')).href)}catch(e){console.error(e);process.exit(1)}})();"
+        "const p=require('node:path'),fs=require('node:fs');const r=process.env.PLUGIN_ROOT||process.env.CLAUDE_PLUGIN_ROOT||process.cwd();const mjs=p.resolve(r,'server','mcp.mjs');if(!fs.existsSync(mjs)){console.error('FlowAgent MCP not found at '+mjs+'. Neither PLUGIN_ROOT nor CLAUDE_PLUGIN_ROOT is set and cwd does not contain server/mcp.mjs. Run /setup to fix.');process.exit(1);}(async()=>{try{await import(require('node:url').pathToFileURL(mjs).href)}catch(e){console.error(e);process.exit(1)}})();"
       ]
     }
   }

--- a/plugins/power-automate/server/mcp.mjs
+++ b/plugins/power-automate/server/mcp.mjs
@@ -30660,6 +30660,7 @@ var FlowClient = class _FlowClient {
     const headers = {
       Authorization: `Bearer ${token}`,
       Accept: "application/json",
+      "User-Agent": "power-automate-plugin/2.0.0",
       ...extraHeaders
     };
     if (body !== void 0) {

--- a/plugins/power-automate/server/mcp.mjs
+++ b/plugins/power-automate/server/mcp.mjs
@@ -30660,8 +30660,8 @@ var FlowClient = class _FlowClient {
     const headers = {
       Authorization: `Bearer ${token}`,
       Accept: "application/json",
-      "User-Agent": "power-automate-plugin/2.0.0",
-      ...extraHeaders
+      ...extraHeaders,
+      "User-Agent": "power-automate-plugin/2.0.0"
     };
     if (body !== void 0) {
       headers["Content-Type"] = "application/json";


### PR DESCRIPTION
## Problem

Users installing the power-automate plugin via GitHub Copilot CLI get:
\\\
Failed to connect to MCP server 'flowagent': Neither PLUGIN_ROOT nor CLAUDE_PLUGIN_ROOT is set
\\\

## Root Cause

The \.mcp.json\ bootstrap requires \PLUGIN_ROOT\ or \CLAUDE_PLUGIN_ROOT\ env vars, which Claude Code sets but GitHub Copilot CLI does not always inject.

## Fix

1. **\.mcp.json\**: Falls back to \process.cwd()\ (which most hosts set to the plugin directory). Includes \s.existsSync\ check with a clear error pointing to \/setup\ if \mcp.mjs\ can't be found.

2. **\server/mcp.mjs\** (rebuilt bundle): Adds \User-Agent: power-automate-plugin/2.0.0\ header to all API requests for server-side telemetry.

## Testing

- env vars unset + cwd = plugin dir: MCP launches correctly
- env vars unset + cwd = wrong dir: clear error with /setup guidance

Source: matow_microsoft/flow-agent main (merged PR #15)