### PR TITLE
Add /setup-prerequisites skill to the power-pages plugin

### DIFF
--- a/plugins/power-pages/AGENTS.md
+++ b/plugins/power-pages/AGENTS.md
@@ -115,7 +115,7 @@ skills/
     scripts/render-alm-plan.js ← Renders alm-plan-template.html from planData JSON (stages diagram, checklist, risks)
     scripts/validate-plan-alm.js ← Validates docs/alm-plan.html exists and is > 500 bytes; gracefully exits 0 if not a plan-alm session
   setup-prerequisites/
-    SKILL.md                   ← Machine setup skill — checks/installs Node, .NET SDK, PAC CLI, Azure CLI and signs both CLIs in
+    SKILL.md                   ← Machine setup skill — checks/installs Node, Git, .NET SDK, PAC CLI, Azure CLI and signs both CLIs in
     scripts/detect-prerequisites.js   ← Read-only probe; emits JSON status + an `actions` list the workflow works through
     scripts/install-prerequisite.js   ← Installs one tool via winget (Windows) / Homebrew (macOS) / dotnet tool (PAC, all platforms)
 ```

--- a/plugins/power-pages/AGENTS.md
+++ b/plugins/power-pages/AGENTS.md
@@ -114,6 +114,10 @@ skills/
     assets/alm-plan-template.html ← HTML template with __PLACEHOLDER__ tokens for the ALM plan document
     scripts/render-alm-plan.js ← Renders alm-plan-template.html from planData JSON (stages diagram, checklist, risks)
     scripts/validate-plan-alm.js ← Validates docs/alm-plan.html exists and is > 500 bytes; gracefully exits 0 if not a plan-alm session
+  setup-prerequisites/
+    SKILL.md                   ← Machine setup skill — checks/installs Node, .NET SDK, PAC CLI, Azure CLI and signs both CLIs in
+    scripts/detect-prerequisites.js   ← Read-only probe; emits JSON status + an `actions` list the workflow works through
+    scripts/install-prerequisite.js   ← Installs one tool via winget (Windows) / Homebrew (macOS) / dotnet tool (PAC, all platforms)
 ```
 
 ## ALM intent routing — `plan-alm` is the front door

--- a/plugins/power-pages/AGENTS.md
+++ b/plugins/power-pages/AGENTS.md
@@ -115,7 +115,7 @@ skills/
     scripts/render-alm-plan.js ← Renders alm-plan-template.html from planData JSON (stages diagram, checklist, risks)
     scripts/validate-plan-alm.js ← Validates docs/alm-plan.html exists and is > 500 bytes; gracefully exits 0 if not a plan-alm session
   setup-prerequisites/
-    SKILL.md                   ← Machine setup skill — checks/installs Node, Git, .NET SDK, PAC CLI, Azure CLI and signs both CLIs in
+    SKILL.md                   ← Machine setup skill — checks/installs Node, Git, .NET SDK, PAC CLI, Azure CLI, optional gh; signs the CLIs in
     scripts/detect-prerequisites.js   ← Read-only probe; emits JSON status + an `actions` list the workflow works through
     scripts/install-prerequisite.js   ← Installs one tool via winget (Windows) / Homebrew (macOS) / dotnet tool (PAC, all platforms)
 ```

--- a/plugins/power-pages/README.md
+++ b/plugins/power-pages/README.md
@@ -36,6 +36,7 @@ This keeps hook behavior in one place and avoids relying on skill-frontmatter ho
 | [Git](https://git-scm.com/downloads) | Commits made by most skills | `winget install Git.Git` |
 | [PAC CLI](https://learn.microsoft.com/power-platform/developer/cli/introduction) | Deploy, activate, data model | `dotnet tool install -g Microsoft.PowerApps.CLI.Tool` |
 | [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli) | Data model, sample data, activation | `winget install Microsoft.AzureCLI` |
+| [GitHub CLI](https://github.com/cli/cli#installation) (optional) | `/report-issue` only | `winget install GitHub.cli` |
 
 Installing from the marketplace copies the skill files and nothing else, so none of these tools come with it. Run [`/setup-prerequisites`](#setup-prerequisites) to check what is on your machine, install what is missing, and sign the two CLIs in.
 
@@ -397,13 +398,14 @@ Adds search engine optimization artifacts: `robots.txt`, `sitemap.xml`, and meta
 
 > "Set up the plugin" · "Check my setup" · "pac is not recognized"
 
-Gets a machine ready to use the plugin. Checks Node.js, Git, the .NET SDK, the Power Platform CLI, and the Azure CLI, installs whatever is missing, and signs both CLIs in.
+Gets a machine ready to use the plugin. Checks Node.js, Git, the .NET SDK, the Power Platform CLI, and the Azure CLI, plus the optional GitHub CLI, installs whatever is missing, and signs the CLIs in.
 
 - Reports each tool's version and sign-in state before changing anything
 - Asks before every install, one tool at a time, showing the exact command
 - Installs via winget on Windows and Homebrew on macOS; hands back commands on Linux
 - Offers a PAC CLI update when a newer version is published
-- Warns when the two CLIs are signed into different tenants
+- Warns when the Power Platform and Azure CLIs are signed into different tenants
+- Offers the GitHub CLI as optional, so a machine without it still reads as ready
 - A failed install never stops the run — everything outstanding lands in the final summary
 
 #### `/report-issue`

--- a/plugins/power-pages/README.md
+++ b/plugins/power-pages/README.md
@@ -33,6 +33,7 @@ This keeps hook behavior in one place and avoids relying on skill-frontmatter ho
 | Prerequisite | Required for | Install |
 |---|---|---|
 | [Node.js](https://nodejs.org/) (LTS) | All skills | `winget install OpenJS.NodeJS.LTS` |
+| [Git](https://git-scm.com/downloads) | Commits made by most skills | `winget install Git.Git` |
 | [PAC CLI](https://learn.microsoft.com/power-platform/developer/cli/introduction) | Deploy, activate, data model | `dotnet tool install -g Microsoft.PowerApps.CLI.Tool` |
 | [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli) | Data model, sample data, activation | `winget install Microsoft.AzureCLI` |
 
@@ -396,7 +397,7 @@ Adds search engine optimization artifacts: `robots.txt`, `sitemap.xml`, and meta
 
 > "Set up the plugin" · "Check my setup" · "pac is not recognized"
 
-Gets a machine ready to use the plugin. Checks Node.js, the .NET SDK, the Power Platform CLI, and the Azure CLI, installs whatever is missing, and signs both CLIs in.
+Gets a machine ready to use the plugin. Checks Node.js, Git, the .NET SDK, the Power Platform CLI, and the Azure CLI, installs whatever is missing, and signs both CLIs in.
 
 - Reports each tool's version and sign-in state before changing anything
 - Asks before every install, one tool at a time, showing the exact command

--- a/plugins/power-pages/README.md
+++ b/plugins/power-pages/README.md
@@ -36,9 +36,11 @@ This keeps hook behavior in one place and avoids relying on skill-frontmatter ho
 | [PAC CLI](https://learn.microsoft.com/power-platform/developer/cli/introduction) | Deploy, activate, data model | `dotnet tool install -g Microsoft.PowerApps.CLI.Tool` |
 | [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli) | Data model, sample data, activation | `winget install Microsoft.AzureCLI` |
 
+Installing from the marketplace copies the skill files and nothing else, so none of these tools come with it. Run [`/setup-prerequisites`](#setup-prerequisites) to check what is on your machine, install what is missing, and sign the two CLIs in.
+
 ## Skills
 
-The plugin provides 31 skills that cover the full lifecycle of a Power Pages code site — scaffolding, deployment, data modeling, backend integration, authentication, ALM and CI/CD, security review, testing, and auditing. Each skill is invoked conversationally — just describe what you want to do.
+The plugin provides 32 skills that cover the full lifecycle of a Power Pages code site — scaffolding, deployment, data modeling, backend integration, authentication, ALM and CI/CD, security review, testing, and auditing. Each skill is invoked conversationally — just describe what you want to do.
 
 ### Site scaffolding and deployment
 
@@ -390,6 +392,19 @@ Adds search engine optimization artifacts: `robots.txt`, `sitemap.xml`, and meta
 
 ### Support
 
+#### `/setup-prerequisites`
+
+> "Set up the plugin" · "Check my setup" · "pac is not recognized"
+
+Gets a machine ready to use the plugin. Checks Node.js, the .NET SDK, the Power Platform CLI, and the Azure CLI, installs whatever is missing, and signs both CLIs in.
+
+- Reports each tool's version and sign-in state before changing anything
+- Asks before every install, one tool at a time, showing the exact command
+- Installs via winget on Windows and Homebrew on macOS; hands back commands on Linux
+- Offers a PAC CLI update when a newer version is published
+- Warns when the two CLIs are signed into different tenants
+- A failed install never stops the run — everything outstanding lands in the final summary
+
 #### `/report-issue`
 
 > "Report a bug with the create-site skill"
@@ -441,6 +456,7 @@ The plugin ships with two MCP servers configured in `.mcp.json` — they start a
 A common end-to-end workflow looks like this:
 
 ```
+0.  /setup-prerequisites    →  Install the CLIs and sign in (first run only)
 1.  /create-site            →  Scaffold + design + build pages
 2.  /deploy-site            →  Upload to Power Pages environment
 3.  /activate-site          →  Provision a public URL

--- a/plugins/power-pages/references/approval-gates.md
+++ b/plugins/power-pages/references/approval-gates.md
@@ -687,12 +687,12 @@ New skill (Power Pages source & dependency security scan). Runs local static ana
 
 ### 6.31 `setup-prerequisites` (2 gate IDs)
 
-New skill (machine setup for marketplace installs). Checks Node.js, Git, the .NET SDK, the PAC CLI, and the Azure CLI, installs what is missing, and signs both CLIs in. Both gates are `consent` — each one authorizes a change to the user's machine (a package install, or a credential prompt that writes a CLI profile) rather than a change to the project.
+New skill (machine setup for marketplace installs). Checks Node.js, Git, the .NET SDK, the PAC CLI, and the Azure CLI, plus the optional GitHub CLI, installs what is missing, and signs the CLIs in. Both gates are `consent` — each one authorizes a change to the user's machine (a package install, or a credential prompt that writes a CLI profile) rather than a change to the project.
 
 | ID | Kind | Category | Phase | Trigger / question | Cancel leaves |
 |---|---|---|---|---|---|
 | `setup-prerequisites:2.install-consent` | gate | consent | 2 | *"Install &lt;tool&gt; using &lt;command&gt;? / Skip"* — fires once per `install`/`update` action returned by `detect-prerequisites.js`. Skipped entirely when nothing is missing. | nothing — the tool stays as it was and the run continues with the next one |
-| `setup-prerequisites:3.signin-consent` | gate | consent | 3 | *"Sign in to &lt;CLI&gt; now? / Skip"* — fires once per `signin` action, and again after an install that added a CLI. | nothing — no CLI profile is created; the outstanding sign-in is listed in the Phase 4 summary |
+| `setup-prerequisites:3.signin-consent` | gate | consent | 3 | *"Sign in to &lt;CLI&gt; now? / Skip"* — fires once per `signin` action (pac, az, and optionally gh), and again after an install that added a CLI. | nothing — no CLI profile is created; the outstanding sign-in is listed in the Phase 4 summary |
 
 ---
 

--- a/plugins/power-pages/references/approval-gates.md
+++ b/plugins/power-pages/references/approval-gates.md
@@ -685,6 +685,17 @@ New skill (Power Pages source & dependency security scan). Runs local static ana
 
 ---
 
+### 6.31 `setup-prerequisites` (2 gate IDs)
+
+New skill (machine setup for marketplace installs). Checks Node.js, the .NET SDK, the PAC CLI, and the Azure CLI, installs what is missing, and signs both CLIs in. Both gates are `consent` — each one authorizes a change to the user's machine (a package install, or a credential prompt that writes a CLI profile) rather than a change to the project.
+
+| ID | Kind | Category | Phase | Trigger / question | Cancel leaves |
+|---|---|---|---|---|---|
+| `setup-prerequisites:2.install-consent` | gate | consent | 2 | *"Install &lt;tool&gt; using &lt;command&gt;? / Skip"* — fires once per `install`/`update` action returned by `detect-prerequisites.js`. Skipped entirely when nothing is missing. | nothing — the tool stays as it was and the run continues with the next one |
+| `setup-prerequisites:3.signin-consent` | gate | consent | 3 | *"Sign in to &lt;CLI&gt; now? / Skip"* — fires once per `signin` action, and again after an install that added a CLI. | nothing — no CLI profile is created; the outstanding sign-in is listed in the Phase 4 summary |
+
+---
+
 ### Cross-plugin shared skills — out of catalog scope
 
 `report-issue` — Its prompts are cross-plugin, not power-pages-specific, so they are not catalogued here. If the shared workflow is ever governed by per-plugin approval-gate linting, add a `report-issue:*` section to this catalog.
@@ -728,6 +739,7 @@ These need explicit confirmation from the reviewer before SKILL.md edits land. R
 - §6.13–§6.24 added — full catalog rows for `create-site`, `deploy-site`, `add-server-logic`, `add-cloud-flow`, `setup-auth`, `integrate-webapi`, `setup-datamodel`, `add-sample-data`, `add-seo`, `create-webroles`, `audit-permissions`, `integrate-backend` (45 gates + 9 not-a-gates).
 - §6.24a–§6.28 added — security skills introduced by PR #151 (`manage-firewall`, `manage-headers`, `scan-site`, `security-review`). The new skills use a runtime-loop prompt pattern; §6.24a documents the marker convention for that pattern. 3 gates + 2 not-a-gates.
 - §6.30 added — `scan-code` (Power Pages source & dependency security scan). 3 `plan` gates (`scan-code:1.agent-review-fallback`, `scan-code:2.scope-choice`, `scan-code:2.depth-choice`); no not-a-gates.
+- §6.31 added — `setup-prerequisites` (machine setup for marketplace installs). 2 `consent` gates (`setup-prerequisites:2.install-consent`, `setup-prerequisites:3.signin-consent`); no not-a-gates.
 - Markers added to all non-ALM SKILL.md files (HTML comment + 🚦 block per gate; `not-a-gate` comment per data-gathering prompt or meta-mention).
 - `scripts/lint-skills-alm.js` warn-only branch removed — all skills now hard-fail.
 - `AGENTS.md` Key Patterns updated — Approval Gate convention applies plugin-wide; new skills must extend §6 in the same PR they introduce a prompt.

--- a/plugins/power-pages/references/approval-gates.md
+++ b/plugins/power-pages/references/approval-gates.md
@@ -687,7 +687,7 @@ New skill (Power Pages source & dependency security scan). Runs local static ana
 
 ### 6.31 `setup-prerequisites` (2 gate IDs)
 
