### PR TITLE
Fix Power Pages plugin MCP bootstrap

### DIFF
--- a/plugins/power-pages/.claude-plugin/plugin.json
+++ b/plugins/power-pages/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "power-pages",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Create and deploy Power Pages sites using modern development approaches. Supports code sites (SPAs) with React, Angular, Vue, or Astro. Includes ALM orchestration (plan-alm) with a solution-splitting decision tree, per-solution pipelines, Azure Blob asset advisory, manifest schema v2 for multi-solution deployments, and force-link remediation for cross-host pipeline migrations.",
   "author": {
     "name": "Microsoft",

--- a/plugins/power-pages/.mcp.json
+++ b/plugins/power-pages/.mcp.json
@@ -4,7 +4,7 @@
             "command": "node",
             "args": [
                 "-e",
-                "const path=require('node:path'); const root=process.env.PLUGIN_ROOT||process.env.CLAUDE_PLUGIN_ROOT; if(!root) throw new Error('PLUGIN_ROOT is not set'); const mod=require(path.resolve(root,'scripts','launch-playwright-mcp.js')); if(mod&&typeof mod.launch==='function') mod.launch();"
+                "const fs=require('node:fs'); const path=require('node:path'); const root=process.env.PLUGIN_ROOT||process.env.CLAUDE_PLUGIN_ROOT||process.cwd(); const entry=path.resolve(root,'scripts','launch-playwright-mcp.js'); if(!fs.existsSync(entry)) throw new Error('Could not resolve Power Pages plugin root; set PLUGIN_ROOT or launch from the plugin root'); const mod=require(entry); if(!mod||typeof mod.launch!=='function') throw new Error('Power Pages Playwright MCP launcher did not export launch()'); mod.launch();"
             ]
         },
         "microsoft-learn": {

--- a/plugins/power-pages/.plugin/plugin.json
+++ b/plugins/power-pages/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "power-pages",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Create and deploy Power Pages sites using modern development approaches. Supports code sites (SPAs) with React, Angular, Vue, or Astro. Includes ALM orchestration (plan-alm) with a solution-splitting decision tree, per-solution pipelines, Azure Blob asset advisory, manifest schema v2 for multi-solution deployments, and force-link remediation for cross-host pipeline migrations.",
   "author": {
     "name": "Microsoft",

--- a/plugins/power-pages/scripts/tests/mcp-config.test.js
+++ b/plugins/power-pages/scripts/tests/mcp-config.test.js
@@ -1,0 +1,43 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const test = require('node:test');
+
+const pluginRoot = path.resolve(__dirname, '..', '..');
+
+function createFakeNpx(dir) {
+  const commandPath = path.join(dir, process.platform === 'win32' ? 'npx.cmd' : 'npx');
+  const script = process.platform === 'win32'
+    ? '@echo off\r\necho fake-npx %*\r\n'
+    : '#!/bin/sh\necho "fake-npx $*"\n';
+
+  fs.writeFileSync(commandPath, script, { mode: 0o755 });
+  return commandPath;
+}
+
+test('playwright MCP bootstrap resolves the plugin root without host-provided env vars', (t) => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'power-pages-mcp-'));
+  t.after(() => fs.rmSync(tempDir, { recursive: true, force: true }));
+
+  createFakeNpx(tempDir);
+
+  const config = JSON.parse(fs.readFileSync(path.join(pluginRoot, '.mcp.json'), 'utf8'));
+  const server = config.mcpServers.playwright;
+  const pathSeparator = process.platform === 'win32' ? ';' : ':';
+  const result = spawnSync(server.command, server.args, {
+    cwd: pluginRoot,
+    encoding: 'utf8',
+    env: {
+      HOME: process.env.HOME,
+      PATH: `${tempDir}${pathSeparator}${process.env.PATH || ''}`,
+      USERPROFILE: process.env.USERPROFILE,
+    },
+    timeout: 5_000,
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /fake-npx/);
+  assert.doesNotMatch(result.stderr, /PLUGIN_ROOT is not set/);
+});


### PR DESCRIPTION
The Power Pages plugin MCP server was installed, but Copilot can launch plugin MCPs without setting `PLUGIN_ROOT`. That made the bundled Playwright MCP bootstrap exit before the server could initialize.

This change lets the bootstrap fall back to the plugin launch cwd, which Copilot already reports as the installed plugin root. It still fails clearly if the launcher cannot be found. The Power Pages plugin version is bumped to `2.6.1`, and the legacy manifest stays in sync.

Validation:
- `node scripts/validate-legacy-compatibility.js`
- `POWER_PLATFORM_SKILLS_TELEMETRY_POWER_PAGES_OPTOUT=1 node --test plugins/power-pages/scripts/tests/mcp-config.test.js plugins/power-pages/scripts/tests/launch-playwright-mcp.test.js`