### PR TITLE
Add Codex plugin packaging

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,92 @@
+{
+  "name": "power-platform-skills",
+  "interface": {
+    "displayName": "Power Platform Skills"
+  },
+  "plugins": [
+    {
+      "name": "power-pages",
+      "source": {
+        "source": "local",
+        "path": "./plugins/power-pages"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    },
+    {
+      "name": "model-apps",
+      "source": {
+        "source": "local",
+        "path": "./plugins/model-apps"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    },
+    {
+      "name": "mcp-apps",
+      "source": {
+        "source": "local",
+        "path": "./plugins/mcp-apps"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    },
+    {
+      "name": "canvas-apps",
+      "source": {
+        "source": "local",
+        "path": "./plugins/canvas-apps"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    },
+    {
+      "name": "code-apps",
+      "source": {
+        "source": "local",
+        "path": "./plugins/code-apps"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    },
+    {
+      "name": "mobile-apps",
+      "source": {
+        "source": "local",
+        "path": "./plugins/mobile-apps"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    },
+    {
+      "name": "power-automate",
+      "source": {
+        "source": "local",
+        "path": "./plugins/power-automate"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    }
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,10 +11,15 @@ A **plugin marketplace** for Power Platform development by Microsoft. The Open P
 ```
 power-platform-skills/
 ├── marketplace.json          # Open Plugins marketplace manifest (lists all available plugins)
+├── .agents/
+│   └── plugins/
+│       └── marketplace.json  # Repository-local Codex marketplace
 ├── .claude-plugin/           # Legacy manifest mirrors for existing subscriptions
 │   └── marketplace.json
 ├── plugins/                  # Directory containing individual plugins
 │   └── <plugin-name>/        # Individual plugin (e.g., power-pages)
+│       ├── .codex-plugin/
+│       │   └── plugin.json   # Codex plugin manifest
 │       ├── .plugin/
 │       │   └── plugin.json   # Plugin manifest
 │       ├── .claude-plugin/
@@ -45,6 +50,7 @@ No root-level build, lint, or test commands exist. Build/test tooling lives insi
 
 Each plugin follows this structure:
 
+- `.codex-plugin/plugin.json` — Codex metadata and interface configuration
 - `.plugin/plugin.json` — Open Plugins metadata (name, version, keywords)
 - `.claude-plugin/plugin.json` — legacy mirror of `.plugin/plugin.json` kept for existing subscriptions
 - `.mcp.json` — MCP server configuration (optional)
@@ -52,6 +58,27 @@ Each plugin follows this structure:
 - `skills/` — Skill definitions, each in its own subdirectory with a `SKILL.md`
 - `scripts/` — Shared utility scripts referenced by skills and agents
 - `references/` — Shared reference documents used by multiple skills
+
+## Codex Compatibility
+
+Keep Codex packaging additive so existing Claude Code and GitHub Copilot
+consumers continue to work:
+
+- Put Codex package metadata in `.codex-plugin/plugin.json`; do not replace the
+  `.plugin` or `.claude-plugin` manifests.
+- Keep the Codex manifest name equal to the plugin folder name. This means the
+  Codex package names are `code-apps` and `mobile-apps`, while the legacy
+  marketplaces retain `code-apps-preview` and `mobile-app`.
+- Reuse the existing `skills/`, hooks, scripts, references, and `.mcp.json`
+  where the Codex schema accepts them.
+- When a shared companion file contains host-specific fields that Codex rejects,
+  declare the equivalent Codex configuration inline in `.codex-plugin/plugin.json`
+  instead of weakening the legacy file.
+- Add every plugin to `.agents/plugins/marketplace.json` with an `AVAILABLE`
+  installation policy, `ON_INSTALL` authentication policy, and a local source
+  matching `./plugins/<folder-name>`.
+- Run `node scripts/validate-codex-plugins.js` and the plugin-creator validator
+  after changing Codex manifests or marketplace metadata.
 
 Skills are defined in `SKILL.md` files with YAML frontmatter (name, description, allowed-tools, model, hooks). The `allowed-tools` field must use a **comma-separated list** (e.g., `allowed-tools: Read, Write, Edit, Bash, Glob, Grep`) — not JSON array syntax (`["Read", "Write"]`) or YAML list syntax. Each skill may include validation scripts in a `scripts/` subdirectory, run as Stop hooks when the skill session ends.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Official agent skills/plugins for Power Platform development by Microsoft.
 
 ## Overview
 
-This repository is a **plugin marketplace** containing Claude Code/GitHub Copilot plugins for Power Platform services. Each plugin provides skills, agents, and commands to help developers build on the Power Platform.
+This repository is a **plugin marketplace** containing Codex, Claude Code, and GitHub Copilot plugins for Power Platform services. Each plugin provides skills, agents, and commands to help developers build on the Power Platform.
 
 ## Installation
 
@@ -30,6 +30,22 @@ The installer automatically:
 - Detects available tools (Claude Code, GitHub Copilot CLI)
 - Registers the plugin marketplace and installs all listed plugins
 - Enables auto-update so plugins stay current
+
+### Codex
+
+The repository includes a local Codex marketplace for testing the converted
+plugins. From the repository root:
+
+```bash
+codex plugin marketplace add .agents/plugins
+codex plugin add power-pages@power-platform-skills
+```
+
+Available Codex package names are `power-pages`, `model-apps`, `mcp-apps`,
+`canvas-apps`, `code-apps`, `mobile-apps`, and `power-automate`.
+
+Start a new Codex task after installing or updating a plugin so its skills and
+MCP tools are loaded.
 
 ### Manual Installation
 
@@ -113,6 +129,12 @@ To develop and test plugins locally, follow these steps:
     claude --plugin-dir /path/to/power-platform-skills/plugins/canvas-apps
     claude --plugin-dir /path/to/power-platform-skills/plugins/power-automate
     ```
+
+Validate the Codex packaging layer:
+
+```bash
+node scripts/validate-codex-plugins.js
+```
 
 ## Running Without Interruption
 
@@ -238,6 +260,13 @@ plugin entry is intentionally just `name` plus repository-root-relative `source`
 Plugin descriptions, versions, licenses, and keywords are controlled from each
 plugin's `.plugin/plugin.json`. This keeps existing subscriptions updating without
 duplicating display/update metadata.
+
+Codex manifests live in each plugin's `.codex-plugin/plugin.json`. They reuse
+the existing `skills/`, scripts, references, hooks, and MCP definitions while
+providing Codex-specific package and interface metadata. The Codex names for
+Code Apps and Mobile Apps match their folder names (`code-apps` and
+`mobile-apps`); the legacy marketplaces retain `code-apps-preview` and
+`mobile-app`.
 
 ## Documentation
 

--- a/plugins/canvas-apps/.codex-plugin/plugin.json
+++ b/plugins/canvas-apps/.codex-plugin/plugin.json
@@ -1,0 +1,33 @@
+{
+  "name": "canvas-apps",
+  "version": "2.1.1",
+  "description": "Build Power Apps Canvas Apps using the Canvas Authoring MCP server.",
+  "author": {
+    "name": "Microsoft",
+    "url": "https://www.microsoft.com"
+  },
+  "homepage": "https://github.com/microsoft/power-platform-skills/",
+  "repository": "https://github.com/microsoft/power-platform-skills/",
+  "license": "MIT",
+  "keywords": [
+    "canvas-apps",
+    "power-apps",
+    "canvas",
+    "pa-yaml",
+    "msapp"
+  ],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "Canvas Apps",
+    "shortDescription": "Build Power Apps canvas apps with Codex.",
+    "longDescription": "Author, validate, and compile Power Apps Canvas App YAML through the Canvas Authoring MCP server.",
+    "developerName": "Microsoft",
+    "category": "Developer Tools",
+    "capabilities": [
+      "Interactive",
+      "Write"
+    ],
+    "defaultPrompt": "Build or update a Power Apps canvas app."
+  }
+}

--- a/plugins/code-apps/.codex-plugin/plugin.json
+++ b/plugins/code-apps/.codex-plugin/plugin.json
@@ -1,0 +1,35 @@
+{
+  "name": "code-apps",
+  "version": "1.0.0",
+  "description": "Build and deploy Power Apps code apps using React, Vite, and Power Platform connectors.",
+  "author": {
+    "name": "Microsoft",
+    "url": "https://www.microsoft.com"
+  },
+  "homepage": "https://github.com/microsoft/power-platform-skills/",
+  "repository": "https://github.com/microsoft/power-platform-skills/",
+  "license": "MIT",
+  "keywords": [
+    "power-apps",
+    "code-apps",
+    "react",
+    "vite",
+    "dataverse",
+    "connectors",
+    "pac-cli",
+    "power-platform"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Power Apps Code Apps",
+    "shortDescription": "Build Power Apps code apps with Codex.",
+    "longDescription": "Create and deploy React, Vite, and TypeScript code apps connected through supported Power Platform connectors.",
+    "developerName": "Microsoft",
+    "category": "Developer Tools",
+    "capabilities": [
+      "Interactive",
+      "Write"
+    ],
+    "defaultPrompt": "Create or update a Power Apps code app."
+  }
+}

--- a/plugins/mcp-apps/.codex-plugin/plugin.json
+++ b/plugins/mcp-apps/.codex-plugin/plugin.json
@@ -1,0 +1,34 @@
+{
+  "name": "mcp-apps",
+  "version": "1.0.0",
+  "description": "Generate MCP App widgets for MCP tools using the MCP Apps protocol.",
+  "author": {
+    "name": "Microsoft",
+    "url": "https://www.microsoft.com"
+  },
+  "homepage": "https://github.com/microsoft/power-platform-skills/",
+  "repository": "https://github.com/microsoft/power-platform-skills/",
+  "license": "MIT",
+  "keywords": [
+    "mcp-apps",
+    "mcp",
+    "widget",
+    "ext-apps",
+    "fluent-ui",
+    "html",
+    "tool-visualization"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "MCP Apps",
+    "shortDescription": "Generate interactive MCP App widgets.",
+    "longDescription": "Create self-contained HTML widgets for MCP tools using the MCP Apps protocol and Fluent UI patterns.",
+    "developerName": "Microsoft",
+    "category": "Developer Tools",
+    "capabilities": [
+      "Interactive",
+      "Write"
+    ],
+    "defaultPrompt": "Generate an MCP App widget for my MCP tool."
+  }
+}

--- a/plugins/mobile-apps/.codex-plugin/plugin.json
+++ b/plugins/mobile-apps/.codex-plugin/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "mobile-apps",
+  "version": "0.1.0",
+  "description": "Build and deploy Power Apps code apps for mobile using Expo and React Native.",
+  "author": {
+    "name": "Microsoft",
+    "url": "https://www.microsoft.com"
+  },
+  "homepage": "https://github.com/microsoft/power-platform-skills/",
+  "repository": "https://github.com/microsoft/power-platform-skills/",
+  "license": "MIT",
+  "keywords": [
+    "power-platform",
+    "power-apps",
+    "code-apps",
+    "mobile",
+    "expo",
+    "react-native",
+    "native",
+    "connectors",
+    "microsoft"
+  ],
+  "skills": "./skills/",
+  "mcpServers": {
+    "microsoft-learn": {
+      "type": "http",
+      "url": "https://learn.microsoft.com/api/mcp"
+    }
+  },
+  "interface": {
+    "displayName": "Power Apps Mobile Apps",
+    "shortDescription": "Build native Power Apps with Expo.",
+    "longDescription": "Create mobile Power Apps code apps with Expo, React Native, native device capabilities, and Power Platform connectors.",
+    "developerName": "Microsoft",
+    "category": "Developer Tools",
+    "capabilities": [
+      "Interactive",
+      "Write"
+    ],
+    "defaultPrompt": "Create or update a Power Apps mobile app."
+  }
+}

--- a/plugins/mobile-apps/skills/add-sample-data/SKILL.md
+++ b/plugins/mobile-apps/skills/add-sample-data/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: add-sample-data
 description: Use when the user wants to seed Dataverse tables with realistic sample records so a freshly-scaffolded code app shows real-looking data on first launch. Generates contextually appropriate rows from each table's schema and inserts them in dependency order. Mirrors microsoft/power-platform-skills/power-pages/add-sample-data, adapted for mobile apps.
-pps.
 user-invocable: true
 allowed-tools: Read, Edit, Write, Grep, Glob, Bash, AskUserQuestion
 model: sonnet

--- a/plugins/model-apps/.codex-plugin/plugin.json
+++ b/plugins/model-apps/.codex-plugin/plugin.json
@@ -1,0 +1,37 @@
+{
+  "name": "model-apps",
+  "version": "2.2.0",
+  "description": "Build and deploy Power Apps generative pages for model-driven apps.",
+  "author": {
+    "name": "Microsoft",
+    "url": "https://www.microsoft.com"
+  },
+  "homepage": "https://github.com/microsoft/power-platform-skills/",
+  "repository": "https://github.com/microsoft/power-platform-skills/",
+  "license": "MIT",
+  "keywords": [
+    "model-apps",
+    "generative-pages",
+    "genux",
+    "genpage",
+    "react",
+    "fluent-ui",
+    "dataverse",
+    "pac-cli",
+    "model-driven"
+  ],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "Model Apps",
+    "shortDescription": "Build generative pages for model-driven apps.",
+    "longDescription": "Plan, build, and deploy React and Fluent UI generative pages for Power Apps model-driven applications.",
+    "developerName": "Microsoft",
+    "category": "Developer Tools",
+    "capabilities": [
+      "Interactive",
+      "Write"
+    ],
+    "defaultPrompt": "Create or update a generative page for a model-driven app."
+  }
+}

--- a/plugins/power-automate/.codex-plugin/plugin.json
+++ b/plugins/power-automate/.codex-plugin/plugin.json
@@ -1,0 +1,34 @@
+{
+  "name": "power-automate",
+  "version": "2.1.0",
+  "description": "Build, edit, run, and debug Power Automate cloud flows via the FlowAgent MCP server.",
+  "author": {
+    "name": "Microsoft",
+    "url": "https://www.microsoft.com"
+  },
+  "homepage": "https://github.com/microsoft/power-platform-skills/",
+  "repository": "https://github.com/microsoft/power-platform-skills/",
+  "license": "MIT",
+  "keywords": [
+    "power-automate",
+    "cloud-flows",
+    "flows",
+    "mcp",
+    "power-platform",
+    "flowagent"
+  ],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "Power Automate",
+    "shortDescription": "Build and debug Power Automate flows.",
+    "longDescription": "Create, edit, run, diagnose, and copy Power Automate cloud flows through the FlowAgent MCP server.",
+    "developerName": "Microsoft",
+    "category": "Developer Tools",
+    "capabilities": [
+      "Interactive",
+      "Write"
+    ],
+    "defaultPrompt": "Create, update, or diagnose a Power Automate flow."
+  }
+}

--- a/plugins/power-pages/.codex-plugin/plugin.json
+++ b/plugins/power-pages/.codex-plugin/plugin.json
@@ -1,0 +1,38 @@
+{
+  "name": "power-pages",
+  "version": "2.6.3",
+  "description": "Create and deploy Power Pages code sites and manage their application lifecycle.",
+  "author": {
+    "name": "Microsoft",
+    "url": "https://www.microsoft.com"
+  },
+  "homepage": "https://github.com/microsoft/power-platform-skills/",
+  "repository": "https://github.com/microsoft/power-platform-skills/",
+  "license": "MIT",
+  "keywords": [
+    "power-pages",
+    "site-builder",
+    "code-sites",
+    "spa",
+    "pac-cli",
+    "dataverse",
+    "web-api",
+    "solution",
+    "alm",
+    "pipeline"
+  ],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "Power Pages",
+    "shortDescription": "Build and manage Power Pages code sites.",
+    "longDescription": "Create, secure, integrate, test, and deploy Power Pages code sites with Dataverse and enterprise ALM workflows.",
+    "developerName": "Microsoft",
+    "category": "Developer Tools",
+    "capabilities": [
+      "Interactive",
+      "Write"
+    ],
+    "defaultPrompt": "Create or update a Power Pages code site."
+  }
+}

--- a/scripts/validate-codex-plugins.js
+++ b/scripts/validate-codex-plugins.js
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+
+/**
+ * Validate the repository's Codex packaging layer.
+ *
+ * The Claude/Open Plugins manifests intentionally remain separate because two
+ * legacy package names do not match their folder names. Codex requires the
+ * `.codex-plugin/plugin.json` name to match the package folder, so this validator
+ * checks the Codex contract directly instead of treating it as another mirror.
+ */
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const repoRoot = path.resolve(__dirname, "..");
+const pluginsRoot = path.join(repoRoot, "plugins");
+const marketplacePath = path.join(repoRoot, ".agents", "plugins", "marketplace.json");
+const errors = [];
+
+function readJson(filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, "utf8"));
+  } catch (error) {
+    errors.push(`${path.relative(repoRoot, filePath)}: ${error.message}`);
+    return null;
+  }
+}
+
+function requireString(value, field, filePath) {
+  if (typeof value !== "string" || value.trim() === "") {
+    errors.push(`${path.relative(repoRoot, filePath)}: ${field} must be a non-empty string`);
+  }
+}
+
+const pluginFolders = fs
+  .readdirSync(pluginsRoot, { withFileTypes: true })
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => entry.name)
+  .sort();
+
+const marketplace = readJson(marketplacePath);
+const marketplaceEntries = new Map();
+
+if (marketplace) {
+  requireString(marketplace.name, "name", marketplacePath);
+  if (!Array.isArray(marketplace.plugins)) {
+    errors.push(`${path.relative(repoRoot, marketplacePath)}: plugins must be an array`);
+  } else {
+    for (const entry of marketplace.plugins) {
+      if (!entry || typeof entry !== "object" || typeof entry.name !== "string") {
+        errors.push(`${path.relative(repoRoot, marketplacePath)}: every plugin entry needs a name`);
+        continue;
+      }
+      marketplaceEntries.set(entry.name, entry);
+    }
+  }
+}
+
+for (const folderName of pluginFolders) {
+  const pluginRoot = path.join(pluginsRoot, folderName);
+  const manifestPath = path.join(pluginRoot, ".codex-plugin", "plugin.json");
+  const manifest = readJson(manifestPath);
+
+  if (!manifest) {
+    continue;
+  }
+
+  if (manifest.name !== folderName) {
+    errors.push(
+      `${path.relative(repoRoot, manifestPath)}: name must match folder '${folderName}'`
+    );
+  }
+  if (
+    typeof manifest.version !== "string" ||
+    !/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(manifest.version)
+  ) {
+    errors.push(`${path.relative(repoRoot, manifestPath)}: version must use semantic versioning`);
+  }
+  requireString(manifest.description, "description", manifestPath);
+  requireString(manifest.author?.name, "author.name", manifestPath);
+
+  if (manifest.skills !== "./skills/" || !fs.existsSync(path.join(pluginRoot, "skills"))) {
+    errors.push(
+      `${path.relative(repoRoot, manifestPath)}: skills must point to the existing './skills/' folder`
+    );
+  }
+
+  if (typeof manifest.mcpServers === "string") {
+    const mcpPath = path.resolve(pluginRoot, manifest.mcpServers);
+    if (!fs.existsSync(mcpPath)) {
+      errors.push(`${path.relative(repoRoot, manifestPath)}: mcpServers path does not exist`);
+    }
+  }
+
+  const requiredInterfaceFields = [
+    "displayName",
+    "shortDescription",
+    "longDescription",
+    "developerName",
+    "category",
+    "defaultPrompt",
+  ];
+  for (const field of requiredInterfaceFields) {
+    requireString(manifest.interface?.[field], `interface.${field}`, manifestPath);
+  }
+  if (!Array.isArray(manifest.interface?.capabilities)) {
+    errors.push(`${path.relative(repoRoot, manifestPath)}: interface.capabilities must be an array`);
+  }
+
+  const marketplaceEntry = marketplaceEntries.get(folderName);
+  if (!marketplaceEntry) {
+    errors.push(`${path.relative(repoRoot, marketplacePath)}: missing '${folderName}' entry`);
+    continue;
+  }
+  const expectedSource = `./plugins/${folderName}`;
+  if (
+    marketplaceEntry.source?.source !== "local" ||
+    marketplaceEntry.source?.path !== expectedSource
+  ) {
+    errors.push(
+      `${path.relative(repoRoot, marketplacePath)}: '${folderName}' must use local source '${expectedSource}'`
+    );
+  }
+  if (
+    marketplaceEntry.policy?.installation !== "AVAILABLE" ||
+    marketplaceEntry.policy?.authentication !== "ON_INSTALL"
+  ) {
+    errors.push(
+      `${path.relative(repoRoot, marketplacePath)}: '${folderName}' has invalid default policy`
+    );
+  }
+  requireString(marketplaceEntry.category, `${folderName}.category`, marketplacePath);
+}
+
+for (const entryName of marketplaceEntries.keys()) {
+  if (!pluginFolders.includes(entryName)) {
+    errors.push(
+      `${path.relative(repoRoot, marketplacePath)}: entry '${entryName}' has no matching plugin folder`
+    );
+  }
+}
+
+if (errors.length > 0) {
+  console.error("Codex plugin validation failed:");
+  for (const error of errors) {
+    console.error(`- ${error}`);
+  }
+  process.exit(1);
+}
+
+console.log(`Codex plugin validation passed for ${pluginFolders.length} plugins.`);


### PR DESCRIPTION
## Summary

- add Codex manifests for all seven Power Platform plugins
- add a repository-local Codex marketplace and installation guidance
- preserve existing Open Plugins and Claude Code compatibility manifests
- add a repository validator for Codex packaging
- fix malformed YAML frontmatter in the mobile add-sample-data skill

## Validation

- official Codex plugin validator passed for all seven plugins
- `node scripts/validate-codex-plugins.js`
- `node scripts/validate-legacy-compatibility.js`
- `node scripts/validate-plugin-names.js`
- `node scripts/validate-keyword-case.js`
- `node scripts/validate-skill-descriptions.js`
- `node scripts/validate-telemetry-ikeys.js`
- `git diff --check`

## Notes

The Codex packaging is additive. Existing Claude Code and GitHub Copilot package metadata remains unchanged. Code Apps and Mobile Apps use folder-matching Codex package names (`code-apps` and `mobile-apps`) while the legacy marketplaces retain their existing names.

An end-to-end local `codex plugin add` smoke test could not be run in the development sandbox because execution of `codex.exe` was denied.