### PR TITLE
docs: correct stale "Stop hook" wording for skill validators

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ Each plugin follows this structure:
 - `scripts/` — Shared utility scripts referenced by skills and agents
 - `references/` — Shared reference documents used by multiple skills
 
-Skills are defined in `SKILL.md` files with YAML frontmatter (name, description, allowed-tools, model, hooks). The `allowed-tools` field must use a **comma-separated list** (e.g., `allowed-tools: Read, Write, Edit, Bash, Glob, Grep`) — not JSON array syntax (`["Read", "Write"]`) or YAML list syntax. Each skill may include validation scripts in a `scripts/` subdirectory, run as Stop hooks when the skill session ends.
+Skills are defined in `SKILL.md` files with YAML frontmatter (name, description, allowed-tools, model, hooks). The `allowed-tools` field must use a **comma-separated list** (e.g., `allowed-tools: Read, Write, Edit, Bash, Glob, Grep`) — not JSON array syntax (`["Read", "Write"]`) or YAML list syntax. Each skill may include a validation script in a `scripts/` subdirectory (the first `validate*.js`, discovered automatically). It is run by the plugin's **`PostToolUse` hook on the `Skill` tool** — `hooks/run-skill-posttool-validation.js` looks the script up and executes it after the Skill tool returns, propagating its exit code. Note this fires when the skill is **invoked**, not when its work finishes, so a validator must no-op (approve) when the artifacts it checks are not present yet.
 
 ## Cross-Plugin Shared Skills
 

--- a/plugins/power-pages/PLUGIN_DEVELOPMENT_GUIDE.md
+++ b/plugins/power-pages/PLUGIN_DEVELOPMENT_GUIDE.md
@@ -114,7 +114,7 @@ After implementation, always run a standalone verification phase that:
 | `/integrate-webapi` | Phase 5 | File inventory matches plan, all imports resolve, build passes |
 | `/audit-permissions` | Phase 6 | Findings report generated, all tables audited, cross-checks complete |
 | `/create-site` | Phase 6 | All pages render, design foundations applied, build passes |
-| `/create-webroles` | Stop hook | Web role YAML validates (schema, naming conventions, booleans) |
+| `/create-webroles` | PostToolUse hook | Web role YAML validates (schema, naming conventions, booleans) |
 
 **Hook-based validation** — Skills tracked in `hooks/hooks.json` get automatic validation when they complete. The `PostToolUse` hook on `Skill` dispatches to per-skill validator scripts via `run-skill-posttool-validation.js`. Validators use `approve()` / `block(reason)` from `scripts/lib/validation-helpers.js`.
 

--- a/plugins/power-pages/skills/activate-site/scripts/validate-activation.js
+++ b/plugins/power-pages/skills/activate-site/scripts/validate-activation.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 // Validates Power Pages site activation output.
-// Runs as a Stop hook to verify the website was provisioned in the environment.
+// Runs as a PostToolUse(Skill) hook to verify the website was provisioned in the environment.
 // Calls the shared check-activation-status.js script to query the Power Platform API
 // instead of relying on an intermediate file.
 

--- a/plugins/power-pages/skills/add-seo/scripts/validate-seo.js
+++ b/plugins/power-pages/skills/add-seo/scripts/validate-seo.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 // Validates SEO assets added to a Power Pages code site.
-// Runs as a Stop hook to verify robots.txt, sitemap.xml, and meta tags were created.
+// Runs as a PostToolUse(Skill) hook to verify robots.txt, sitemap.xml, and meta tags were created.
 
 const fs = require('fs');
 const path = require('path');

--- a/plugins/power-pages/skills/audit-permissions/scripts/validate-audit.js
+++ b/plugins/power-pages/skills/audit-permissions/scripts/validate-audit.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 // Validates that the permissions audit report was generated.
-// Runs as a Stop hook to verify the skill produced output.
+// Runs as a PostToolUse(Skill) hook to verify the skill produced output.
 
 const fs = require('fs');
 const path = require('path');

--- a/plugins/power-pages/skills/configure-env-variables/scripts/validate-env-variables.js
+++ b/plugins/power-pages/skills/configure-env-variables/scripts/validate-env-variables.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // validate-env-variables.js
-// Stop hook validator for the configure-env-variables skill.
+// PostToolUse(Skill) hook validator for the configure-env-variables skill.
 // Checks that deployment-settings.json was written with at least one env var entry.
 
 const { approve, block, runValidation } = require('../../../scripts/lib/validation-helpers.js');

--- a/plugins/power-pages/skills/create-site/scripts/validate-site.js
+++ b/plugins/power-pages/skills/create-site/scripts/validate-site.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 // Validates Power Pages code site generation output.
-// Runs as a Stop hook to verify the site was properly created.
+// Runs as a PostToolUse(Skill) hook to verify the site was properly created.
 
 const fs = require('fs');
 const path = require('path');

