### PR TITLE
fix(mobile-apps): clean up sample data skill metadata

### DIFF
--- a/plugins/mobile-apps/skills/add-sample-data/SKILL.md
+++ b/plugins/mobile-apps/skills/add-sample-data/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: add-sample-data
 description: Use when the user wants to seed Dataverse tables with realistic sample records so a freshly-scaffolded code app shows real-looking data on first launch. Generates contextually appropriate rows from each table's schema and inserts them in dependency order. Mirrors microsoft/power-platform-skills/power-pages/add-sample-data, adapted for mobile apps.
-pps.
 user-invocable: true
 allowed-tools: Read, Edit, Write, Grep, Glob, Bash, AskUserQuestion
 model: sonnet
@@ -18,7 +17,7 @@ Populate Dataverse tables with realistic sample records so a freshly-scaffolded 
 - **Coverage over volume — every table in the manifest gets seeded.** The #1 failure mode of a freshly-scaffolded code app is a home / dashboard / list screen that renders an empty state on first launch because its source table has zero rows. An empty downstream table is **worse than a 3-row table.** Default to minimal-but-complete: small counts everywhere, no table left empty. Volume is a secondary knob — coverage is the contract.
 - **Insertion order matters.** Parent / referenced tables must be inserted before child / referencing tables so lookup IDs are available.
 - **Contextual data, not Lorem Ipsum.** Generate values that match column names + types. A `cr3e9_sitename` column in an inspection app gets "Westside Construction Site", not "Sample Name 1".
-- **Scenario-aware rows.** Read `native-app-plan.md` and, when present, `### Shared Conventions` / `Scenario archetype` from [power-apps-scenario-archetypes.md](${CLAUDE_SKILL_DIR}/../../shared/references/power-apps-scenario-archetypes.md). Seed rows should exercise the app's actual workflow: statuses, dates, relationships, priority/severity, media metadata, and edge cases that make the planned first viewport light up.
+- **Scenario-aware rows.** Read `native-app-plan.md`, especially `### Shared Conventions` and per-screen `Operational pattern` values defined in [screen-templates.md](${CLAUDE_SKILL_DIR}/../../shared/references/screen-templates.md). Seed rows should exercise the app's actual workflow: statuses, dates, relationships, priority/severity, media metadata, and edge cases that make the planned first viewport light up.
 - **Fail gracefully.** On insertion failure, log the error and continue with remaining records — never auto-rollback. The user can re-run after fixing the issue.
 - **Idempotent re-runs.** If a previous run partially completed, the second run reads `memory-bank.md`'s seeded-data table and skips records already inserted.
 - **Solution-scoped inserts.** Always pass `--solution <uniqueName>` so records land in our solution, not the default.


### PR DESCRIPTION
## Summary

- remove the stray `pps.` line from the `add-sample-data` YAML frontmatter
- replace the nonexistent `power-apps-scenario-archetypes.md` reference with the current `screen-templates.md` operational-pattern contract
- preserve scenario-aware sample-data generation using `Shared Conventions` and per-screen `Operational pattern` values

## Why

The stray frontmatter text could prevent reliable skill discovery, and the stale reference pointed to a file that does not exist in the mobile-app plugin.

## Validation

- parsed `add-sample-data` frontmatter successfully
- verified `shared/references/screen-templates.md` exists
- `node scripts/validate-skill-descriptions.js`
- `node scripts/validate-keyword-case.js`
- `node scripts/validate-plugin-names.js`
- `node scripts/validate-legacy-compatibility.js`
- `git diff --check`