### PR TITLE
power-pages: bump to 2.6.3

### DIFF
--- a/plugins/power-pages/.claude-plugin/plugin.json
+++ b/plugins/power-pages/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "power-pages",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "description": "Create and deploy Power Pages sites using modern development approaches. Supports code sites (SPAs) with React, Angular, Vue, or Astro. Includes ALM orchestration (plan-alm) with a solution-splitting decision tree, per-solution pipelines, Azure Blob asset advisory, manifest schema v2 for multi-solution deployments, and force-link remediation for cross-host pipeline migrations.",
   "author": {
     "name": "Microsoft",

--- a/plugins/power-pages/.plugin/plugin.json
+++ b/plugins/power-pages/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "power-pages",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "description": "Create and deploy Power Pages sites using modern development approaches. Supports code sites (SPAs) with React, Angular, Vue, or Astro. Includes ALM orchestration (plan-alm) with a solution-splitting decision tree, per-solution pipelines, Azure Blob asset advisory, manifest schema v2 for multi-solution deployments, and force-link remediation for cross-host pipeline migrations.",
   "author": {
     "name": "Microsoft",

--- a/plugins/power-pages/skills/setup-auth/references/idp-provisioning-reference.md
+++ b/plugins/power-pages/skills/setup-auth/references/idp-provisioning-reference.md
@@ -26,7 +26,7 @@ Everything Power Pages needs downstream (Authority, MetadataAddress, ClientId) i
 
 ## Client secret: code id_token is the default
 
-Power Pages' default OIDC response type is **`code id_token`**: the ID token returns on the front channel, so the app is a **Web application** that needs **no client secret**. A confidential-client app with a client secret is equally valid and secure — the only tradeoff is storing and rotating the secret (Phase 8.1.1 Key Vault).
+Power Pages' default OIDC response type is **`code id_token`**: the ID token returns on the front channel, so the app is a **Web application** that needs **no client secret**.
 
 **Default to `code id_token`; configure a client secret only when the user prefers a confidential client.**
 


### PR DESCRIPTION
## What

Small follow-up to #252 (already merged):

- **Neutralize client-secret wording** in `idp-provisioning-reference.md` — drop the "equally valid and secure … only tradeoff is storing and rotating the secret" sentence per @srinidhivkms review feedback. The line now just states the `code id_token` default.
- **Bump plugin version** `2.6.2 → 2.6.3` in both `.plugin/plugin.json` and the `.claude-plugin/plugin.json` legacy mirror.

## Why

The reviewer asked to remove the editorializing about the client secret being "valid and secure". #252 was already merged before this last tweak landed, so it needs its own PR.

## Validation

- `node scripts/validate-legacy-compatibility.js` → in sync.
- Docs/metadata only — no scripts touched.