### PR TITLE
docs(scan-code): warn about third-party tools and AI source-code review

### DIFF
--- a/plugins/power-pages/.claude-plugin/plugin.json
+++ b/plugins/power-pages/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "power-pages",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "Create and deploy Power Pages sites using modern development approaches. Supports code sites (SPAs) with React, Angular, Vue, or Astro. Includes ALM orchestration (plan-alm) with a solution-splitting decision tree, per-solution pipelines, Azure Blob asset advisory, manifest schema v2 for multi-solution deployments, and force-link remediation for cross-host pipeline migrations.",
   "author": {
     "name": "Microsoft",

--- a/plugins/power-pages/.plugin/plugin.json
+++ b/plugins/power-pages/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "power-pages",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "Create and deploy Power Pages sites using modern development approaches. Supports code sites (SPAs) with React, Angular, Vue, or Astro. Includes ALM orchestration (plan-alm) with a solution-splitting decision tree, per-solution pipelines, Azure Blob asset advisory, manifest schema v2 for multi-solution deployments, and force-link remediation for cross-host pipeline migrations.",
   "author": {
     "name": "Microsoft",

--- a/plugins/power-pages/skills/scan-code/SKILL.md
+++ b/plugins/power-pages/skills/scan-code/SKILL.md
@@ -23,6 +23,8 @@ Scan a Power Pages site project's source files and dependencies for security iss
 
 **Initial request:** $ARGUMENTS
 
+> **WARNING:** Before proceeding, inform the user: "This scan runs **third-party open-source security tools** against your source code and dependencies. If those tools aren't installed and you opt into the fallback review, the **AI model reads your source code directly**. **Do not proceed with sensitive information** — such as credentials, internal URLs, tenant IDs, customer data, or proprietary code — that you're not comfortable exposing to third-party tools or an AI model."
+
 ## Gotchas
 
 - **Both tools must be installed.** Run `check-tools.js` to verify. If either is missing, offer an agent-driven review fallback (see Step 1.2).

--- a/plugins/power-pages/skills/scan-code/SKILL.md
+++ b/plugins/power-pages/skills/scan-code/SKILL.md
@@ -23,7 +23,7 @@ Scan a Power Pages site project's source files and dependencies for security iss
 
 **Initial request:** $ARGUMENTS
 
-> **WARNING:** Before proceeding, inform the user: "This scan runs **third-party open-source security tools** against your source code and dependencies. If those tools aren't installed and you opt into the fallback review, the **AI model reads your source code directly**. **Do not proceed with sensitive information** — such as credentials, internal URLs, tenant IDs, customer data, or proprietary code — that you're not comfortable exposing to third-party tools or an AI model."
+> **WARNING:** Before proceeding, inform the user: "This skill uses **opengrep** and **trivy**, only if they are installed on your local machine. These third-party, open-source tools scan your source code and dependencies and might collect or transmit data under their own terms, privacy policies, and data-handling practices. Microsoft does not control these. If you select the AI fallback, the AI service processes your source code. Review your organization's policies and applicable third-party terms before continuing."
 
 ## Gotchas
 


### PR DESCRIPTION
## What & why

The `scan-code` skill runs **third-party open-source security tools** against the user''s source code and dependencies, and — when those tools aren''t installed — falls back to an **agent-driven review that reads source code with the AI model**. Neither behavior was surfaced to the user before the scan started.

This adds a top-of-skill `> **WARNING:**` block, mirroring the `report-issue` skill.

## Changes

- `plugins/power-pages/skills/scan-code/SKILL.md` — add a warning covering (a) use of third-party tools and (b) the agent-driven review sending source code to the AI model.
- Bump `power-pages` plugin version **2.6.1 → 2.6.2** in both `.plugin/plugin.json` (Open Plugins) and the legacy `.claude-plugin/plugin.json` mirror.

## Validation

- `node scripts/validate-legacy-compatibility.js` → "in sync" ✓
- `node plugins/power-pages/scripts/lint-skills-alm.js` → 0 findings ✓ (the blockquote is not a gate, so gate lint is unaffected)
