### PR TITLE
Add missing plugins to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -9,7 +9,9 @@ body:
       description: Which plugin is this bug related to?
       options:
         - canvas-apps
-        - code-apps
+        - code-apps-preview
+        - mcp-apps
+        - mobile-app
         - model-apps
         - power-automate
         - power-pages

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -9,7 +9,7 @@ body:
       description: Which plugin is this bug related to?
       options:
         - canvas-apps
-        - code-apps-preview
+        - code-apps
         - mcp-apps
         - mobile-app
         - model-apps

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -9,7 +9,9 @@ body:
       description: Which plugin is this feature request for?
       options:
         - canvas-apps
-        - code-apps
+        - code-apps-preview
+        - mcp-apps
+        - mobile-app
         - model-apps
         - power-automate
         - power-pages

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -9,7 +9,7 @@ body:
       description: Which plugin is this feature request for?
       options:
         - canvas-apps
-        - code-apps-preview
+        - code-apps
         - mcp-apps
         - mobile-app
         - model-apps


### PR DESCRIPTION
Add `mcp-apps` and `mobile-app` to both plugin dropdowns while creating issues