### PR TITLE
docs(mobile-app): simplify Wrap app registration

### DIFF
--- a/plugins/mobile-apps/README.md
+++ b/plugins/mobile-apps/README.md
@@ -65,32 +65,25 @@ connector wiring.
     When prompted to sign in, use credentials for the tenant where the Dataverse
     environment belongs.
 
-4. Create a Microsoft Entra app registration and grant admin consent.
+4. Create the Microsoft Entra app registration from Power Apps Wrap.
 
-    Create a native/public client app registration for the mobile app, then add
-    the following redirect URIs:
+    Open the app-registration page for the Power Platform environment selected
+    during `/create-mobile-app`:
 
     ```text
-    https://login.microsoftonline.com/common/oauth2/nativeclient
-    msauth.com.microsoft.PreviewApp://auth
+    https://make.powerapps.com/environments/<environment-id>/wraps#create-app-registration
     ```
 
-    Add these API permissions as **Delegated** permissions, then grant admin
-    consent for the tenant:
+    Create the registration on that page, copy its **Application (client) ID**,
+    and paste it when `/create-mobile-app` asks. The Wrap experience configures
+    the native app registration for this flow. You do not need to add redirect
+    URIs or API permissions manually, and tenant-wide admin consent is not
+    required.
 
-    - Azure API Connections
-        - `Runtime.All`
-    - Dynamics CRM
-        - `user_impersonation`
-    - Microsoft Graph
-        - `User.Read`
-    - Power Platform API
-        - `Connectivity.Connections.Read`
-        - `Connectivity.Connections.Write`
-        - `Connectivity.Connectors.Read`
-        - `PowerApps.Apps.Read`
-    - PowerApps Service
-        - `User`
+    If the app was created without a client ID, run
+    `/set-app-registration-native` later from the app folder. It opens the same
+    environment-specific page and writes the pasted client ID to
+    `auth.config.json`.
 
 5. Start mobile app:
 

--- a/plugins/mobile-apps/skills/create-mobile-app/SKILL.md
+++ b/plugins/mobile-apps/skills/create-mobile-app/SKILL.md
@@ -1124,7 +1124,7 @@ Jump to Step 8.
 Resolve the selected Power Platform environment ID from `$ACTIVE_ENV_ID`, then `power.config.json`. Print the public Power Apps Wrap URL:
 
 > "Open the Power Apps Wrap app-registration page for the selected environment:
-> https://make.powerapps.com/environments/<environment-id>/wraps#create-app-registration
+> `https://make.powerapps.com/environments/<environment-id>/wraps#create-app-registration`
 >
 > Create the app registration on that page, then copy the Application (client) ID and paste it here.
 > The Wrap experience configures the native registration for this flow. Do not add redirect URIs or API permissions manually; tenant-wide admin consent is not required.

--- a/plugins/mobile-apps/skills/create-mobile-app/SKILL.md
+++ b/plugins/mobile-apps/skills/create-mobile-app/SKILL.md
@@ -1097,7 +1097,7 @@ Ask one question, using the resolved tenant:
 Do not default to any option silently. The user must choose because app registration ownership varies by tenant/admin role.
 
 - **(a) Paste existing** — run the client-ID write path in 7.3.
-- **(b) Create new manually** — print the portal URL and checklist in 7.4, then ask for the client ID and run 7.3. If the user cannot finish creation, allow `skip` and follow 7.5.
+- **(b) Create new in Power Apps Wrap** — print the environment-specific Wrap URL in 7.4, then ask for the client ID and run 7.3. If the user cannot finish creation, allow `skip` and follow 7.5.
 - **(c) Skip** — run the skip path in 7.5.
 
 #### 7.3 Write client ID into `auth.config.json`
@@ -1119,17 +1119,18 @@ Print:
 
 Jump to Step 8.
 
-#### 7.4 Create a new app registration manually
+#### 7.4 Create a new app registration in Power Apps Wrap
 
 Resolve the selected Power Platform environment ID from `$ACTIVE_ENV_ID`, then `power.config.json`. Print the public Power Apps Wrap URL:
 
 > "Open the Power Apps Wrap app-registration page for the selected environment:
 > https://make.powerapps.com/environments/<environment-id>/wraps#create-app-registration
 >
-> Create/register the app, then copy the Application (client) ID and paste it here.
+> Create the app registration on that page, then copy the Application (client) ID and paste it here.
+> The Wrap experience configures the native registration for this flow. Do not add redirect URIs or API permissions manually; tenant-wide admin consent is not required.
 > If you cannot create it now, type `skip` and run `/set-app-registration-native` later."
 
-Tell the user the registration must be created/configured from the Power Apps Wrap page for the selected environment.
+Tell the user the registration must be created/configured from the Power Apps Wrap page for the selected environment. Do not direct them to the Entra admin center for manual redirect URI, delegated permission, or admin-consent setup.
 
 After the user creates the registration, run 7.3 to capture and write the client ID.
 

--- a/plugins/mobile-apps/skills/set-app-registration-native/SKILL.md
+++ b/plugins/mobile-apps/skills/set-app-registration-native/SKILL.md
@@ -14,7 +14,10 @@ Wire `auth.config.json` to an Entra ID app registration for a Power Apps Wrap mo
 
 This skill is manual by design:
 - Do **not** create or patch app registrations from this skill.