-New skill (machine setup for marketplace installs). Checks Node.js, the .NET SDK, the PAC CLI, and the Azure CLI, installs what is missing, and signs both CLIs in. Both gates are `consent` — each one authorizes a change to the user's machine (a package install, or a credential prompt that writes a CLI profile) rather than a change to the project.
+New skill (machine setup for marketplace installs). Checks Node.js, Git, the .NET SDK, the PAC CLI, and the Azure CLI, installs what is missing, and signs both CLIs in. Both gates are `consent` — each one authorizes a change to the user's machine (a package install, or a credential prompt that writes a CLI profile) rather than a change to the project.
 
 | ID | Kind | Category | Phase | Trigger / question | Cancel leaves |
 |---|---|---|---|---|---|

--- a/plugins/power-pages/references/skill-tracking-reference.md
+++ b/plugins/power-pages/references/skill-tracking-reference.md
@@ -56,6 +56,7 @@ If the tracking script creates or updates site setting YAML files, include those
 | deploy-pipeline | DeployPipeline | Site/AI/Skills/DeployPipeline |
 | ensure-pipelines-host | EnsurePipelinesHost | Site/AI/Skills/EnsurePipelinesHost |
 | force-link-environment | ForceLinkEnvironment | Site/AI/Skills/ForceLinkEnvironment |
+| setup-prerequisites | SetupPrerequisites | Site/AI/Skills/SetupPrerequisites |
 
 ## YAML Format
 