--- a/plugins/power-pages/skills/create-webroles/scripts/validate-webroles.js
+++ b/plugins/power-pages/skills/create-webroles/scripts/validate-webroles.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 // Validates that new web role YAML files were created in .powerpages-site/web-roles/.
-// Runs as a Stop hook to verify the skill produced output.
+// Runs as a PostToolUse(Skill) hook to verify the skill produced output.
 
 const path = require('path');
 const { approve, block, runValidation, findPowerPagesSiteDir } = require('../../../scripts/lib/validation-helpers');

--- a/plugins/power-pages/skills/ensure-pipelines-host/SKILL.md
+++ b/plugins/power-pages/skills/ensure-pipelines-host/SKILL.md
@@ -1051,7 +1051,7 @@ Existing helpers reused (no changes):
 
 ## Validation script
 
-`skills/ensure-pipelines-host/scripts/validate-ensure-host.js` (PostToolUse Stop hook, registered via `TRACKED_SKILLS` in `scripts/lib/powerpages-hook-utils.js`):
+`skills/ensure-pipelines-host/scripts/validate-ensure-host.js` (run by the centralized PostToolUse hook on the `Skill` tool; the skill is tracked automatically because `skills/ensure-pipelines-host/SKILL.md` exists — see `scripts/lib/powerpages-hook-utils.js`):
 
 - If no `docs/alm/last-host-check.json` in cwd → exit 0 (not an ensure-host session).
 - If present: validate `schemaVersion === 1` or `2` (forward-compatible); required fields populated (`tenantId`, `sourceEnvUrl`, `resolutionStatus`); `ready === true` for non-terminal-error statuses; `finalHostEnvUrl` populated when `ready === true`.

--- a/plugins/power-pages/skills/integrate-webapi/scripts/validate-webapi-integration.js
+++ b/plugins/power-pages/skills/integrate-webapi/scripts/validate-webapi-integration.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 // Validates that Web API integration code was created for a Power Pages code site.
-// Runs as a Stop hook to verify the skill produced output.
+// Runs as a PostToolUse(Skill) hook to verify the skill produced output.
 
 const fs = require('fs');
 const path = require('path');

--- a/plugins/power-pages/skills/plan-alm/scripts/validate-plan-alm.js
+++ b/plugins/power-pages/skills/plan-alm/scripts/validate-plan-alm.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * validate-plan-alm.js — Stop hook validator for the plan-alm skill.
+ * validate-plan-alm.js — PostToolUse(Skill) hook validator for the plan-alm skill.
  *
  * Checks that docs/alm-plan.html was written and is non-empty/non-malformed.
  * Gracefully approves if the file does not exist (not a plan-alm session).

--- a/plugins/power-pages/skills/setup-datamodel/scripts/validate-datamodel.js
+++ b/plugins/power-pages/skills/setup-datamodel/scripts/validate-datamodel.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 // Validates Dataverse data model creation output.
-// Runs as a Stop hook to verify tables and columns were properly created.
+// Runs as a PostToolUse(Skill) hook to verify tables and columns were properly created.
 // Reads .datamodel-manifest.json (written by the setup-datamodel skill) and
 // queries the Dataverse OData API to confirm each table/column exists.
 


### PR DESCRIPTION
Skill validators are run by the centralized **PostToolUse** hook on the `Skill` tool (`hooks/run-skill-posttool-validation.js`), not by a Stop hook. Stop hooks were removed from power-pages in `e670581` and are documented there as an anti-pattern (they fire on every assistant pause; one incident produced a runaway forced-continuation loop). Nine validators and two docs still described themselves as Stop hooks — and that stale wording is what propagated into the repo-root `AGENTS.md`, which every plugin author reads.

### Changes (comment/prose only — no logic, 12 files, 12 lines)

- **Root `AGENTS.md`** — describe the actual mechanism (PostToolUse on the `Skill` tool, first `validate*.js` discovered automatically, exit code propagated), plus the consequence that matters when writing one: it fires when the skill is **invoked**, not when its work finishes, so a validator must no-op when the artifacts it checks aren't present yet (which is exactly what the power-pages validators already do).
- **9 power-pages validators** — `Runs as a Stop hook` → `Runs as a PostToolUse(Skill) hook`; same for the two `Stop hook validator for` headers.
- **`PLUGIN_DEVELOPMENT_GUIDE.md`** — the `/create-webroles` verification row said `Stop hook`.
- **`ensure-pipelines-host/SKILL.md`** — said "PostToolUse Stop hook, registered via `TRACKED_SKILLS`"; tracked skills are now derived from `skills/*/SKILL.md`, so no manual registration exists.

Deliberately **kept**: the anti-pattern rationale in `PLUGIN_DEVELOPMENT_GUIDE.md` / `AGENTS.md` and the test comment about skills that *previously* declared a Stop hook — that history is correct.

### Validation

- All 9 validators parse (`node --check`).
- power-pages suite unchanged: **1279 pass / 23 fail** — those 23 are **pre-existing on `main`** (the test files are byte-identical to `main` and fail identically with these changes stashed). Flagging separately; not addressed here.

Split out of #229 so that PR stays model-apps-only and this is easy to review.
