### PR TITLE
Fix Dependabot XSS alerts by bumping Astro site template to 7.1

### DIFF
--- a/plugins/power-pages/skills/create-site/SKILL.md
+++ b/plugins/power-pages/skills/create-site/SKILL.md
@@ -178,7 +178,6 @@ npm install
 
 > **Astro requires Node 22.12 or newer.**
 > Astro 7 exits with `Node.js vX is not supported by Astro!` on anything older, so when the chosen framework is Astro, run `node --version` first and ask the user to upgrade before continuing.
-> The React, Vue, and Angular templates still run on Node 20.
 
 ### 2.5 Initialize Git Repository
 

--- a/plugins/power-pages/skills/create-site/SKILL.md
+++ b/plugins/power-pages/skills/create-site/SKILL.md
@@ -176,6 +176,10 @@ cd "<PROJECT_ROOT>"
 npm install
 ```
 
+> **Astro requires Node 22.12 or newer.**
+> Astro 7 exits with `Node.js vX is not supported by Astro!` on anything older, so when the chosen framework is Astro, run `node --version` first and ask the user to upgrade before continuing.
+> The React, Vue, and Angular templates still run on Node 20.
+
 ### 2.5 Initialize Git Repository
 
 Initialize a git repo and make the first commit. This captures all template files AND `package-lock.json` in one clean baseline:

--- a/plugins/power-pages/skills/create-site/assets/astro/package.json
+++ b/plugins/power-pages/skills/create-site/assets/astro/package.json
@@ -9,6 +9,9 @@
     "preview": "astro preview"
   },
   "dependencies": {
-    "astro": "^6.1.6"
+    "astro": "^7.1.0"
+  },
+  "engines": {
+    "node": ">=22.12.0"
   }
 }


### PR DESCRIPTION
Three open Dependabot alerts flag XSS vulnerabilities in the `astro` dependency of the Power Pages `create-site` scaffold. None of them have a 6.x backport, so every site scaffolded from the Astro template today ships a vulnerable Astro.

## The alerts

| Advisory | Severity | Issue | Patched in |
|---|---|---|---|
| [GHSA-4g3v-8h47-v7g6](https://github.com/withastro/astro/security/advisories/GHSA-4g3v-8h47-v7g6) | medium | Reflected XSS via unescaped View Transition animation properties (affects `>= 2.9.0, <= 7.0.9`) | 7.1.0 |
| [GHSA-f48w-9m4c-m7f5](https://github.com/withastro/astro/security/advisories/GHSA-f48w-9m4c-m7f5) / CVE-2026-59729 | medium | XSS via unescaped spread attribute names in `renderHTMLElement` | 7.0.6 |
| [GHSA-7pw4-f3q4-r2p2](https://github.com/withastro/astro/security/advisories/GHSA-7pw4-f3q4-r2p2) / CVE-2026-59727 | low | XSS via unescaped `transition:*` directive values on hydrated islands | 7.0.4 |

## Approach

Bumped the template from `astro: ^6.1.6` to `^7.1.0`. The first advisory's vulnerable range extends through 7.0.9 with no 6.x fix, so the major bump was the only way to clear all three.

The knock-on worth flagging: Astro 7 raises the runtime floor to Node `>=22.12.0` and hard-exits below it (`Node.js v20.20.2 is not supported by Astro!`, confirmed locally). Since the template ships without a lockfile and users install fresh, that would have surfaced as a confusing mid-skill failure. So the template now declares `engines`, and `create-site/SKILL.md` section 2.4 tells the agent to check `node --version` before scaffolding Astro. The React, Vue, and Angular templates are untouched.

## Verification

Rather than just editing the manifest, I scaffolded the template into a clean directory the way the skill does it (placeholder substitution, `gitignore` -> `.gitignore`) and ran it on Node 22.23.1:

- `npm install` resolves astro 7.1.2
- `npm run build` emits `dist/index.html` and `dist/about/index.html`, matching the `compiledPath` / `defaultLandingPage` contract in `powerpages.config.json`
- `astro dev` serves both routes with 200 on port 4321, the port the skill and evals already document

No breaking changes hit this template - it only uses `output: 'static'`, `build.format: 'directory'`, and plain `.astro` components. All six repo validators pass.