--- a/plugins/power-pages/scripts/tests/detect-prerequisites.test.js
+++ b/plugins/power-pages/scripts/tests/detect-prerequisites.test.js
@@ -6,6 +6,7 @@ const {
   parsePacVersion,
   parseAzVersion,
   parseDotnetVersion,
+  parseGitVersion,
   parsePacAuthWho,
   parseAzAccountShow,
   compareVersions,
@@ -42,6 +43,7 @@ function statusFixture(overrides = {}) {
   return Object.assign(
     {
       node: { available: true, version: '22.11.0' },
+      git: { available: true, version: '2.53.0' },
       dotnet: { available: true, version: '10.0.102' },
       pac: { available: true, version: '1.51.1', updateAvailable: false },
       az: { available: true, version: '2.77.0' },
@@ -87,6 +89,14 @@ test('parseDotnetVersion handles stable and preview SDKs', () => {
   assert.equal(parseDotnetVersion('10.0.102\n'), '10.0.102');
   assert.equal(parseDotnetVersion('9.0.100-preview.1.24101.2\n'), '9.0.100-preview.1.24101.2');
   assert.equal(parseDotnetVersion(null), null);
+});
+
+test('parseGitVersion reads upstream and Apple-shipped builds', () => {
+  assert.equal(parseGitVersion('git version 2.53.0\n'), '2.53.0');
+  assert.equal(parseGitVersion('git version 2.39.5 (Apple Git-154)\n'), '2.39.5');
+  assert.equal(parseGitVersion('git version 2.51.0.windows.1\n'), '2.51.0');
+  assert.equal(parseGitVersion(null), null);
+  assert.equal(parseGitVersion('command not found: git'), null);
 });
 
 test('parsePacAuthWho extracts tenant, user, and cloud', () => {
@@ -161,12 +171,14 @@ test('buildActions is empty when everything is present and signed in', () => {
 test('buildActions reports one install per missing tool', () => {
   const actions = buildActions(
     statusFixture({
+      git: { available: false, version: null },
       dotnet: { available: false, version: null },
       az: { available: false, version: null },
       azAuth: { signedIn: false, tenantId: null },
     })
   );
   assert.deepEqual(actions, [
+    { tool: 'git', kind: 'install' },
     { tool: 'dotnet', kind: 'install' },
     { tool: 'az', kind: 'install' },
   ]);

--- a/plugins/power-pages/scripts/tests/detect-prerequisites.test.js
+++ b/plugins/power-pages/scripts/tests/detect-prerequisites.test.js
@@ -1,0 +1,218 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  buildProbeInvocation,
+  parsePacVersion,
+  parseAzVersion,
+  parseDotnetVersion,
+  parsePacAuthWho,
+  parseAzAccountShow,
+  compareVersions,
+  latestStableVersion,
+  buildActions,
+  tenantMismatch,
+} = require('../../skills/setup-prerequisites/scripts/detect-prerequisites');
+
+// Captured from `pac help` on 1.51.1 — the version carries a `+<git-sha>` build
+// suffix that must not leak into the comparison against NuGet's plain semver.
+const PAC_HELP = `
+Microsoft PowerPlatform CLI
+
+Version: 1.51.1+g8a2ec33
+
+Usage: pac [command] [options]
+`;
+
+// Captured from `pac auth who` on 2.9.3. Note the "Tenant Id" casing, and that
+// the banner opens with a "Connected as" line before the label/value block.
+const PAC_AUTH_WHO = `
+Connected as user@contoso.com
+
+Type:                       User
+Cloud:                      Public
+Tenant Id:                  72f988bf-86f1-41af-91ab-2d7cd011db47
+Tenant Country:             IN
+User:                       user@contoso.com
+Environment Id:             11111111-1111-1111-1111-111111111111
+Organization Friendly Name: Contoso Dev
+`;
+
+function statusFixture(overrides = {}) {
+  return Object.assign(
+    {
+      node: { available: true, version: '22.11.0' },
+      dotnet: { available: true, version: '10.0.102' },
+      pac: { available: true, version: '1.51.1', updateAvailable: false },
+      az: { available: true, version: '2.77.0' },
+      pacAuth: { signedIn: true, tenantId: 'tenant-a' },
+      azAuth: { signedIn: true, tenantId: 'tenant-a' },
+    },
+    overrides
+  );
+}
+
+// The Azure CLI installs only `az.cmd` on Windows, which Node refuses to spawn
+// directly, so every Windows probe goes through `cmd.exe /c`.
+test('buildProbeInvocation routes Windows probes through cmd.exe', () => {
+  assert.deepEqual(buildProbeInvocation('az', ['version', '-o', 'tsv'], 'win32'), {
+    file: 'cmd.exe',
+    args: ['/c', 'az', 'version', '-o', 'tsv'],
+  });
+});
+
+test('buildProbeInvocation runs the command directly off Windows', () => {
+  for (const platform of ['darwin', 'linux']) {
+    assert.deepEqual(buildProbeInvocation('az', ['account', 'show'], platform), {
+      file: 'az',
+      args: ['account', 'show'],
+    });
+  }
+});
+
+test('parsePacVersion strips the build-metadata suffix', () => {  assert.equal(parsePacVersion(PAC_HELP), '1.51.1');
+});
+
+test('parsePacVersion returns null for missing or unparseable output', () => {
+  assert.equal(parsePacVersion(null), null);
+  assert.equal(parsePacVersion('command not found: pac'), null);
+});
+
+test('parseAzVersion reads the version from tsv output', () => {
+  assert.equal(parseAzVersion('2.77.0\t2.77.0\t\t\n'), '2.77.0');
+  assert.equal(parseAzVersion(null), null);
+});
+
+test('parseDotnetVersion handles stable and preview SDKs', () => {
+  assert.equal(parseDotnetVersion('10.0.102\n'), '10.0.102');
+  assert.equal(parseDotnetVersion('9.0.100-preview.1.24101.2\n'), '9.0.100-preview.1.24101.2');
+  assert.equal(parseDotnetVersion(null), null);
+});
+
+test('parsePacAuthWho extracts tenant, user, and cloud', () => {
+  const auth = parsePacAuthWho(PAC_AUTH_WHO);
+  assert.equal(auth.signedIn, true);
+  assert.equal(auth.tenantId, '72f988bf-86f1-41af-91ab-2d7cd011db47');
+  assert.equal(auth.user, 'user@contoso.com');
+  assert.equal(auth.cloud, 'Public');
+});
+
+test('parsePacAuthWho accepts the older "Tenant ID" casing', () => {
+  const auth = parsePacAuthWho('Tenant ID: t-1\nUser: u@c.com');
+  assert.equal(auth.tenantId, 't-1');
+});
+
+test('parsePacAuthWho reports signed out when no profile exists', () => {
+  assert.deepEqual(parsePacAuthWho('No profiles were found on this computer.'), {
+    signedIn: false,
+    tenantId: null,
+    user: null,
+    cloud: null,
+  });
+  assert.equal(parsePacAuthWho(null).signedIn, false);
+  assert.equal(parsePacAuthWho('some unrelated banner text').signedIn, false);
+});
+
+test('parseAzAccountShow extracts tenant, user, and subscription', () => {
+  const account = parseAzAccountShow(
+    JSON.stringify({ tenantId: 'tenant-a', user: { name: 'user@contoso.com' }, name: 'Pay-As-You-Go' })
+  );
+  assert.deepEqual(account, {
+    signedIn: true,
+    tenantId: 'tenant-a',
+    user: 'user@contoso.com',
+    subscription: 'Pay-As-You-Go',
+  });
+});
+
+test('parseAzAccountShow treats a subscription-less account as signed in', () => {
+  const account = parseAzAccountShow(JSON.stringify({ tenantId: 'tenant-a', user: { name: 'u@c.com' } }));
+  assert.equal(account.signedIn, true);
+  assert.equal(account.subscription, null);
+});
+
+test('parseAzAccountShow reports signed out for null, non-JSON, and empty payloads', () => {
+  assert.equal(parseAzAccountShow(null).signedIn, false);
+  assert.equal(parseAzAccountShow("Please run 'az login' to setup account.").signedIn, false);
+  assert.equal(parseAzAccountShow('{}').signedIn, false);
+  assert.equal(parseAzAccountShow('null').signedIn, false);
+});
+
+test('compareVersions orders versions and ignores prerelease suffixes', () => {
+  assert.equal(compareVersions('1.51.1', '1.52.0'), 1);
+  assert.equal(compareVersions('1.52.0', '1.51.1'), -1);
+  assert.equal(compareVersions('1.51.1', '1.51.1'), 0);
+  assert.equal(compareVersions('1.51.1-preview', '1.51.1'), 0);
+  assert.equal(compareVersions('1.51', '1.51.0'), 0);
+  assert.equal(compareVersions(null, '1.51.1'), 0);
+});
+
+test('latestStableVersion picks the last stable entry', () => {
+  assert.equal(latestStableVersion(['1.50.1', '1.51.1', '1.52.1']), '1.52.1');
+  assert.equal(latestStableVersion(['1.50.1', '1.52.0-preview']), '1.50.1');
+  assert.equal(latestStableVersion([]), null);
+  assert.equal(latestStableVersion(undefined), null);
+});
+
+test('buildActions is empty when everything is present and signed in', () => {
+  assert.deepEqual(buildActions(statusFixture()), []);
+});
+
+test('buildActions reports one install per missing tool', () => {
+  const actions = buildActions(
+    statusFixture({
+      dotnet: { available: false, version: null },
+      az: { available: false, version: null },
+      azAuth: { signedIn: false, tenantId: null },
+    })
+  );
+  assert.deepEqual(actions, [
+    { tool: 'dotnet', kind: 'install' },
+    { tool: 'az', kind: 'install' },
+  ]);
+});
+
+test('buildActions does not ask a missing CLI to sign in', () => {
+  const actions = buildActions(
+    statusFixture({
+      pac: { available: false, version: null, updateAvailable: false },
+      pacAuth: { signedIn: false, tenantId: null },
+    })
+  );
+  assert.deepEqual(actions, [{ tool: 'pac', kind: 'install' }]);
+});
+
+test('buildActions offers a pac update only when pac is installed', () => {
+  const actions = buildActions(
+    statusFixture({ pac: { available: true, version: '1.50.1', updateAvailable: true } })
+  );
+  assert.deepEqual(actions, [{ tool: 'pac', kind: 'update' }]);
+});
+
+test('buildActions asks a signed-out but installed CLI to sign in', () => {
+  const actions = buildActions(statusFixture({ azAuth: { signedIn: false, tenantId: null } }));
+  assert.deepEqual(actions, [{ tool: 'az', kind: 'signin' }]);
+});
+
+test('tenantMismatch flags differing tenants', () => {
+  const mismatch = tenantMismatch(
+    { signedIn: true, tenantId: 'tenant-a' },
+    { signedIn: true, tenantId: 'tenant-b' }
+  );
+  assert.deepEqual(mismatch, { pacTenantId: 'tenant-a', azTenantId: 'tenant-b' });
+});
+
+test('tenantMismatch ignores casing differences', () => {
+  assert.equal(
+    tenantMismatch({ signedIn: true, tenantId: 'TENANT-A' }, { signedIn: true, tenantId: 'tenant-a' }),
+    null
+  );
+});
+
+test('tenantMismatch stays silent when either side is signed out or unknown', () => {
+  assert.equal(tenantMismatch({ signedIn: false }, { signedIn: true, tenantId: 'tenant-b' }), null);
+  assert.equal(
+    tenantMismatch({ signedIn: true, tenantId: null }, { signedIn: true, tenantId: 'tenant-b' }),
+    null
+  );
+});

--- a/plugins/power-pages/scripts/tests/detect-prerequisites.test.js
+++ b/plugins/power-pages/scripts/tests/detect-prerequisites.test.js
@@ -76,7 +76,8 @@ test('buildProbeInvocation runs the command directly off Windows', () => {
   }
 });
 
-test('parsePacVersion strips the build-metadata suffix', () => {  assert.equal(parsePacVersion(PAC_HELP), '1.51.1');
+test('parsePacVersion strips the build-metadata suffix', () => {
+  assert.equal(parsePacVersion(PAC_HELP), '1.51.1');
 });
 
 test('parsePacVersion returns null for missing or unparseable output', () => {

--- a/plugins/power-pages/scripts/tests/detect-prerequisites.test.js
+++ b/plugins/power-pages/scripts/tests/detect-prerequisites.test.js
@@ -7,6 +7,8 @@ const {
   parseAzVersion,
   parseDotnetVersion,
   parseGitVersion,
+  parseGhVersion,
+  parseGhAuthStatus,
   parsePacAuthWho,
   parseAzAccountShow,
   compareVersions,
@@ -47,8 +49,10 @@ function statusFixture(overrides = {}) {
       dotnet: { available: true, version: '10.0.102' },
       pac: { available: true, version: '1.51.1', updateAvailable: false },
       az: { available: true, version: '2.77.0' },
+      gh: { available: true, version: '2.96.0', optional: true },
       pacAuth: { signedIn: true, tenantId: 'tenant-a' },
       azAuth: { signedIn: true, tenantId: 'tenant-a' },
+      ghAuth: { signedIn: true, account: 'octocat' },
     },
     overrides
   );
@@ -164,6 +168,76 @@ test('latestStableVersion picks the last stable entry', () => {
   assert.equal(latestStableVersion(undefined), null);
 });
 
+test('parseGhVersion ignores the release URL on the second line', () => {
+  const banner = 'gh version 2.96.0 (2026-07-02)\nhttps://github.com/cli/cli/releases/tag/v2.96.0\n';
+  assert.equal(parseGhVersion(banner), '2.96.0');
+  assert.equal(parseGhVersion(null), null);
+  assert.equal(parseGhVersion('command not found: gh'), null);
+});
+
+// Captured from gh 2.96.0 with two hosts configured. The whole report goes to
+// stderr, and gh exits 1 because the enterprise host is broken — even though
+// github.com is authenticated. Reading this as "signed out" was a real bug.
+const GH_AUTH_MULTI_HOST = `github.com
+  ✓ Logged in to github.com account octocat (GH_TOKEN)
+  - Active account: true
+  - Token scopes: 'gist', 'repo', 'workflow'
+
+contoso.ghe.com
+  X Failed to log in to contoso.ghe.com using token (GH_TOKEN)
+  - Active account: true
+  - The token in GH_TOKEN is invalid.
+`;
+
+test('parseGhAuthStatus reads a signed-in account', () => {
+  assert.deepEqual(parseGhAuthStatus('  ✓ Logged in to github.com account octocat (keyring)\n'), {
+    signedIn: true,
+    account: 'octocat',
+  });
+});
+
+test('parseGhAuthStatus prefers github.com when several hosts are configured', () => {
+  assert.deepEqual(parseGhAuthStatus(GH_AUTH_MULTI_HOST), { signedIn: true, account: 'octocat' });
+});
+
+// The inverse of the capture above: an enterprise host works, github.com does
+// not. /report-issue files against github.com, so this must read as signed out
+// rather than deferring the failure to `gh issue create`.
+test('parseGhAuthStatus does not accept an enterprise-only login', () => {
+  const enterpriseOnly = `github.com
+  X Failed to log in to github.com account octocat (GH_TOKEN)
+  - The token in GH_TOKEN is invalid.
+
+contoso.ghe.com
+  ✓ Logged in to contoso.ghe.com account alice (keyring)
+  - Active account: true
+`;
+  assert.deepEqual(parseGhAuthStatus(enterpriseOnly), { signedIn: false, account: null });
+});
+
+test('parseGhAuthStatus does not read a failed host as signed in', () => {
+  const failedOnly = `contoso.ghe.com
+  X Failed to log in to contoso.ghe.com using token (GH_TOKEN)
+  - The token in GH_TOKEN is invalid.
+`;
+  assert.deepEqual(parseGhAuthStatus(failedOnly), { signedIn: false, account: null });
+});
+
+test('parseGhAuthStatus accepts the older "as <account>" phrasing', () => {
+  assert.deepEqual(parseGhAuthStatus('✓ Logged in to github.com as octocat (oauth_token)'), {
+    signedIn: true,
+    account: 'octocat',
+  });
+});
+
+test('parseGhAuthStatus reports signed out for null and the empty-hosts message', () => {
+  assert.deepEqual(parseGhAuthStatus(null), { signedIn: false, account: null });
+  assert.deepEqual(parseGhAuthStatus('You are not logged into any GitHub hosts.'), {
+    signedIn: false,
+    account: null,
+  });
+});
+
 test('buildActions is empty when everything is present and signed in', () => {
   assert.deepEqual(buildActions(statusFixture()), []);
 });
@@ -227,4 +301,38 @@ test('tenantMismatch stays silent when either side is signed out or unknown', ()
     tenantMismatch({ signedIn: true, tenantId: null }, { signedIn: true, tenantId: 'tenant-b' }),
     null
   );
+});
+
+// The GitHub CLI backs exactly one skill (/report-issue), so it is offered but
+// never withholds the ready verdict.
+test('buildActions marks GitHub CLI install and sign-in as optional', () => {
+  const missing = buildActions(
+    statusFixture({ gh: { available: false, version: null, optional: true } })
+  );
+  assert.deepEqual(missing, [{ tool: 'gh', kind: 'install', optional: true }]);
+
+  const signedOut = buildActions(statusFixture({ ghAuth: { signedIn: false, account: null } }));
+  assert.deepEqual(signedOut, [{ tool: 'gh', kind: 'signin', optional: true }]);
+});
+
+test('buildActions does not ask a missing GitHub CLI to sign in', () => {
+  const actions = buildActions(
+    statusFixture({
+      gh: { available: false, version: null, optional: true },
+      ghAuth: { signedIn: false, account: null },
+    })
+  );
+  assert.deepEqual(actions, [{ tool: 'gh', kind: 'install', optional: true }]);
+});
+
+test('required actions are never marked optional', () => {
+  const actions = buildActions(
+    statusFixture({
+      git: { available: false, version: null },
+      pac: { available: true, version: '1.50.1', updateAvailable: true },
+      azAuth: { signedIn: false, tenantId: null },
+    })
+  );
+  assert.ok(actions.length > 0);
+  for (const action of actions) assert.equal(action.optional, undefined);
 });

--- a/plugins/power-pages/scripts/tests/install-prerequisite.test.js
+++ b/plugins/power-pages/scripts/tests/install-prerequisite.test.js
@@ -45,8 +45,17 @@ test('pac without the .NET SDK has no automated path', () => {
   assert.ok(plan.manual.length > 0);
 });
 
-test('dotnet uses winget on Windows and Homebrew on macOS', () => {
-  const win = resolveInstallPlan({ tool: 'dotnet', platform: 'win32', commandExists: everythingPresent });
+test('git uses winget on Windows and Homebrew on macOS', () => {
+  const win = resolveInstallPlan({ tool: 'git', platform: 'win32', commandExists: everythingPresent });
+  assert.equal(win.command, 'winget');
+  assert.ok(win.args.includes('Git.Git'));
+
+  const mac = resolveInstallPlan({ tool: 'git', platform: 'darwin', commandExists: everythingPresent });
+  assert.equal(mac.command, 'brew');
+  assert.deepEqual(mac.args, ['install', 'git']);
+});
+
+test('dotnet uses winget on Windows and Homebrew on macOS', () => {  const win = resolveInstallPlan({ tool: 'dotnet', platform: 'win32', commandExists: everythingPresent });
   assert.equal(win.command, 'winget');
   assert.ok(win.args.includes('Microsoft.DotNet.SDK.10'));
   assert.ok(win.args.includes('--accept-package-agreements'));
@@ -66,8 +75,8 @@ test('az uses winget on Windows and Homebrew on macOS', () => {
   assert.deepEqual(mac.args, ['install', 'azure-cli']);
 });
 
-test('Linux falls back to manual instructions for dotnet and az', () => {
-  for (const tool of ['dotnet', 'az']) {
+test('Linux falls back to manual instructions for git, dotnet, and az', () => {
+  for (const tool of ['git', 'dotnet', 'az']) {
     const plan = resolveInstallPlan({ tool, platform: 'linux', commandExists: everythingPresent });
     assert.equal(plan.command, null);
     assert.match(plan.reason, /linux/);

--- a/plugins/power-pages/scripts/tests/install-prerequisite.test.js
+++ b/plugins/power-pages/scripts/tests/install-prerequisite.test.js
@@ -1,0 +1,114 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  resolveInstallPlan,
+  parseArgs,
+  TOOLS,
+  MANUAL_INSTRUCTIONS,
+} = require('../../skills/setup-prerequisites/scripts/install-prerequisite');
+
+const everythingPresent = () => true;
+const nothingPresent = () => false;
+
+test('pac installs as a dotnet global tool on every platform', () => {
+  for (const platform of ['win32', 'darwin', 'linux']) {
+    const plan = resolveInstallPlan({ tool: 'pac', platform, commandExists: everythingPresent });
+    assert.equal(plan.command, 'dotnet');
+    assert.deepEqual(plan.args, [
+      'tool',
+      'install',
+      '--global',
+      'Microsoft.PowerApps.CLI.Tool',
+    ]);
+  }
+});
+
+test('pac --update switches install to update', () => {
+  const plan = resolveInstallPlan({
+    tool: 'pac',
+    platform: 'darwin',
+    update: true,
+    commandExists: everythingPresent,
+  });
+  assert.deepEqual(plan.args, ['tool', 'update', '--global', 'Microsoft.PowerApps.CLI.Tool']);
+});
+
+test('pac without the .NET SDK has no automated path', () => {
+  const plan = resolveInstallPlan({ tool: 'pac', platform: 'darwin', commandExists: nothingPresent });
+  assert.equal(plan.command, null);
+  assert.match(plan.reason, /\.NET SDK/);
+  // The fresh-machine path installs the SDK and PAC in the same session, where
+  // the new SDK is invisible to the already-running shell — the reason has to
+  // name the restart so the agent does not report a platform limitation.
+  assert.match(plan.reason, /restart your terminal/i);
+  assert.ok(plan.manual.length > 0);
+});
+
+test('dotnet uses winget on Windows and Homebrew on macOS', () => {
+  const win = resolveInstallPlan({ tool: 'dotnet', platform: 'win32', commandExists: everythingPresent });
+  assert.equal(win.command, 'winget');
+  assert.ok(win.args.includes('Microsoft.DotNet.SDK.10'));
+  assert.ok(win.args.includes('--accept-package-agreements'));
+
+  const mac = resolveInstallPlan({ tool: 'dotnet', platform: 'darwin', commandExists: everythingPresent });
+  assert.equal(mac.command, 'brew');
+  assert.deepEqual(mac.args, ['install', '--cask', 'dotnet-sdk']);
+});
+
+test('az uses winget on Windows and Homebrew on macOS', () => {
+  const win = resolveInstallPlan({ tool: 'az', platform: 'win32', commandExists: everythingPresent });
+  assert.equal(win.command, 'winget');
+  assert.ok(win.args.includes('Microsoft.AzureCLI'));
+
+  const mac = resolveInstallPlan({ tool: 'az', platform: 'darwin', commandExists: everythingPresent });
+  assert.equal(mac.command, 'brew');
+  assert.deepEqual(mac.args, ['install', 'azure-cli']);
+});
+
+test('Linux falls back to manual instructions for dotnet and az', () => {
+  for (const tool of ['dotnet', 'az']) {
+    const plan = resolveInstallPlan({ tool, platform: 'linux', commandExists: everythingPresent });
+    assert.equal(plan.command, null);
+    assert.match(plan.reason, /linux/);
+    assert.deepEqual(plan.manual, MANUAL_INSTRUCTIONS[tool]);
+  }
+});
+
+test('a missing package manager names the package manager in the reason', () => {
+  const win = resolveInstallPlan({ tool: 'az', platform: 'win32', commandExists: nothingPresent });
+  assert.match(win.reason, /winget/);
+
+  const mac = resolveInstallPlan({ tool: 'az', platform: 'darwin', commandExists: nothingPresent });
+  assert.match(mac.reason, /Homebrew/);
+});
+
+test('an unknown tool is rejected with the supported list', () => {
+  const plan = resolveInstallPlan({ tool: 'node', platform: 'darwin', commandExists: everythingPresent });
+  assert.equal(plan.command, null);
+  for (const tool of TOOLS) assert.ok(plan.reason.includes(tool));
+});
+
+test('every plan carries manual instructions as a fallback', () => {
+  for (const tool of TOOLS) {
+    const plan = resolveInstallPlan({ tool, platform: 'linux', commandExists: everythingPresent });
+    assert.ok(plan.manual.length > 0, `${tool} should carry manual instructions`);
+  }
+});
+
+test('parseArgs reads the tool as a flag or a positional', () => {
+  assert.deepEqual(parseArgs(['--tool', 'pac']), { tool: 'pac', update: false, dryRun: false, help: false });
+  assert.deepEqual(parseArgs(['az']), { tool: 'az', update: false, dryRun: false, help: false });
+});
+
+test('parseArgs reads --update, --dry-run, and --help', () => {
+  const args = parseArgs(['--tool', 'pac', '--update', '--dry-run', '--help']);
+  assert.equal(args.update, true);
+  assert.equal(args.dryRun, true);
+  assert.equal(args.help, true);
+});
+
+test('parseArgs defaults to no tool when none is given', () => {
+  assert.equal(parseArgs([]).tool, null);
+  assert.equal(parseArgs(['--dry-run']).tool, null);
+});

--- a/plugins/power-pages/scripts/tests/install-prerequisite.test.js
+++ b/plugins/power-pages/scripts/tests/install-prerequisite.test.js
@@ -75,6 +75,16 @@ test('az uses winget on Windows and Homebrew on macOS', () => {
   assert.deepEqual(mac.args, ['install', 'azure-cli']);
 });
 
+test('gh uses winget on Windows and Homebrew on macOS', () => {
+  const win = resolveInstallPlan({ tool: 'gh', platform: 'win32', commandExists: everythingPresent });
+  assert.equal(win.command, 'winget');
+  assert.ok(win.args.includes('GitHub.cli'));
+
+  const mac = resolveInstallPlan({ tool: 'gh', platform: 'darwin', commandExists: everythingPresent });
+  assert.equal(mac.command, 'brew');
+  assert.deepEqual(mac.args, ['install', 'gh']);
+});
+
 test('Linux falls back to manual instructions for git, dotnet, and az', () => {
   for (const tool of ['git', 'dotnet', 'az']) {
     const plan = resolveInstallPlan({ tool, platform: 'linux', commandExists: everythingPresent });

--- a/plugins/power-pages/scripts/tests/install-prerequisite.test.js
+++ b/plugins/power-pages/scripts/tests/install-prerequisite.test.js
@@ -5,6 +5,7 @@ const {
   resolveInstallPlan,
   parseArgs,
   TOOLS,
+  UPDATABLE_TOOLS,
   MANUAL_INSTRUCTIONS,
 } = require('../../skills/setup-prerequisites/scripts/install-prerequisite');
 
@@ -34,6 +35,28 @@ test('pac --update switches install to update', () => {
   assert.deepEqual(plan.args, ['tool', 'update', '--global', 'Microsoft.PowerApps.CLI.Tool']);
 });
 
+// The skill shows the dry-run command at its approval prompt and then runs the
+// same command for real, so quietly turning an unsupported --update into an
+// install would have the user approve one command and get another.
+test('--update is rejected for tools that have no update path', () => {
+  for (const tool of TOOLS) {
+    if (UPDATABLE_TOOLS.has(tool)) continue;
+    const plan = resolveInstallPlan({
+      tool,
+      platform: 'win32',
+      update: true,
+      commandExists: everythingPresent,
+    });
+    assert.equal(plan.command, null, `${tool} should reject --update`);
+    assert.match(plan.reason, /--update is not supported/);
+    assert.match(plan.reason, /pac/);
+  }
+});
+
+test('only pac is updatable', () => {
+  assert.deepEqual([...UPDATABLE_TOOLS], ['pac']);
+});
+
 test('pac without the .NET SDK has no automated path', () => {
   const plan = resolveInstallPlan({ tool: 'pac', platform: 'darwin', commandExists: nothingPresent });
   assert.equal(plan.command, null);
@@ -55,7 +78,8 @@ test('git uses winget on Windows and Homebrew on macOS', () => {
   assert.deepEqual(mac.args, ['install', 'git']);
 });
 
-test('dotnet uses winget on Windows and Homebrew on macOS', () => {  const win = resolveInstallPlan({ tool: 'dotnet', platform: 'win32', commandExists: everythingPresent });
+test('dotnet uses winget on Windows and Homebrew on macOS', () => {
+  const win = resolveInstallPlan({ tool: 'dotnet', platform: 'win32', commandExists: everythingPresent });
   assert.equal(win.command, 'winget');
   assert.ok(win.args.includes('Microsoft.DotNet.SDK.10'));
   assert.ok(win.args.includes('--accept-package-agreements'));

--- a/plugins/power-pages/skills/setup-prerequisites/SKILL.md
+++ b/plugins/power-pages/skills/setup-prerequisites/SKILL.md
@@ -91,7 +91,7 @@ Work through `actions` in order, one tool per `AskUserQuestion`. Combining them 
 > **Why we ask:** An install writes to the machine outside the project, can need elevation, and can take several minutes. The user may also prefer their own package manager or a company-managed build.
 > **Cancel leaves:** Nothing — the tool stays as it was, and the run continues with the next tool.
 
-For each prompt, show the command that will run. Get it from the script rather than writing it out from memory, passing the same flags the real run will use — for a `kind` of `update`, that means `--update` on both calls, because the resolved command differs (`dotnet tool update` rather than `dotnet tool install`):
+For each prompt, show the command that will run. Get it from the script rather than writing it out from memory, passing the same flags the real run will use — for a `kind` of `update`, that means `--update` on both calls, because the resolved command differs (`dotnet tool update` rather than `dotnet tool install`). Only `pac` accepts `--update`; passing it for anything else is rejected rather than treated as an install, so pass it only when the action's `kind` is `update`:
 
 ```bash
 node "${PLUGIN_ROOT}/skills/setup-prerequisites/scripts/install-prerequisite.js" --tool <git|dotnet|pac|az|gh> [--update] --dry-run

--- a/plugins/power-pages/skills/setup-prerequisites/SKILL.md
+++ b/plugins/power-pages/skills/setup-prerequisites/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: setup-prerequisites
 description: >-
-  Gets a machine ready to use the power-pages plugin — checks Node.js, the .NET
-  SDK, the Power Platform CLI (pac), and the Azure CLI (az), installs whatever
-  is missing, and signs both CLIs in.
+  Gets a machine ready to use the power-pages plugin — checks Node.js, Git, the
+  .NET SDK, the Power Platform CLI (pac), and the Azure CLI (az), installs
+  whatever is missing, and signs both CLIs in.
 user-invocable: true
 disable-model-invocation: true
 argument-hint: "[optional: check | install]"
@@ -15,7 +15,7 @@ model: sonnet
 
 # Setup Prerequisites
 
-Check every tool the power-pages skills depend on, install what is missing, and sign the Power Platform CLI and Azure CLI in.
+Check every tool the power-pages skills depend on — Node.js, Git, the .NET SDK, the Power Platform CLI, and the Azure CLI — install what is missing, and sign the Power Platform CLI and Azure CLI in.
 
 **Initial request:** $ARGUMENTS
 
@@ -23,9 +23,10 @@ Installing the plugin from the marketplace copies skill files and nothing else, 
 
 ## Gotchas
 
-- **A newly installed CLI does not resolve until the terminal restarts.** `pac` and `az` land in a PATH entry the current shell resolved at startup. After an install, tell the user to restart the terminal rather than reporting a false failure.
+- **A newly installed CLI does not resolve until the terminal restarts.** A freshly installed `git`, `pac`, or `az` lands in a PATH entry the current shell resolved at startup. After an install, tell the user to restart the terminal rather than reporting a false failure.
 - **PAC CLI is a .NET global tool.** Installing it needs the .NET SDK already on PATH. Installing the SDK in this session is not enough — see Phase 2.
-- **Linux has no automated path** for the .NET SDK and Azure CLI. Detection still works; the install step hands back commands.
+- **Git is what the skills commit with.** Most skills commit after each milestone, and the plugin's own version check shells out to `git`. Without it those steps fail rather than degrade.
+- **Linux has no automated path** for Git, the .NET SDK, and the Azure CLI. Detection still works; the install step hands back commands.
 - **`--allow-no-subscriptions` is only valid on `az login`.** Never add it to `az account show` or any other `az` subcommand — they reject it as an unrecognized argument.
 - **A failed install is not the end of the run.** Report it, keep going with the remaining tools, and collect every failure into the final summary.
 - **Environment selection is out of scope.** This skill stops once the CLIs are installed and signed in. Choosing a Dataverse environment belongs to the skill that needs one.
@@ -60,7 +61,7 @@ The script exits `1` when anything needs attention — that is a report, not a f
 
 | Field | Meaning |
 |---|---|
-| `node`, `dotnet`, `pac`, `az` | `available` plus the detected `version` |
+| `node`, `git`, `dotnet`, `pac`, `az` | `available` plus the detected `version` |
 | `pac.updateAvailable` | A newer PAC CLI is published on NuGet (`pac.latestVersion`) |
 | `pacAuth`, `azAuth` | `signedIn`, plus `tenantId` and `user` when signed in |
 | `tenantMismatch` | Non-null when the two CLIs are signed into different tenants |
@@ -90,13 +91,13 @@ Work through `actions` in order, one tool per `AskUserQuestion`. Combining them 
 For each prompt, show the command that will run. Get it from the script rather than writing it out from memory, passing the same flags the real run will use — for a `kind` of `update`, that means `--update` on both calls, because the resolved command differs (`dotnet tool update` rather than `dotnet tool install`):
 
 ```bash
-node "${PLUGIN_ROOT}/skills/setup-prerequisites/scripts/install-prerequisite.js" --tool <dotnet|pac|az> [--update] --dry-run
+node "${PLUGIN_ROOT}/skills/setup-prerequisites/scripts/install-prerequisite.js" --tool <git|dotnet|pac|az> [--update] --dry-run
 ```
 
 On approval, run the same command without `--dry-run`:
 
 ```bash
-node "${PLUGIN_ROOT}/skills/setup-prerequisites/scripts/install-prerequisite.js" --tool <dotnet|pac|az> [--update]
+node "${PLUGIN_ROOT}/skills/setup-prerequisites/scripts/install-prerequisite.js" --tool <git|dotnet|pac|az> [--update]
 ```
 
 The script streams installer output to the terminal and ends with a JSON line:

--- a/plugins/power-pages/skills/setup-prerequisites/SKILL.md
+++ b/plugins/power-pages/skills/setup-prerequisites/SKILL.md
@@ -1,15 +1,11 @@
 ---
 name: setup-prerequisites
 description: >-
-  Gets a machine ready to use the power-pages plugin by checking the tools the
-  skills depend on — Node.js, the .NET SDK, the Power Platform CLI (pac), and
-  the Azure CLI (az) — installing whatever is missing, and signing both CLIs in.
-  Use when the user installed the plugin from the marketplace and wants to set
-  it up, asks how to get started, says a skill failed because "pac is not
-  recognized" or "az is not installed", asks "do I have everything I need?",
-  "check my setup", "install the prerequisites", or needs to sign in to the
-  Power Platform or Azure CLI.
+  Gets a machine ready to use the power-pages plugin — checks Node.js, the .NET
+  SDK, the Power Platform CLI (pac), and the Azure CLI (az), installs whatever
+  is missing, and signs both CLIs in.
 user-invocable: true
+disable-model-invocation: true
 argument-hint: "[optional: check | install]"
 allowed-tools: Read, Bash, AskUserQuestion, TaskCreate, TaskUpdate, TaskList
 model: sonnet

--- a/plugins/power-pages/skills/setup-prerequisites/SKILL.md
+++ b/plugins/power-pages/skills/setup-prerequisites/SKILL.md
@@ -1,0 +1,199 @@
+---
+name: setup-prerequisites
+description: >-
+  Gets a machine ready to use the power-pages plugin by checking the tools the
+  skills depend on — Node.js, the .NET SDK, the Power Platform CLI (pac), and
+  the Azure CLI (az) — installing whatever is missing, and signing both CLIs in.
+  Use when the user installed the plugin from the marketplace and wants to set
+  it up, asks how to get started, says a skill failed because "pac is not
+  recognized" or "az is not installed", asks "do I have everything I need?",
+  "check my setup", "install the prerequisites", or needs to sign in to the
+  Power Platform or Azure CLI.
+user-invocable: true
+argument-hint: "[optional: check | install]"
+allowed-tools: Read, Bash, AskUserQuestion, TaskCreate, TaskUpdate, TaskList
+model: sonnet
+---
+
+> **Plugin check**: Run `node "${PLUGIN_ROOT}/scripts/check-version.js"` — if it outputs a message, show it to the user before proceeding.
+
+# Setup Prerequisites
+
+Check every tool the power-pages skills depend on, install what is missing, and sign the Power Platform CLI and Azure CLI in.
+
+**Initial request:** $ARGUMENTS
+
+Installing the plugin from the marketplace copies skill files and nothing else, so a marketplace user can arrive here with none of the command-line tools the skills call. This skill closes that gap.
+
+## Gotchas
+
+- **A newly installed CLI does not resolve until the terminal restarts.** `pac` and `az` land in a PATH entry the current shell resolved at startup. After an install, tell the user to restart the terminal rather than reporting a false failure.
+- **PAC CLI is a .NET global tool.** Installing it needs the .NET SDK already on PATH. Installing the SDK in this session is not enough — see Phase 2.
+- **Linux has no automated path** for the .NET SDK and Azure CLI. Detection still works; the install step hands back commands.
+- **`--allow-no-subscriptions` is only valid on `az login`.** Never add it to `az account show` or any other `az` subcommand — they reject it as an unrecognized argument.
+- **A failed install is not the end of the run.** Report it, keep going with the remaining tools, and collect every failure into the final summary.
+- **Environment selection is out of scope.** This skill stops once the CLIs are installed and signed in. Choosing a Dataverse environment belongs to the skill that needs one.
+
+## Workflow
+
+1. **Detect** — Run the status check, present what is present and what is missing
+2. **Install** — Ask per missing tool, install it
+3. **Sign in** — Sign the Power Platform CLI and Azure CLI in
+4. **Summarize** — Re-check, report, point at the next step
+
+## Task Tracking
+
+Create all four tasks at the start of Phase 1. Mark each `in_progress` when starting, `completed` when done.
+
+| Task subject | activeForm | Description |
+|---|---|---|
+| Detect prerequisites | Detecting prerequisites | Run detect-prerequisites.js and present the status |
+| Install missing tools | Installing missing tools | Install each approved tool, one at a time |
+| Sign in to the CLIs | Signing in | Run pac auth create and az login where needed |
+| Summarize setup | Summarizing setup | Re-check status and report what is left |
+
+---
+
+## 1. Detect
+
+```bash
+node "${PLUGIN_ROOT}/skills/setup-prerequisites/scripts/detect-prerequisites.js"
+```
+
+The script exits `1` when anything needs attention — that is a report, not a failure. Read the JSON on stdout:
+
+| Field | Meaning |
+|---|---|
+| `node`, `dotnet`, `pac`, `az` | `available` plus the detected `version` |
+| `pac.updateAvailable` | A newer PAC CLI is published on NuGet (`pac.latestVersion`) |
+| `pacAuth`, `azAuth` | `signedIn`, plus `tenantId` and `user` when signed in |
+| `tenantMismatch` | Non-null when the two CLIs are signed into different tenants |
+| `actions` | What needs doing, as `{ tool, kind }` where `kind` is `install`, `update`, or `signin` |
+| `ready` | True when `actions` is empty |
+
+Add `--no-update-check` to skip the NuGet lookup when the machine is offline or behind a proxy that blocks it.
+
+Present the status as a short plain-language table — tool, version, and whether it is ready. If `ready` is true and there is no `tenantMismatch`, tell the user they are set up and skip to Phase 4.
+
+**Node.js** is always reported as available, because this script runs under Node. If the user reached this skill with no Node at all, no script here can run — point them at <https://nodejs.org/> and stop.
+
+---
+
+## 2. Install
+
+Work through `actions` in order, one tool per `AskUserQuestion`. Combining them into a single prompt hides which install the user is approving.
+
+<!-- gate: setup-prerequisites:2.install-consent | category=consent | cancel-leaves=nothing -->
+
+> 🚦 **Gate (consent · setup-prerequisites:2.install-consent):** Ask before installing each tool. One prompt per tool, naming the tool and the exact command.
+>
+> **Trigger:** Phase 2, once per entry in `actions` with `kind` of `install` or `update`.
+> **Why we ask:** An install writes to the machine outside the project, can need elevation, and can take several minutes. The user may also prefer their own package manager or a company-managed build.
+> **Cancel leaves:** Nothing — the tool stays as it was, and the run continues with the next tool.
+
+For each prompt, show the command that will run. Get it from the script rather than writing it out from memory, passing the same flags the real run will use — for a `kind` of `update`, that means `--update` on both calls, because the resolved command differs (`dotnet tool update` rather than `dotnet tool install`):
+
+```bash
+node "${PLUGIN_ROOT}/skills/setup-prerequisites/scripts/install-prerequisite.js" --tool <dotnet|pac|az> [--update] --dry-run
+```
+
+On approval, run the same command without `--dry-run`:
+
+```bash
+node "${PLUGIN_ROOT}/skills/setup-prerequisites/scripts/install-prerequisite.js" --tool <dotnet|pac|az> [--update]
+```
+
+The script streams installer output to the terminal and ends with a JSON line:
+
+| `status` | What it means | What to do |
+|---|---|---|
+| `installed` | The install succeeded | Note that a terminal restart may be needed, move to the next tool |
+| `unsupported` | No automated path on this platform | Show the `manual` commands, record it for the summary, move on |
+| `failed` | The installer ran and failed | Show the exit code and the `manual` commands, record it, move on |
+
+**Order matters, and a fresh .NET SDK does not help until the terminal restarts.** `pac` installs as a .NET global tool, so a PAC install with no SDK on PATH resolves to `unsupported`. Installing the SDK in this session does not change that: the installer writes PATH for future processes, while every script here runs under a shell that started earlier. So when both `dotnet` and `pac` are in `actions`:
+
+1. Offer the .NET SDK install first.
+2. Expect the PAC install to come back `unsupported` — that is the stale-PATH case, not a platform limitation.
+3. Tell the user to restart the terminal and re-run `/setup-prerequisites`, which will then find the SDK and install PAC.
+
+Do not present that `unsupported` result as a failure of their machine or their platform.
+
+**Never stop the run on a failure.** Every failed or unsupported install is carried into Phase 4.
+
+---
+
+## 3. Sign in
+
+Sign-in is interactive: it opens a browser and waits for the user. Run each command in the foreground, one at a time.
+
+<!-- gate: setup-prerequisites:3.signin-consent | category=consent | cancel-leaves=nothing -->
+
+> 🚦 **Gate (consent · setup-prerequisites:3.signin-consent):** Ask before starting each CLI sign-in.
+>
+> **Trigger:** Phase 3, once per entry in `actions` with `kind` of `signin`, and again after any install that added a CLI.
+> **Why we ask:** Sign-in opens a browser, hands credentials to a CLI, and stores a profile on the machine. The user may want to pick a different account or tenant than the one they are signed into elsewhere.
+> **Cancel leaves:** Nothing — no profile is created, and the summary lists the sign-in as still outstanding.
+
+**Power Platform CLI:**
+
+```bash
+pac auth create
+```
+
+**Azure CLI:**
+
+```bash
+az login
+```
+
+If `az login` fails because the account has no Azure subscription, retry with `az login --allow-no-subscriptions`. That variant lets subscription-less accounts sign in and still mint the tokens the plugin's scripts need. It is valid on `az login` only.
+
+### Tenant mismatch
+
+When `tenantMismatch` is non-null, tell the user which tenant each CLI is signed into and that the plugin's skills use both against the same environment, so mismatched tenants surface later as permission errors. Offer to re-run the sign-in for whichever CLI is on the wrong tenant. This is a warning, not a blocker — the user may have a reason.
+
+---
+
+## 4. Summarize
+
+### 4.1 Re-check
+
+```bash
+node "${PLUGIN_ROOT}/skills/setup-prerequisites/scripts/detect-prerequisites.js" --no-update-check
+```
+
+Skip the update check here — it was already done in Phase 1, and the second call is about confirming the installs landed.
+
+If a tool the user just installed still reports missing, that is the PATH-refresh case, not a failed install. Say so and ask them to restart the terminal and re-run this skill.
+
+### 4.2 Report
+
+Present a final table of every prerequisite with its state, then:
+
+- **Everything ready** — say so and move to 4.3.
+- **Anything outstanding** — list each gap with the exact command to run by hand, taken from the `manual` array of the failing install. Include failures the user declined, so nothing is silently dropped.
+
+### 4.3 Record skill usage
+
+> Reference: `${PLUGIN_ROOT}/references/skill-tracking-reference.md`
+>
+> Use `--skillName "SetupPrerequisites"`. This skill often runs outside a project; the tracking script exits silently when there is no site directory, so call it unconditionally with the current directory as `--projectRoot`.
+
+### 4.4 Next step
+
+Point at what the user came here to do:
+
+- No project yet → `/create-site`
+- An existing project → the skill they were blocked on
+- Not sure → `/create-site` to scaffold a site
+
+---
+
+## Constraints
+
+- **Plain language** — Say "the Power Platform command-line tool" before "pac", "the Azure command-line tool" before "az". Do not assume the user knows what a .NET global tool, a package manager, or PATH is; explain in a sentence when it matters.
+- **One install per approval** — Every install runs against its own `AskUserQuestion`. Never batch approvals or infer consent for a second tool from the first.
+- **Report, do not abandon** — A failed install, an unsupported platform, or a declined prompt moves to the next item and lands in the final summary.
+- **Never print a token** — `pac auth create` and `az login` handle their own credentials. Do not run token commands, and never echo a token, secret, or password.
+- **Stop at sign-in** — Do not select a Dataverse environment, create a profile against a specific org, or run any project-changing command.

--- a/plugins/power-pages/skills/setup-prerequisites/SKILL.md
+++ b/plugins/power-pages/skills/setup-prerequisites/SKILL.md
@@ -2,8 +2,8 @@
 name: setup-prerequisites
 description: >-
   Gets a machine ready to use the power-pages plugin — checks Node.js, Git, the
-  .NET SDK, the Power Platform CLI (pac), and the Azure CLI (az), installs
-  whatever is missing, and signs both CLIs in.
+  .NET SDK, the Power Platform CLI (pac), the Azure CLI (az), and the GitHub CLI
+  (gh), installs whatever is missing, and signs the CLIs in.
 user-invocable: true
 disable-model-invocation: true
 argument-hint: "[optional: check | install]"
@@ -15,7 +15,7 @@ model: sonnet
 
 # Setup Prerequisites
 
-Check every tool the power-pages skills depend on — Node.js, Git, the .NET SDK, the Power Platform CLI, and the Azure CLI — install what is missing, and sign the Power Platform CLI and Azure CLI in.
+Check every tool the power-pages skills depend on — Node.js, Git, the .NET SDK, the Power Platform CLI, and the Azure CLI, plus the optional GitHub CLI — install what is missing, and sign the CLIs in.
 
 **Initial request:** $ARGUMENTS
 
@@ -29,13 +29,14 @@ Installing the plugin from the marketplace copies skill files and nothing else, 
 - **Linux has no automated path** for Git, the .NET SDK, and the Azure CLI. Detection still works; the install step hands back commands.
 - **`--allow-no-subscriptions` is only valid on `az login`.** Never add it to `az account show` or any other `az` subcommand — they reject it as an unrecognized argument.
 - **A failed install is not the end of the run.** Report it, keep going with the remaining tools, and collect every failure into the final summary.
+- **The GitHub CLI is optional.** Only `/report-issue` uses it, so a missing `gh` is offered but never holds back the ready verdict.
 - **Environment selection is out of scope.** This skill stops once the CLIs are installed and signed in. Choosing a Dataverse environment belongs to the skill that needs one.
 
 ## Workflow
 
 1. **Detect** — Run the status check, present what is present and what is missing
 2. **Install** — Ask per missing tool, install it
-3. **Sign in** — Sign the Power Platform CLI and Azure CLI in
+3. **Sign in** — Sign the Power Platform CLI and Azure CLI in, and the GitHub CLI when present
 4. **Summarize** — Re-check, report, point at the next step
 
 ## Task Tracking
@@ -57,20 +58,22 @@ Create all four tasks at the start of Phase 1. Mark each `in_progress` when star
 node "${PLUGIN_ROOT}/skills/setup-prerequisites/scripts/detect-prerequisites.js"
 ```
 
-The script exits `1` when anything needs attention — that is a report, not a failure. Read the JSON on stdout:
+The script exits `1` when something required needs attention, and `0` when only optional items are left — either way that is a report, not a failure. Read the JSON on stdout:
 
 | Field | Meaning |
 |---|---|
-| `node`, `git`, `dotnet`, `pac`, `az` | `available` plus the detected `version` |
+| `node`, `git`, `dotnet`, `pac`, `az`, `gh` | `available` plus the detected `version` |
 | `pac.updateAvailable` | A newer PAC CLI is published on NuGet (`pac.latestVersion`) |
-| `pacAuth`, `azAuth` | `signedIn`, plus `tenantId` and `user` when signed in |
+| `pacAuth`, `azAuth`, `ghAuth` | `signedIn`, plus the account details when signed in |
 | `tenantMismatch` | Non-null when the two CLIs are signed into different tenants |
 | `actions` | What needs doing, as `{ tool, kind }` where `kind` is `install`, `update`, or `signin` |
-| `ready` | True when `actions` is empty |
+| `ready` | True when nothing required is outstanding |
 
 Add `--no-update-check` to skip the NuGet lookup when the machine is offline or behind a proxy that blocks it.
 
-Present the status as a short plain-language table — tool, version, and whether it is ready. If `ready` is true and there is no `tenantMismatch`, tell the user they are set up and skip to Phase 4.
+Present the status as a short plain-language table — tool, version, and whether it is ready. If `ready` is true and there is no `tenantMismatch`, tell the user they are set up. Mention any optional action still open, then skip to Phase 4.
+
+**Optional actions.** An action carrying `optional: true` is offered like any other but never withholds the ready verdict. The GitHub CLI is the only one today: just `/report-issue` uses it, so a user without it is still set up for everything else. Say what it unlocks rather than presenting it as a gap.
 
 **Node.js** is always reported as available, because this script runs under Node. If the user reached this skill with no Node at all, no script here can run — point them at <https://nodejs.org/> and stop.
 
@@ -91,13 +94,13 @@ Work through `actions` in order, one tool per `AskUserQuestion`. Combining them 
 For each prompt, show the command that will run. Get it from the script rather than writing it out from memory, passing the same flags the real run will use — for a `kind` of `update`, that means `--update` on both calls, because the resolved command differs (`dotnet tool update` rather than `dotnet tool install`):
 
 ```bash
-node "${PLUGIN_ROOT}/skills/setup-prerequisites/scripts/install-prerequisite.js" --tool <git|dotnet|pac|az> [--update] --dry-run
+node "${PLUGIN_ROOT}/skills/setup-prerequisites/scripts/install-prerequisite.js" --tool <git|dotnet|pac|az|gh> [--update] --dry-run
 ```
 
 On approval, run the same command without `--dry-run`:
 
 ```bash
-node "${PLUGIN_ROOT}/skills/setup-prerequisites/scripts/install-prerequisite.js" --tool <git|dotnet|pac|az> [--update]
+node "${PLUGIN_ROOT}/skills/setup-prerequisites/scripts/install-prerequisite.js" --tool <git|dotnet|pac|az|gh> [--update]
 ```
 
 The script streams installer output to the terminal and ends with a JSON line:
@@ -115,6 +118,8 @@ The script streams installer output to the terminal and ends with a JSON line:
 3. Tell the user to restart the terminal and re-run `/setup-prerequisites`, which will then find the SDK and install PAC.
 
 Do not present that `unsupported` result as a failure of their machine or their platform.
+
+**Optional tools are offered last and framed as a choice.** Ask for the GitHub CLI after the required tools, and say what it buys — it is what `/report-issue` uses to file a bug. Declining it leaves a working setup.
 
 **Never stop the run on a failure.** Every failed or unsupported install is carried into Phase 4.
 
@@ -146,6 +151,12 @@ az login
 
 If `az login` fails because the account has no Azure subscription, retry with `az login --allow-no-subscriptions`. That variant lets subscription-less accounts sign in and still mint the tokens the plugin's scripts need. It is valid on `az login` only.
 
+**GitHub CLI** (optional — only `/report-issue` needs it):
+
+```bash
+gh auth login
+```
+
 ### Tenant mismatch
 
 When `tenantMismatch` is non-null, tell the user which tenant each CLI is signed into and that the plugin's skills use both against the same environment, so mismatched tenants surface later as permission errors. Offer to re-run the sign-in for whichever CLI is on the wrong tenant. This is a warning, not a blocker — the user may have a reason.
@@ -169,7 +180,8 @@ If a tool the user just installed still reports missing, that is the PATH-refres
 Present a final table of every prerequisite with its state, then:
 
 - **Everything ready** — say so and move to 4.3.
-- **Anything outstanding** — list each gap with the exact command to run by hand, taken from the `manual` array of the failing install. Include failures the user declined, so nothing is silently dropped.
+- **Anything required outstanding** — list each gap with the exact command to run by hand, taken from the `manual` array of the failing install. Include failures the user declined, so nothing is silently dropped.
+- **Only optional items outstanding** — the setup is complete. Note what is missing and what it would unlock, in one line, without calling it a gap.
 
 ### 4.3 Record skill usage
 

--- a/plugins/power-pages/skills/setup-prerequisites/scripts/detect-prerequisites.js
+++ b/plugins/power-pages/skills/setup-prerequisites/scripts/detect-prerequisites.js
@@ -98,6 +98,21 @@ function parseAzVersion(output) {
 }
 
 /**
+ * Extracts the version from `git --version`, whose banner is:
+ *
+ *   git version 2.53.0
+ *
+ * The Apple-shipped build appends its own suffix:
+ *
+ *   git version 2.39.5 (Apple Git-154)
+ */
+function parseGitVersion(output) {
+  if (!output) return null;
+  const match = output.match(/git version\s+([0-9]+(?:\.[0-9]+)*)/i);
+  return match ? match[1] : null;
+}
+
+/**
  * Extracts the version from `dotnet --version`, which prints a bare version such
  * as `10.0.102` (or `9.0.100-preview.1.24101.2` on a preview SDK).
  */
@@ -237,6 +252,7 @@ function fetchLatestPacVersion() {
 function buildActions(status) {
   const actions = [];
   if (!status.node.available) actions.push({ tool: 'node', kind: 'install' });
+  if (!status.git.available) actions.push({ tool: 'git', kind: 'install' });
   if (!status.dotnet.available) actions.push({ tool: 'dotnet', kind: 'install' });
   if (!status.pac.available) actions.push({ tool: 'pac', kind: 'install' });
   else if (status.pac.updateAvailable) actions.push({ tool: 'pac', kind: 'update' });
@@ -281,6 +297,7 @@ Exit codes:
   const checkUpdates = !process.argv.includes('--no-update-check');
 
   const nodeVersion = process.version.replace(/^v/, '');
+  const gitVersion = parseGitVersion(probe('git', ['--version']));
   const dotnetVersion = parseDotnetVersion(probe('dotnet', ['--version']));
   const pacVersion = parsePacVersion(probe('pac', ['help']));
   const azVersion = parseAzVersion(probe('az', ['version', '-o', 'tsv']));
@@ -297,6 +314,7 @@ Exit codes:
     // This script runs under Node, so Node is present by construction. It stays
     // in the report because the skill's summary lists every prerequisite.
     node: { available: true, version: nodeVersion },
+    git: { available: Boolean(gitVersion), version: gitVersion },
     dotnet: { available: Boolean(dotnetVersion), version: dotnetVersion },
     pac: {
       available: Boolean(pacVersion),
@@ -322,6 +340,7 @@ module.exports = {
   parsePacVersion,
   parseAzVersion,
   parseDotnetVersion,
+  parseGitVersion,
   parsePacAuthWho,
   parseAzAccountShow,
   compareVersions,

--- a/plugins/power-pages/skills/setup-prerequisites/scripts/detect-prerequisites.js
+++ b/plugins/power-pages/skills/setup-prerequisites/scripts/detect-prerequisites.js
@@ -1,0 +1,335 @@
+#!/usr/bin/env node
+
+/**
+ * detect-prerequisites.js — Reports which Power Pages plugin prerequisites are
+ * present on this machine, at what version, and whether the PAC CLI and Azure
+ * CLI are signed in.
+ *
+ * The `/setup-prerequisites` skill consumes the JSON on stdout to decide what to
+ * offer the user. All probing is read-only — nothing here installs or signs in.
+ *
+ * Usage:
+ *   node detect-prerequisites.js [--no-update-check]
+ *
+ * Exit codes:
+ *   0  Everything the plugin needs is present and signed in
+ *   1  At least one item needs action (missing tool, signed out, or an update)
+ *
+ * Pure parsers are exported so the tests can assert against captured CLI banners
+ * without spawning the real tools.
+ */
+
+'use strict';
+
+const { execFileSync } = require('child_process');
+const https = require('https');
+
+// NuGet's flat-container index for the PAC CLI dotnet tool. The `versions` array
+// is ascending, so the last stable entry is the newest published version.
+// See: https://learn.microsoft.com/nuget/api/package-base-address-resource
+const PAC_NUGET_INDEX =
+  'https://api.nuget.org/v3-flatcontainer/microsoft.powerapps.cli.tool/index.json';
+
+// `pac help` cold-starts the .NET runtime, which can take several seconds on a
+// first run (Windows Defender scan, NGen warm-up), so the probes get a generous
+// timeout rather than reporting a slow tool as missing.
+const PROBE_TIMEOUT_MS = 60000;
+
+/**
+ * Builds the invocation used to probe a tool.
+ *
+ * On Windows, some Microsoft CLIs ship only as a batch shim rather than an
+ * `.exe` — the Azure CLI installs `az.cmd` (plus `az.ps1`) and no `az.exe` at
+ * all. Node refuses to spawn a `.bat`/`.cmd` file without a shell (it throws
+ * `EINVAL` since 18.20.2 / 20.12.2, and failed with CreateProcess error 193
+ * before that), so probing `az` directly reports an installed Azure CLI as
+ * missing. Routing every Windows probe through `cmd.exe /c` resolves the shim
+ * the same way a terminal would, while still passing arguments as an array so
+ * nothing is concatenated into a shell command string.
+ *
+ * See: https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2
+ */
+function buildProbeInvocation(command, args, platform = process.platform) {
+  if (platform === 'win32') return { file: 'cmd.exe', args: ['/c', command, ...args] };
+  return { file: command, args };
+}
+
+/**
+ * Runs a command and returns its stdout, or null when the command is missing or
+ * fails. Arguments are passed as an array, never as a shell command string.
+ */
+function probe(command, args, { timeout = PROBE_TIMEOUT_MS } = {}) {
+  const invocation = buildProbeInvocation(command, args);
+  try {
+    return execFileSync(invocation.file, invocation.args, {
+      encoding: 'utf8',
+      timeout,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Extracts the version from `pac help`, whose banner looks like:
+ *
+ *   Microsoft PowerPlatform CLI
+ *   Version: 1.51.1+g8a2ec33
+ *
+ * The `+<git-sha>` build-metadata suffix is dropped so the value compares
+ * cleanly against the plain semver NuGet publishes.
+ */
+function parsePacVersion(output) {
+  if (!output) return null;
+  const match = output.match(/Version:\s*([0-9]+(?:\.[0-9]+)*)/i);
+  return match ? match[1] : null;
+}
+
+/**
+ * Extracts the version from `az version -o tsv`, a tab-separated line:
+ *
+ *   2.77.0\t2.77.0\t...
+ */
+function parseAzVersion(output) {
+  if (!output) return null;
+  const match = output.match(/([0-9]+\.[0-9]+\.[0-9]+)/);
+  return match ? match[1] : null;
+}
+
+/**
+ * Extracts the version from `dotnet --version`, which prints a bare version such
+ * as `10.0.102` (or `9.0.100-preview.1.24101.2` on a preview SDK).
+ */
+function parseDotnetVersion(output) {
+  if (!output) return null;
+  const match = output.match(/([0-9]+\.[0-9]+\.[0-9]+[0-9A-Za-z.\-]*)/);
+  return match ? match[1] : null;
+}
+
+/**
+ * Parses the `pac auth who` banner, a label/value block. Captured from 2.9.3:
+ *
+ *   Connected as user@contoso.com
+ *
+ *   Type:                       User
+ *   Cloud:                      Public
+ *   Tenant Id:                  00000000-0000-0000-0000-000000000000
+ *   User:                       user@contoso.com
+ *   Environment Id:             11111111-1111-1111-1111-111111111111
+ *   Organization Friendly Name: Contoso Dev
+ *
+ * PAC has shipped both "Tenant Id" and "Tenant ID" casing across versions, so
+ * the match is case-insensitive. When no profile is selected, PAC prints an
+ * error instead ("No profiles were found on this computer") and this returns the
+ * signed-out shape. Values can contain their own ':' (URLs, timestamps), so each
+ * pattern stops at the first colon after the label and takes the rest of the line.
+ */
+function parsePacAuthWho(output) {
+  const signedOut = { signedIn: false, tenantId: null, user: null, cloud: null };
+  if (!output) return signedOut;
+  if (/no profiles were found/i.test(output)) return signedOut;
+
+  // `label` is always a fixed, code-controlled string below, so interpolating it
+  // into the pattern is safe. Escape it first if it ever comes from input.
+  const field = (label) => {
+    const match = output.match(new RegExp(`^\\s*${label}\\s*:\\s*(\\S.*?)\\s*$`, 'im'));
+    return match ? match[1] : null;
+  };
+
+  const tenantId = field('Tenant Id');
+  const user = field('User');
+
+  if (!tenantId && !user) return signedOut;
+  return { signedIn: true, tenantId, user, cloud: field('Cloud') };
+}
+
+/**
+ * Parses `az account show -o json`:
+ *
+ *   { "tenantId": "...", "user": { "name": "user@contoso.com" }, "name": "Sub" }
+ *
+ * A signed-out Azure CLI exits non-zero and prints "Please run 'az login'", so
+ * the caller passes null and this returns the signed-out shape. An account with
+ * no subscription can still be signed in, so a missing subscription name is not
+ * treated as a sign-out signal.
+ */
+function parseAzAccountShow(output) {
+  const signedOut = { signedIn: false, tenantId: null, user: null, subscription: null };
+  if (!output) return signedOut;
+  let parsed;
+  try {
+    parsed = JSON.parse(output);
+  } catch {
+    return signedOut;
+  }
+  if (!parsed || typeof parsed !== 'object') return signedOut;
+  if (!parsed.tenantId && !(parsed.user && parsed.user.name)) return signedOut;
+  return {
+    signedIn: true,
+    tenantId: parsed.tenantId || null,
+    user: parsed.user && parsed.user.name ? parsed.user.name : null,
+    subscription: parsed.name || null,
+  };
+}
+
+/**
+ * Compares two dotted version strings. Returns 1 when `b` is newer, -1 when `a`
+ * is newer, 0 when equal. Prerelease suffixes are ignored — a `-preview` build
+ * compares as its numeric base, which is good enough for "is an update
+ * available?" and avoids nagging preview users on every run.
+ */
+function compareVersions(a, b) {
+  if (!a || !b) return 0;
+  const parts = (v) => v.split('-')[0].split('.').map((n) => Number(n) || 0);
+  const pa = parts(a);
+  const pb = parts(b);
+  const length = Math.max(pa.length, pb.length);
+  for (let i = 0; i < length; i++) {
+    if ((pb[i] || 0) > (pa[i] || 0)) return 1;
+    if ((pb[i] || 0) < (pa[i] || 0)) return -1;
+  }
+  return 0;
+}
+
+/** Picks the newest stable version from NuGet's ascending `versions` array. */
+function latestStableVersion(versions) {
+  if (!Array.isArray(versions)) return null;
+  const stable = versions.filter((v) => typeof v === 'string' && !v.includes('-'));
+  return stable.length ? stable[stable.length - 1] : null;
+}
+
+/** Fetches the newest published PAC CLI version, or null on any network error. */
+function fetchLatestPacVersion() {
+  return new Promise((resolve) => {
+    const request = https.get(PAC_NUGET_INDEX, { timeout: 10000 }, (res) => {
+      if (res.statusCode !== 200) {
+        res.resume();
+        resolve(null);
+        return;
+      }
+      let body = '';
+      res.on('data', (chunk) => {
+        body += chunk;
+      });
+      res.on('end', () => {
+        try {
+          resolve(latestStableVersion(JSON.parse(body).versions));
+        } catch {
+          resolve(null);
+        }
+      });
+    });
+    // An update check must never hold up or fail the skill, so every failure
+    // path — DNS, proxy, offline, malformed body — resolves to null.
+    request.on('error', () => resolve(null));
+    request.on('timeout', () => {
+      request.destroy();
+      resolve(null);
+    });
+  });
+}
+
+/**
+ * Turns a raw status map into the action list the skill works through. Each
+ * action names the tool the workflow passes to `install-prerequisite.js`.
+ */
+function buildActions(status) {
+  const actions = [];
+  if (!status.node.available) actions.push({ tool: 'node', kind: 'install' });
+  if (!status.dotnet.available) actions.push({ tool: 'dotnet', kind: 'install' });
+  if (!status.pac.available) actions.push({ tool: 'pac', kind: 'install' });
+  else if (status.pac.updateAvailable) actions.push({ tool: 'pac', kind: 'update' });
+  if (!status.az.available) actions.push({ tool: 'az', kind: 'install' });
+  // Sign-in is only actionable once the CLI itself exists; a missing CLI already
+  // has an install action and would otherwise produce two entries for one gap.
+  if (status.pac.available && !status.pacAuth.signedIn) actions.push({ tool: 'pac', kind: 'signin' });
+  if (status.az.available && !status.azAuth.signedIn) actions.push({ tool: 'az', kind: 'signin' });
+  return actions;
+}
+
+/**
+ * Flags a PAC/Azure tenant mismatch. Both CLIs mint tokens the plugin's scripts
+ * use against the same environment, so signing them into different tenants
+ * surfaces as confusing 401/403s rather than an obvious error.
+ */
+function tenantMismatch(pacAuth, azAuth) {
+  if (!pacAuth.signedIn || !azAuth.signedIn) return null;
+  if (!pacAuth.tenantId || !azAuth.tenantId) return null;
+  if (pacAuth.tenantId.toLowerCase() === azAuth.tenantId.toLowerCase()) return null;
+  return { pacTenantId: pacAuth.tenantId, azTenantId: azAuth.tenantId };
+}
+
+async function main() {
+  if (process.argv.includes('--help')) {
+    process.stdout.write(
+      `detect-prerequisites.js — Reports Power Pages plugin prerequisite status as JSON.
+
+Usage:
+  node detect-prerequisites.js [--no-update-check]
+
+  --no-update-check   Skip the NuGet lookup for a newer PAC CLI version.
+
+Exit codes:
+  0  Ready — every tool present and both CLIs signed in
+  1  Action needed — see the "actions" array in the JSON output
+`
+    );
+    process.exit(0);
+  }
+
+  const checkUpdates = !process.argv.includes('--no-update-check');
+
+  const nodeVersion = process.version.replace(/^v/, '');
+  const dotnetVersion = parseDotnetVersion(probe('dotnet', ['--version']));
+  const pacVersion = parsePacVersion(probe('pac', ['help']));
+  const azVersion = parseAzVersion(probe('az', ['version', '-o', 'tsv']));
+
+  const pacAuth = parsePacAuthWho(pacVersion ? probe('pac', ['auth', 'who']) : null);
+  const azAuth = parseAzAccountShow(
+    azVersion ? probe('az', ['account', 'show', '-o', 'json']) : null
+  );
+
+  const latestPac = checkUpdates && pacVersion ? await fetchLatestPacVersion() : null;
+
+  const status = {
+    platform: process.platform,
+    // This script runs under Node, so Node is present by construction. It stays
+    // in the report because the skill's summary lists every prerequisite.
+    node: { available: true, version: nodeVersion },
+    dotnet: { available: Boolean(dotnetVersion), version: dotnetVersion },
+    pac: {
+      available: Boolean(pacVersion),
+      version: pacVersion,
+      latestVersion: latestPac,
+      updateAvailable: Boolean(latestPac && compareVersions(pacVersion, latestPac) === 1),
+    },
+    az: { available: Boolean(azVersion), version: azVersion },
+    pacAuth,
+    azAuth,
+  };
+
+  status.tenantMismatch = tenantMismatch(pacAuth, azAuth);
+  status.actions = buildActions(status);
+  status.ready = status.actions.length === 0;
+
+  process.stdout.write(JSON.stringify(status, null, 2) + '\n');
+  process.exit(status.ready ? 0 : 1);
+}
+
+module.exports = {
+  buildProbeInvocation,
+  parsePacVersion,
+  parseAzVersion,
+  parseDotnetVersion,
+  parsePacAuthWho,
+  parseAzAccountShow,
+  compareVersions,
+  latestStableVersion,
+  buildActions,
+  tenantMismatch,
+};
+
+if (require.main === module) {
+  main();
+}

--- a/plugins/power-pages/skills/setup-prerequisites/scripts/detect-prerequisites.js
+++ b/plugins/power-pages/skills/setup-prerequisites/scripts/detect-prerequisites.js
@@ -21,7 +21,7 @@
 
 'use strict';
 
-const { execFileSync } = require('child_process');
+const { spawnSync } = require('child_process');
 const https = require('https');
 
 // NuGet's flat-container index for the PAC CLI dotnet tool. The `versions` array
@@ -55,20 +55,36 @@ function buildProbeInvocation(command, args, platform = process.platform) {
 }
 
 /**
- * Runs a command and returns its stdout, or null when the command is missing or
- * fails. Arguments are passed as an array, never as a shell command string.
+ * Runs a command and returns its output, or null when the command is missing,
+ * fails, or times out. Arguments are passed as an array, never as a shell
+ * command string.
+ *
+ * @param {object} [options]
+ * @param {boolean} [options.mergeStderr]  Append stderr to stdout. Needed for
+ *   CLIs that report on stderr rather than stdout (`gh auth status` writes its
+ *   whole report there), where reading stdout alone yields an empty string.
+ * @param {boolean} [options.acceptNonZeroExit]  Return the output even when the
+ *   command exits non-zero. Needed where a non-zero exit does not mean "no
+ *   answer" — see the `gh auth status` note in `parseGhAuthStatus`.
  */
-function probe(command, args, { timeout = PROBE_TIMEOUT_MS } = {}) {
+function probe(
+  command,
+  args,
+  { timeout = PROBE_TIMEOUT_MS, mergeStderr = false, acceptNonZeroExit = false } = {}
+) {
   const invocation = buildProbeInvocation(command, args);
-  try {
-    return execFileSync(invocation.file, invocation.args, {
-      encoding: 'utf8',
-      timeout,
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
-  } catch {
-    return null;
-  }
+  const result = spawnSync(invocation.file, invocation.args, {
+    encoding: 'utf8',
+    timeout,
+    shell: false,
+  });
+  // `error` means the binary is missing or could not be spawned — never an
+  // answer. A non-zero exit usually means the question came back negative
+  // (signed out, no profile), unless the caller says otherwise.
+  if (result.error) return null;
+  if (result.status !== 0 && !acceptNonZeroExit) return null;
+  const stdout = result.stdout || '';
+  return mergeStderr ? stdout + (result.stderr || '') : stdout;
 }
 
 /**
@@ -110,6 +126,66 @@ function parseGitVersion(output) {
   if (!output) return null;
   const match = output.match(/git version\s+([0-9]+(?:\.[0-9]+)*)/i);
   return match ? match[1] : null;
+}
+
+/**
+ * Extracts the version from `gh --version`, which prints two lines:
+ *
+ *   gh version 2.96.0 (2026-07-02)
+ *   https://github.com/cli/cli/releases/tag/v2.96.0
+ *
+ * The trailing release URL also carries a version-shaped substring, so the
+ * pattern anchors on the "gh version" prefix rather than matching any digits.
+ */
+function parseGhVersion(output) {
+  if (!output) return null;
+  const match = output.match(/gh version\s+([0-9]+(?:\.[0-9]+)*)/i);
+  return match ? match[1] : null;
+}
+
+/**
+ * Reads sign-in state out of `gh auth status`. The report goes to **stderr**,
+ * groups accounts per host, and looks like this (captured from gh 2.96.0, with
+ * a second host configured):
+ *
+ *   github.com
+ *     ✓ Logged in to github.com account octocat (GH_TOKEN)
+ *     - Active account: true
+ *     - Token scopes: 'gist', 'repo', 'workflow'
+ *
+ *   contoso.ghe.com
+ *     X Failed to log in to contoso.ghe.com using token (GH_TOKEN)
+ *     - The token in GH_TOKEN is invalid.
+ *
+ * Two quirks drive this parser:
+ *
+ * 1. **A partial failure exits 1.** That run above exits non-zero purely because
+ *    the enterprise host is broken, even though github.com is authenticated. So
+ *    the caller must pass `acceptNonZeroExit` and let this function judge, or a
+ *    signed-in user is reported as signed out.
+ * 2. **The failure line is not the negation of the success line.** Failures read
+ *    "Failed to log in to", successes "Logged in to" — close enough to match the
+ *    same loose pattern, so this anchors on the "Logged in to <host> account"
+ *    shape rather than a bare "logged in" substring.
+ *
+ * `/report-issue` files against github.com, so that is the host that counts: an
+ * enterprise-only login does not let `gh issue create --repo microsoft/...`
+ * work, and reporting it as signed in would push the failure to issue-creation
+ * time. Signed out prints "You are not logged into any GitHub hosts", which
+ * matches nothing here.
+ */
+function parseGhAuthStatus(output) {
+  const signedOut = { signedIn: false, account: null };
+  if (!output) return signedOut;
+
+  // Older gh phrases the line "Logged in to github.com as octocat"; current
+  // builds use "account octocat". Accept both, and tolerate a missing name.
+  const pattern = /Logged in to (\S+)(?: (?:account|as) (\S+))?/gi;
+  const logins = [...output.matchAll(pattern)].map((m) => ({ host: m[1], account: m[2] || null }));
+
+  const github = logins.find((l) => l.host.toLowerCase() === 'github.com');
+  if (!github) return signedOut;
+  return { signedIn: true, account: github.account };
 }
 
 /**
@@ -248,6 +324,11 @@ function fetchLatestPacVersion() {
 /**
  * Turns a raw status map into the action list the skill works through. Each
  * action names the tool the workflow passes to `install-prerequisite.js`.
+ *
+ * Actions carrying `optional: true` are offered but never withhold the ready
+ * verdict. Only the GitHub CLI is optional today: exactly one skill uses it
+ * (`/report-issue`), so telling a user with a working Power Pages setup that
+ * they are not ready would be noise.
  */
 function buildActions(status) {
   const actions = [];
@@ -257,10 +338,14 @@ function buildActions(status) {
   if (!status.pac.available) actions.push({ tool: 'pac', kind: 'install' });
   else if (status.pac.updateAvailable) actions.push({ tool: 'pac', kind: 'update' });
   if (!status.az.available) actions.push({ tool: 'az', kind: 'install' });
+  if (!status.gh.available) actions.push({ tool: 'gh', kind: 'install', optional: true });
   // Sign-in is only actionable once the CLI itself exists; a missing CLI already
   // has an install action and would otherwise produce two entries for one gap.
   if (status.pac.available && !status.pacAuth.signedIn) actions.push({ tool: 'pac', kind: 'signin' });
   if (status.az.available && !status.azAuth.signedIn) actions.push({ tool: 'az', kind: 'signin' });
+  if (status.gh.available && !status.ghAuth.signedIn) {
+    actions.push({ tool: 'gh', kind: 'signin', optional: true });
+  }
   return actions;
 }
 
@@ -287,8 +372,11 @@ Usage:
   --no-update-check   Skip the NuGet lookup for a newer PAC CLI version.
 
 Exit codes:
-  0  Ready — every tool present and both CLIs signed in
+  0  Ready — every required tool present and both required CLIs signed in
   1  Action needed — see the "actions" array in the JSON output
+
+Actions marked "optional" (the GitHub CLI, used only by /report-issue)
+are reported but never withhold the ready verdict.
 `
     );
     process.exit(0);
@@ -301,10 +389,17 @@ Exit codes:
   const dotnetVersion = parseDotnetVersion(probe('dotnet', ['--version']));
   const pacVersion = parsePacVersion(probe('pac', ['help']));
   const azVersion = parseAzVersion(probe('az', ['version', '-o', 'tsv']));
+  const ghVersion = parseGhVersion(probe('gh', ['--version']));
 
   const pacAuth = parsePacAuthWho(pacVersion ? probe('pac', ['auth', 'who']) : null);
   const azAuth = parseAzAccountShow(
     azVersion ? probe('az', ['account', 'show', '-o', 'json']) : null
+  );
+  // `gh auth status` writes its report to stderr and exits non-zero when any
+  // configured host fails, so read both streams and keep the output regardless
+  // of exit code — see parseGhAuthStatus for why.
+  const ghAuth = parseGhAuthStatus(
+    ghVersion ? probe('gh', ['auth', 'status'], { mergeStderr: true, acceptNonZeroExit: true }) : null
   );
 
   const latestPac = checkUpdates && pacVersion ? await fetchLatestPacVersion() : null;
@@ -323,13 +418,18 @@ Exit codes:
       updateAvailable: Boolean(latestPac && compareVersions(pacVersion, latestPac) === 1),
     },
     az: { available: Boolean(azVersion), version: azVersion },
+    // Optional: only /report-issue uses the GitHub CLI.
+    gh: { available: Boolean(ghVersion), version: ghVersion, optional: true },
     pacAuth,
     azAuth,
+    ghAuth,
   };
 
   status.tenantMismatch = tenantMismatch(pacAuth, azAuth);
   status.actions = buildActions(status);
-  status.ready = status.actions.length === 0;
+  // Optional actions are reported but do not withhold the ready verdict, so a
+  // user with a working Power Pages setup and no GitHub CLI still reads as ready.
+  status.ready = status.actions.every((a) => a.optional === true);
 
   process.stdout.write(JSON.stringify(status, null, 2) + '\n');
   process.exit(status.ready ? 0 : 1);
@@ -341,6 +441,8 @@ module.exports = {
   parseAzVersion,
   parseDotnetVersion,
   parseGitVersion,
+  parseGhVersion,
+  parseGhAuthStatus,
   parsePacAuthWho,
   parseAzAccountShow,
   compareVersions,

--- a/plugins/power-pages/skills/setup-prerequisites/scripts/install-prerequisite.js
+++ b/plugins/power-pages/skills/setup-prerequisites/scripts/install-prerequisite.js
@@ -1,0 +1,262 @@
+#!/usr/bin/env node
+
+/**
+ * install-prerequisite.js — Installs (or updates) one Power Pages plugin
+ * prerequisite using the package manager that fits the current platform.
+ *
+ * The `/setup-prerequisites` skill calls this once per tool, after the user has
+ * approved that specific install. Nothing here is chained or implicit: one
+ * invocation installs exactly one tool.
+ *
+ * Usage:
+ *   node install-prerequisite.js --tool <dotnet|pac|az> [--update] [--dry-run]
+ *
+ * Exit codes:
+ *   0  Installed, or a dry run printed the plan
+ *   1  No automated install path on this platform, or the install failed
+ *
+ * `resolveInstallPlan` is pure and exported so the tests can assert the plan for
+ * every platform without a package manager present.
+ */
+
+'use strict';
+
+const { execFileSync, spawnSync } = require('child_process');
+
+const TOOLS = ['dotnet', 'pac', 'az'];
+
+// Winget package identifiers, verified against the microsoft/winget-pkgs
+// manifests at manifests/m/Microsoft/DotNet/SDK/10 and manifests/m/Microsoft/AzureCLI.
+const WINGET_DOTNET_SDK_ID = 'Microsoft.DotNet.SDK.10';
+const WINGET_AZURE_CLI_ID = 'Microsoft.AzureCLI';
+
+// Non-interactive winget flags. Without the agreement flags winget stops on a
+// prompt that never gets an answer when it runs from a skill.
+const WINGET_FLAGS = [
+  '-e',
+  '--accept-source-agreements',
+  '--accept-package-agreements',
+  '--disable-interactivity',
+];
+
+// The PAC CLI ships as a .NET global tool. It is the only prerequisite whose
+// install path is the same on every platform.
+// See: https://learn.microsoft.com/power-platform/developer/cli/introduction
+const PAC_NUGET_PACKAGE = 'Microsoft.PowerApps.CLI.Tool';
+
+const MANUAL_INSTRUCTIONS = {
+  dotnet: [
+    'Windows (winget)   winget install -e --id Microsoft.DotNet.SDK.10',
+    'macOS (Homebrew)   brew install --cask dotnet-sdk',
+    'Any platform       https://aka.ms/dotnet/download',
+  ],
+  pac: [
+    'Any platform       dotnet tool install --global Microsoft.PowerApps.CLI.Tool',
+    'Docs               https://aka.ms/PowerPlatformCLI',
+  ],
+  az: [
+    'Windows (winget)   winget install -e --id Microsoft.AzureCLI',
+    'macOS (Homebrew)   brew install azure-cli',
+    'Linux (curl)       curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash',
+    'Docs               https://aka.ms/InstallAzureCLI',
+  ],
+};
+
+/** Reports whether a command resolves on PATH, without running it. */
+function hasCommand(command) {
+  const locator = process.platform === 'win32' ? 'where' : 'which';
+  try {
+    execFileSync(locator, [command], { stdio: 'ignore', timeout: 15000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Picks the install command for one tool on one platform.
+ *
+ * Returns `{ command, args, description }` when an automated path exists, or
+ * `{ command: null, reason, manual }` when the user has to install by hand —
+ * which is the expected outcome on Linux, where the plugin does not guess
+ * between apt, dnf, and the Azure install script.
+ *
+ * @param {object} options
+ * @param {string} options.tool           One of TOOLS.
+ * @param {string} options.platform       A `process.platform` value.
+ * @param {boolean} [options.update]      Update an installed tool instead of installing it.
+ * @param {(cmd: string) => boolean} [options.commandExists]  PATH probe, injected by the tests.
+ */
+function resolveInstallPlan({ tool, platform, update = false, commandExists = hasCommand }) {
+  const manual = MANUAL_INSTRUCTIONS[tool] || [];
+
+  if (tool === 'pac') {
+    // PAC installs as a dotnet global tool on every platform, so the only thing
+    // that can block it is a missing .NET SDK. A same-session SDK install also
+    // lands here: the installer writes PATH for future processes, but this
+    // process inherited its environment from a shell that started earlier, so
+    // `dotnet` stays unresolvable until the terminal restarts.
+    if (!commandExists('dotnet')) {
+      return {
+        command: null,
+        reason:
+          'The .NET SDK is required to install the Power Platform CLI, and dotnet was not found on PATH. ' +
+          'If the SDK was just installed, restart your terminal and run this skill again — a new install is not visible to an already-running shell.',
+        manual,
+      };
+    }
+    return {
+      command: 'dotnet',
+      args: ['tool', update ? 'update' : 'install', '--global', PAC_NUGET_PACKAGE],
+      description: `${update ? 'Updating' : 'Installing'} the Power Platform CLI as a .NET global tool`,
+      manual,
+    };
+  }
+
+  if (tool === 'dotnet') {
+    if (platform === 'win32' && commandExists('winget')) {
+      return {
+        command: 'winget',
+        args: ['install', ...WINGET_FLAGS, '--id', WINGET_DOTNET_SDK_ID],
+        description: 'Installing the .NET SDK via winget',
+        manual,
+      };
+    }
+    if (platform === 'darwin' && commandExists('brew')) {
+      return {
+        command: 'brew',
+        args: ['install', '--cask', 'dotnet-sdk'],
+        description: 'Installing the .NET SDK via Homebrew',
+        manual,
+      };
+    }
+    return { command: null, reason: noPackageManagerReason(platform, '.NET SDK'), manual };
+  }
+
+  if (tool === 'az') {
+    if (platform === 'win32' && commandExists('winget')) {
+      return {
+        command: 'winget',
+        args: ['install', ...WINGET_FLAGS, '--id', WINGET_AZURE_CLI_ID],
+        description: 'Installing the Azure CLI via winget',
+        manual,
+      };
+    }
+    if (platform === 'darwin' && commandExists('brew')) {
+      return {
+        command: 'brew',
+        args: ['install', 'azure-cli'],
+        description: 'Installing the Azure CLI via Homebrew',
+        manual,
+      };
+    }
+    return { command: null, reason: noPackageManagerReason(platform, 'Azure CLI'), manual };
+  }
+
+  return {
+    command: null,
+    reason: `Unknown tool "${tool}". Expected one of: ${TOOLS.join(', ')}.`,
+    manual: [],
+  };
+}
+
+function noPackageManagerReason(platform, label) {
+  if (platform === 'win32') return `winget was not found, so the ${label} cannot be installed automatically.`;
+  if (platform === 'darwin') return `Homebrew was not found, so the ${label} cannot be installed automatically.`;
+  return `Automated install of the ${label} is not supported on ${platform}.`;
+}
+
+function parseArgs(argv) {
+  const args = { tool: null, update: false, dryRun: false, help: false };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--tool') args.tool = argv[++i];
+    else if (arg === '--update') args.update = true;
+    else if (arg === '--dry-run') args.dryRun = true;
+    else if (arg === '--help') args.help = true;
+    else if (!arg.startsWith('--') && !args.tool) args.tool = arg;
+  }
+  return args;
+}
+
+function emit(payload) {
+  process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  if (args.help || !args.tool) {
+    process.stdout.write(
+      `install-prerequisite.js — Installs one Power Pages plugin prerequisite.
+
+Usage:
+  node install-prerequisite.js --tool <${TOOLS.join('|')}> [--update] [--dry-run]
+
+  --update    Update an already-installed tool (supported for: pac).
+  --dry-run   Print the resolved command without running it.
+
+Exit codes:
+  0  Installed, or the dry run printed a plan
+  1  No automated install path on this platform, or the install failed
+`
+    );
+    process.exit(args.tool ? 0 : 1);
+  }
+
+  const plan = resolveInstallPlan({
+    tool: args.tool,
+    platform: process.platform,
+    update: args.update,
+  });
+
+  if (!plan.command) {
+    emit({ tool: args.tool, status: 'unsupported', reason: plan.reason, manual: plan.manual });
+    process.exit(1);
+  }
+
+  if (args.dryRun) {
+    emit({
+      tool: args.tool,
+      status: 'planned',
+      command: plan.command,
+      args: plan.args,
+      description: plan.description,
+    });
+    process.exit(0);
+  }
+
+  process.stderr.write(`${plan.description}...\n`);
+  // Installs are long and chatty, so their output streams straight to the user's
+  // terminal instead of being buffered and replayed after the fact.
+  const result = spawnSync(plan.command, plan.args, { stdio: 'inherit', shell: false });
+
+  if (result.status === 0) {
+    emit({
+      tool: args.tool,
+      status: 'installed',
+      command: plan.command,
+      // A freshly installed global tool lands in a PATH entry the current shell
+      // resolved at startup, so `pac`/`az` often stay unresolvable until the
+      // terminal restarts. Say so rather than letting the next skill fail.
+      note: 'You may need to restart your terminal before this command resolves on PATH.',
+    });
+    process.exit(0);
+  }
+
+  emit({
+    tool: args.tool,
+    status: 'failed',
+    command: plan.command,
+    exitCode: result.status,
+    error: result.error ? result.error.message : null,
+    manual: plan.manual,
+  });
+  process.exit(1);
+}
+
+module.exports = { resolveInstallPlan, parseArgs, hasCommand, TOOLS, MANUAL_INSTRUCTIONS };
+
+if (require.main === module) {
+  main();
+}

--- a/plugins/power-pages/skills/setup-prerequisites/scripts/install-prerequisite.js
+++ b/plugins/power-pages/skills/setup-prerequisites/scripts/install-prerequisite.js
@@ -9,7 +9,7 @@
  * invocation installs exactly one tool.
  *
  * Usage:
- *   node install-prerequisite.js --tool <git|dotnet|pac|az> [--update] [--dry-run]
+ *   node install-prerequisite.js --tool <git|dotnet|pac|az|gh> [--update] [--dry-run]
  *
  * Exit codes:
  *   0  Installed, or a dry run printed the plan
@@ -23,12 +23,13 @@
 
 const { execFileSync, spawnSync } = require('child_process');
 
-const TOOLS = ['git', 'dotnet', 'pac', 'az'];
+const TOOLS = ['git', 'dotnet', 'pac', 'az', 'gh'];
 
 // Winget package identifiers, verified against the microsoft/winget-pkgs
-// manifests at manifests/g/Git/Git, manifests/m/Microsoft/DotNet/SDK/10, and
-// manifests/m/Microsoft/AzureCLI.
+// manifests at manifests/g/Git/Git, manifests/g/GitHub/cli,
+// manifests/m/Microsoft/DotNet/SDK/10, and manifests/m/Microsoft/AzureCLI.
 const WINGET_GIT_ID = 'Git.Git';
+const WINGET_GH_ID = 'GitHub.cli';
 const WINGET_DOTNET_SDK_ID = 'Microsoft.DotNet.SDK.10';
 const WINGET_AZURE_CLI_ID = 'Microsoft.AzureCLI';
 
@@ -68,6 +69,11 @@ const MANUAL_INSTRUCTIONS = {
     'macOS (Homebrew)   brew install azure-cli',
     'Linux (curl)       curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash',
     'Docs               https://aka.ms/InstallAzureCLI',
+  ],
+  gh: [
+    'Windows (winget)   winget install -e --id GitHub.cli',
+    'macOS (Homebrew)   brew install gh',
+    'Any platform       https://github.com/cli/cli#installation',
   ],
 };
 
@@ -160,6 +166,26 @@ function resolveInstallPlan({ tool, platform, update = false, commandExists = ha
       };
     }
     return { command: null, reason: noPackageManagerReason(platform, '.NET SDK'), manual };
+  }
+
+  if (tool === 'gh') {
+    if (platform === 'win32' && commandExists('winget')) {
+      return {
+        command: 'winget',
+        args: ['install', ...WINGET_FLAGS, '--id', WINGET_GH_ID],
+        description: 'Installing the GitHub CLI via winget',
+        manual,
+      };
+    }
+    if (platform === 'darwin' && commandExists('brew')) {
+      return {
+        command: 'brew',
+        args: ['install', 'gh'],
+        description: 'Installing the GitHub CLI via Homebrew',
+        manual,
+      };
+    }
+    return { command: null, reason: noPackageManagerReason(platform, 'GitHub CLI'), manual };
   }
 
   if (tool === 'az') {

--- a/plugins/power-pages/skills/setup-prerequisites/scripts/install-prerequisite.js
+++ b/plugins/power-pages/skills/setup-prerequisites/scripts/install-prerequisite.js
@@ -47,6 +47,14 @@ const WINGET_FLAGS = [
 // See: https://learn.microsoft.com/power-platform/developer/cli/introduction
 const PAC_NUGET_PACKAGE = 'Microsoft.PowerApps.CLI.Tool';
 
+// Tools with an update path of their own. Only PAC has one: `dotnet tool update`
+// is a distinct command, whereas updating a winget/brew package would mean
+// `winget upgrade` / `brew upgrade`, which this script does not offer — those
+// managers update the whole machine's packages and are the user's business, not
+// a prerequisite check's. `detect-prerequisites.js` only ever emits an `update`
+// action for `pac`, so anything else arriving here is a caller mistake.
+const UPDATABLE_TOOLS = new Set(['pac']);
+
 const MANUAL_INSTRUCTIONS = {
   git: [
     'Windows (winget)   winget install -e --id Git.Git',
@@ -100,10 +108,22 @@ function hasCommand(command) {
  * @param {string} options.tool           One of TOOLS.
  * @param {string} options.platform       A `process.platform` value.
  * @param {boolean} [options.update]      Update an installed tool instead of installing it.
+ *   Rejected for tools outside UPDATABLE_TOOLS rather than quietly downgraded to
+ *   an install: the skill shows the dry-run command at its approval prompt and
+ *   then runs it for real, so silently swapping update for install would have the
+ *   user approve one command and get another.
  * @param {(cmd: string) => boolean} [options.commandExists]  PATH probe, injected by the tests.
  */
 function resolveInstallPlan({ tool, platform, update = false, commandExists = hasCommand }) {
   const manual = MANUAL_INSTRUCTIONS[tool] || [];
+
+  if (update && !UPDATABLE_TOOLS.has(tool)) {
+    return {
+      command: null,
+      reason: `--update is not supported for "${tool}". Updatable tools: ${[...UPDATABLE_TOOLS].join(', ')}.`,
+      manual,
+    };
+  }
 
   if (tool === 'pac') {
     // PAC installs as a dotnet global tool on every platform, so the only thing
@@ -248,7 +268,9 @@ function main() {
 Usage:
   node install-prerequisite.js --tool <${TOOLS.join('|')}> [--update] [--dry-run]
 
-  --update    Update an already-installed tool (supported for: pac).
+  --update    Update an already-installed tool. Only supported for: pac.
+              Passing it for any other tool is rejected, not silently
+              treated as an install.
   --dry-run   Print the resolved command without running it.
 
 Exit codes:
@@ -310,7 +332,14 @@ Exit codes:
   process.exit(1);
 }
 
-module.exports = { resolveInstallPlan, parseArgs, hasCommand, TOOLS, MANUAL_INSTRUCTIONS };
+module.exports = {
+  resolveInstallPlan,
+  parseArgs,
+  hasCommand,
+  TOOLS,
+  UPDATABLE_TOOLS,
+  MANUAL_INSTRUCTIONS,
+};
 
 if (require.main === module) {
   main();

--- a/plugins/power-pages/skills/setup-prerequisites/scripts/install-prerequisite.js
+++ b/plugins/power-pages/skills/setup-prerequisites/scripts/install-prerequisite.js
@@ -9,7 +9,7 @@
  * invocation installs exactly one tool.
  *
  * Usage:
- *   node install-prerequisite.js --tool <dotnet|pac|az> [--update] [--dry-run]
+ *   node install-prerequisite.js --tool <git|dotnet|pac|az> [--update] [--dry-run]
  *
  * Exit codes:
  *   0  Installed, or a dry run printed the plan
@@ -23,10 +23,12 @@
 
 const { execFileSync, spawnSync } = require('child_process');
 
-const TOOLS = ['dotnet', 'pac', 'az'];
+const TOOLS = ['git', 'dotnet', 'pac', 'az'];
 
 // Winget package identifiers, verified against the microsoft/winget-pkgs
-// manifests at manifests/m/Microsoft/DotNet/SDK/10 and manifests/m/Microsoft/AzureCLI.
+// manifests at manifests/g/Git/Git, manifests/m/Microsoft/DotNet/SDK/10, and
+// manifests/m/Microsoft/AzureCLI.
+const WINGET_GIT_ID = 'Git.Git';
 const WINGET_DOTNET_SDK_ID = 'Microsoft.DotNet.SDK.10';
 const WINGET_AZURE_CLI_ID = 'Microsoft.AzureCLI';
 
@@ -45,6 +47,13 @@ const WINGET_FLAGS = [
 const PAC_NUGET_PACKAGE = 'Microsoft.PowerApps.CLI.Tool';
 
 const MANUAL_INSTRUCTIONS = {
+  git: [
+    'Windows (winget)   winget install -e --id Git.Git',
+    'macOS (Homebrew)   brew install git',
+    'macOS (built-in)   xcode-select --install',
+    'Linux (apt)        sudo apt install git',
+    'Any platform       https://git-scm.com/downloads',
+  ],
   dotnet: [
     'Windows (winget)   winget install -e --id Microsoft.DotNet.SDK.10',
     'macOS (Homebrew)   brew install --cask dotnet-sdk',
@@ -111,6 +120,26 @@ function resolveInstallPlan({ tool, platform, update = false, commandExists = ha
       description: `${update ? 'Updating' : 'Installing'} the Power Platform CLI as a .NET global tool`,
       manual,
     };
+  }
+
+  if (tool === 'git') {
+    if (platform === 'win32' && commandExists('winget')) {
+      return {
+        command: 'winget',
+        args: ['install', ...WINGET_FLAGS, '--id', WINGET_GIT_ID],
+        description: 'Installing Git via winget',
+        manual,
+      };
+    }
+    if (platform === 'darwin' && commandExists('brew')) {
+      return {
+        command: 'brew',
+        args: ['install', 'git'],
+        description: 'Installing Git via Homebrew',
+        manual,
+      };
+    }
+    return { command: null, reason: noPackageManagerReason(platform, 'Git'), manual };
   }
 
   if (tool === 'dotnet') {


### PR DESCRIPTION
## Why

Installing the power-pages plugin from the marketplace copies the skill files and nothing else. Only the repo-root `scripts/install.js` sets up the CLIs, and it never runs on the marketplace path, so a user can land in the plugin with no PAC CLI, no Azure CLI, no .NET SDK, and no sign-in. Today they find out one skill at a time, as "pac is not recognized".

This adds `/setup-prerequisites` to close that gap.

## What it does

Checks Node.js, the .NET SDK, the Power Platform CLI, and the Azure CLI, plus both CLI sign-ins. Asks before each install, one tool at a time, then signs in. It stops before Dataverse environment selection - picking an environment belongs to whichever skill needs one.

Two scripts do the deterministic work, with the SKILL.md orchestrating the asking:

- `detect-prerequisites.js` probes read-only and emits a JSON status plus an `actions` list of `{ tool, kind }`. It also checks NuGet for a newer PAC CLI and warns when the two CLIs are signed into different tenants, which otherwise surfaces later as confusing 401s.
- `install-prerequisite.js` owns the per-platform install command: winget on Windows, Homebrew on macOS, `dotnet tool install` for PAC everywhere. `--dry-run` gives the workflow the exact command to show at the consent prompt, so the approval and the execution can't drift.

A failed or unsupported install never stops the run. Everything outstanding lands in the final summary with a manual command.

## Worth a careful look

**Windows `az.cmd`.** The Azure CLI ships only as a batch shim on Windows, and Node refuses to spawn a `.cmd` without a shell (EINVAL since 18.20.2/20.12.2). Probing `az` directly reports an installed Azure CLI as missing, which then prompts the user to reinstall a CLI they already have. Windows probes now route through `cmd.exe /c` via `buildProbeInvocation`, still passing args as an array so nothing is concatenated into a shell string. `install-prerequisite.js` is unaffected - it only ever spawns `winget`, `brew`, and `dotnet`, all real executables.

**The fresh-machine ordering case.** On a machine with neither the .NET SDK nor PAC, installing the SDK does not unblock the PAC install in the same session: the installer writes PATH for future processes, while every script here runs under a shell that started earlier. Phase 2 tells the agent to expect the `unsupported` result and route the user to a terminal restart, rather than reporting it as a platform limitation. The script's own reason string says the same thing.

**Scope deliberately left out.** `disable-model-invocation: true` keeps the agent from firing this on its own mid-task; it stays reachable by name, so another skill can still delegate to it. None of the existing 31 skills do yet - wiring them to hand off on a missing tool would mean touching every one of them, so it is left for a follow-up.

## Verification

34 new tests, full power-pages suite passing at 1343, `lint-skills-alm.js` clean, and all repo-level validators pass. Both scripts were run live on macOS against a real signed-in PAC and Azure CLI.

Two review passes caught three real bugs before this landed: the Windows `az.cmd` case, a `--dry-run` invocation that omitted `--update` and so displayed the wrong command at the PAC update prompt, and the misleading same-session SDK guidance. All three are fixed with test coverage.

Docs updated: plugin README (prerequisites note, skill entry, count 31 -> 32, workflow step 0), `AGENTS.md` skill tree, approval-gates catalog section 6.31, and the skill-tracking mapping table.