-- Use the public Power Apps Wrap app-registration page and then write the pasted client ID into `auth.config.json`.
+- Use the public Power Apps Wrap app-registration page to create/configure the
+  registration, then write the pasted client ID into `auth.config.json`.
+- Do not direct the user to add redirect URIs or API permissions manually.
+  Tenant-wide admin consent is not required for this Wrap registration flow.
 
 ## Workflow
 
@@ -69,6 +72,8 @@ Open the Power Apps Wrap app-registration page for this environment:
 https://make.powerapps.com/environments/<environment-id>/wraps#create-app-registration
 
 Create/register the app there, then paste the Application (client) ID here.
+The Wrap page configures the native registration. Do not add redirect URIs or
+API permissions manually; tenant-wide admin consent is not required.
 If you already have a client ID, paste it directly.
 If you cannot configure auth now, type skip.
 ```

--- a/plugins/mobile-apps/template/README.md
+++ b/plugins/mobile-apps/template/README.md
@@ -65,32 +65,25 @@ connector wiring.
 	When prompted to sign in, use credentials for the tenant where the Dataverse
 	environment belongs.
 
-4. Create a Microsoft Entra app registration and grant admin consent. (simplified experience coming soon)
+4. Create the Microsoft Entra app registration from Power Apps Wrap.
 
-	Create a native/public client app registration for the mobile app, then add
-	the following redirect URIs:
+	Open the app-registration page for the Power Platform environment selected
+	during `/create-mobile-app`:
 
 	```text
-	https://login.microsoftonline.com/common/oauth2/nativeclient
-	msauth.com.microsoft.PreviewApp://auth
+	https://make.powerapps.com/environments/<environment-id>/wraps#create-app-registration
 	```
 
-	Add these API permissions as **Delegated** permissions, then grant admin
-	consent for the tenant:
+	Create the registration on that page, copy its **Application (client) ID**,
+	and paste it when `/create-mobile-app` asks. The Wrap experience configures
+	the native app registration for this flow. You do not need to add redirect
+	URIs or API permissions manually, and tenant-wide admin consent is not
+	required.
 
-	- Azure API Connections
-		- `Runtime.All`
-	- Dynamics CRM
-		- `user_impersonation`
-	- Microsoft Graph
-		- `User.Read`
-	- Power Platform API
-		- `Connectivity.Connections.Read`
-		- `Connectivity.Connections.Write`
-		- `Connectivity.Connectors.Read`
-		- `PowerApps.Apps.Read`
-	- PowerApps Service
-		- `User`
+	If the app was created without a client ID, run
+	`/set-app-registration-native` later from the app folder. It opens the same
+	environment-specific page and writes the pasted client ID to
+	`auth.config.json`.
 
 5. Start mobile app:
 


### PR DESCRIPTION
## Summary

Update the mobile-app onboarding and auth skills to use the environment-specific Power Apps Wrap app-registration page as the primary Entra registration path.

The previous READMEs instructed users to manually create a native/public client registration, add redirect URIs, add a long list of delegated permissions, and grant tenant-wide admin consent. That guidance no longer matches the simplified Wrap registration experience.

## What changed

- Replaced the manual Entra registration/permission checklist with:

  ```text
  https://make.powerapps.com/environments/<environment-id>/wraps#create-app-registration
  ```

- Clarified that users create/configure the registration on the Wrap page, copy the **Application (client) ID**, and paste it into `/create-mobile-app`.
- Explicitly state that users should not manually add redirect URIs or API permissions for this flow.
- Explicitly state that tenant-wide admin consent is not required.
- Point users who skipped auth during creation to `/set-app-registration-native`, which opens the same environment-specific page and writes the client ID into `auth.config.json`.
- Aligned `/create-mobile-app` Step 7.4 and `/set-app-registration-native` with the same wording, preventing the skills from sending users back to the Entra admin center for obsolete manual setup.

## Files updated

- `plugins/mobile-apps/README.md`
- `plugins/mobile-apps/template/README.md`
- `plugins/mobile-apps/skills/create-mobile-app/SKILL.md`
- `plugins/mobile-apps/skills/set-app-registration-native/SKILL.md`

## Why

The old setup had unnecessary friction and implied an administrator was required before a maker could run the app. It also duplicated configuration that the Power Apps Wrap registration experience now owns.

Using the Wrap page keeps registration creation scoped to the selected Power Platform environment, reduces setup mistakes, and matches the behavior already implemented by the mobile auth skills.

## User experience after this change

1. Run `/create-mobile-app` and select the target environment.
2. Choose **Create a new app registration from Power Apps Wrap**.
3. Open the environment-specific URL shown by the skill.
4. Create the registration and copy its Application client ID.
5. Paste the client ID into the skill.
6. The skill writes `msal.clientId` and the resolved tenant into `auth.config.json`.

No manual redirect URI/API permission checklist and no tenant-wide admin-consent step are presented.

## Validation

- `git diff --check`
- `node scripts/validate-skill-descriptions.js`
- searched the mobile plugin for the removed permission names and old admin-consent instructions
- VS Code reports no diagnostics in the four changed files
