### PR TITLE
Secure Key Vault secret temporary files

### DIFF
--- a/plugins/power-pages/scripts/store-keyvault-secret.js
+++ b/plugins/power-pages/scripts/store-keyvault-secret.js
@@ -25,7 +25,12 @@ const { spawnSync } = require('child_process');
 
 function getArg(args, name) {
   const idx = args.indexOf(`--${name}`);
-  return idx !== -1 && idx + 1 < args.length ? args[idx + 1] : null;
+  if (idx === -1) return null;
+
+  // Arguments use `--name value`. A bare flag or `--name --other` is present but
+  // empty, so callers can reject it without falling back to another input source.
+  const value = args[idx + 1];
+  return value === undefined || value.startsWith('--') ? '' : value;
 }
 
 function parseArgs(args) {

--- a/plugins/power-pages/scripts/store-keyvault-secret.js
+++ b/plugins/power-pages/scripts/store-keyvault-secret.js
@@ -8,8 +8,10 @@
 // Usage (preferred — secret never in process args):
 //   printf '%s' '<value>' | node store-keyvault-secret.js --vaultName <name> --secretName <name>
 //
-// Usage (convenience — secret is in the node process args but NOT in the az args):
+// Usage (convenience - secret is visible in the Node process args, not the az args):
 //   node store-keyvault-secret.js --vaultName <name> --secretName <name> --secretValue <value>
+//   node store-keyvault-secret.js --vaultName <name> --secretName <name> --secretValue=<value>
+// Use the `=` form when the value begins with dashes.
 //
 // Output (JSON to stdout):
 //   { "secretUri": "https://myvault.vault.azure.net/secrets/mysecret/abc123..." }
@@ -210,7 +212,9 @@ function runCli(
     stderr.write(
       'Usage:\n' +
       '  printf \'%s\' \'<value>\' | node store-keyvault-secret.js --vaultName <name> --secretName <name>\n' +
-      '  node store-keyvault-secret.js --vaultName <name> --secretName <name> --secretValue <value>\n'
+      '  node store-keyvault-secret.js --vaultName <name> --secretName <name> --secretValue <value>\n' +
+      '  node store-keyvault-secret.js --vaultName <name> --secretName <name> --secretValue=<value>\n' +
+      'Prefer stdin so the secret is not visible in process arguments. Use the `=` form for values that begin with dashes.\n'
     );
     return 1;
   }

--- a/plugins/power-pages/scripts/store-keyvault-secret.js
+++ b/plugins/power-pages/scripts/store-keyvault-secret.js
@@ -24,8 +24,15 @@ const path = require('path');
 const { spawnSync } = require('child_process');
 
 function getArg(args, name) {
-  const idx = args.indexOf(`--${name}`);
-  if (idx === -1) return null;
+  const flag = `--${name}`;
+  const idx = args.indexOf(flag);
+  const inlineArg = args.find((arg) => arg.startsWith(`${flag}=`));
+
+  if (idx === -1) {
+    // Slice after the first `=` so values can contain leading dashes, spaces, and
+    // additional `=` characters without entering the spaced-form option grammar.
+    return inlineArg === undefined ? null : inlineArg.slice(flag.length + 1);
+  }
 
   // Arguments use `--name value`. A bare flag or `--name --other` is present but
   // empty, so callers can reject it without falling back to another input source.

--- a/plugins/power-pages/scripts/store-keyvault-secret.js
+++ b/plugins/power-pages/scripts/store-keyvault-secret.js
@@ -221,7 +221,7 @@ function runCli(
 
   // Resolve the secret value: use --secretValue when present, otherwise read stdin.
   let secretValue = secretValueArg;
-  if (!secretValue) {
+  if (secretValue === null) {
     // Read from stdin (non-TTY only — don't block waiting for interactive input).
     if (stdin.isTTY) {
       stderr.write(

--- a/plugins/power-pages/scripts/store-keyvault-secret.js
+++ b/plugins/power-pages/scripts/store-keyvault-secret.js
@@ -219,7 +219,7 @@ function runCli(
     return 1;
   }
 
-  // Resolve the secret value: prefer stdin, fall back to --secretValue.
+  // Resolve the secret value: use --secretValue when present, otherwise read stdin.
   let secretValue = secretValueArg;
   if (!secretValue) {
     // Read from stdin (non-TTY only — don't block waiting for interactive input).

--- a/plugins/power-pages/scripts/store-keyvault-secret.js
+++ b/plugins/power-pages/scripts/store-keyvault-secret.js
@@ -23,105 +23,263 @@ const os = require('os');
 const path = require('path');
 const { spawnSync } = require('child_process');
 
-const args = process.argv.slice(2);
-
-function getArg(name) {
+function getArg(args, name) {
   const idx = args.indexOf(`--${name}`);
   return idx !== -1 && idx + 1 < args.length ? args[idx + 1] : null;
 }
 
-const vaultName = getArg('vaultName');
-const secretName = getArg('secretName');
-const secretValueArg = getArg('secretValue');
-
-if (!vaultName || !secretName) {
-  process.stderr.write(
-    'Usage:\n' +
-    '  printf \'%s\' \'<value>\' | node store-keyvault-secret.js --vaultName <name> --secretName <name>\n' +
-    '  node store-keyvault-secret.js --vaultName <name> --secretName <name> --secretValue <value>\n'
-  );
-  process.exit(1);
+function parseArgs(args) {
+  return {
+    vaultName: getArg(args, 'vaultName'),
+    secretName: getArg(args, 'secretName'),
+    secretValue: getArg(args, 'secretValue'),
+  };
 }
 
-// Azure Key Vault name: 3-24 chars, starts with letter, alphanumerics and hyphens
-if (!/^[a-zA-Z][a-zA-Z0-9-]{1,22}[a-zA-Z0-9]$/.test(vaultName)) {
-  process.stderr.write(
-    'Error: --vaultName must be 3-24 characters, starting with a letter, containing only alphanumerics and hyphens.\n'
-  );
-  process.exit(1);
-}
+function cleanupTemporarySecret(
+  fsImpl,
+  tempFileHandle,
+  tempFile,
+  tempFileCreated,
+  tempDir
+) {
+  const errors = [];
 
-// Key Vault secret name: 1-127 chars, alphanumerics and hyphens
-if (!/^[a-zA-Z0-9]([a-zA-Z0-9-]{0,125}[a-zA-Z0-9])?$/.test(secretName)) {
-  process.stderr.write(
-    'Error: --secretName must be 1-127 characters, alphanumerics and hyphens only.\n'
-  );
-  process.exit(1);
-}
+  if (tempFileHandle !== null) {
+    try {
+      fsImpl.closeSync(tempFileHandle);
+    } catch (error) {
+      errors.push(error);
+    }
+  }
 
-// Resolve the secret value: prefer stdin, fall back to --secretValue
-let secretValue = secretValueArg;
+  if (tempFileCreated) {
+    try {
+      fsImpl.unlinkSync(tempFile);
+    } catch (error) {
+      if (error.code !== 'ENOENT') errors.push(error);
+    }
+  }
 
-if (!secretValue) {
-  // Read from stdin (non-TTY only — don't block waiting for interactive input)
-  if (process.stdin.isTTY) {
-    process.stderr.write(
-      'Error: No secret value provided. Pipe the value via stdin or pass --secretValue.\n'
+  if (tempDir) {
+    try {
+      fsImpl.rmdirSync(tempDir);
+    } catch (error) {
+      if (error.code !== 'ENOENT') errors.push(error);
+    }
+  }
+
+  if (errors.length === 1) {
+    const error = new Error(`Failed to remove temporary secret artifacts: ${errors[0].message}`, {
+      cause: errors[0],
+    });
+    error.code = 'TEMP_CLEANUP_FAILED';
+    throw error;
+  }
+
+  if (errors.length > 1) {
+    const detail = errors.map((item) => item.message).join('; ');
+    const error = new AggregateError(
+      errors,
+      `Failed to remove temporary secret artifacts: ${detail}`
     );
-    process.exit(1);
-  }
-  try {
-    secretValue = fs.readFileSync(process.stdin.fd, 'utf8');
-  } catch {
-    process.stderr.write('Error: Failed to read secret value from stdin.\n');
-    process.exit(1);
+    error.code = 'TEMP_CLEANUP_FAILED';
+    throw error;
   }
 }
 
-if (!secretValue) {
-  process.stderr.write('Error: Secret value is empty.\n');
-  process.exit(1);
-}
-
-// Write the secret to a temp file with restrictive permissions (owner-only read/write).
-// This avoids passing the secret as a CLI argument to `az`, which would be visible
-// in process listings (ps, /proc) to other users on the same machine.
-const tmpFile = path.join(os.tmpdir(), `kv-secret-${process.pid}-${Date.now()}`);
-
-try {
-  fs.writeFileSync(tmpFile, secretValue, { mode: 0o600 });
-
-  const result = spawnSync('az', [
-    'keyvault', 'secret', 'set',
-    '--vault-name', vaultName,
-    '--name', secretName,
-    '--file', tmpFile,
-    '--encoding', 'utf-8',
-    '--query', '{secretUri:id}',
-    '-o', 'json',
-  ], { encoding: 'utf8', timeout: 30000 });
-
-  if (result.error) {
-    process.stderr.write('Failed to run Azure CLI. Ensure `az` is installed and available on PATH.\n');
-    process.exit(1);
-  }
-
-  if (result.status !== 0) {
-    process.stderr.write(
-      `Failed to store secret in Key Vault "${vaultName}". Ensure you have access and the vault exists.\n`
-    );
-    if (result.stderr) process.stderr.write(result.stderr);
-    process.exit(1);
-  }
+function storeKeyVaultSecret(
+  { vaultName, secretName, secretValue },
+  {
+    fsImpl = fs,
+    osImpl = os,
+    pathImpl = path,
+    spawnSyncImpl = spawnSync,
+    platform = process.platform,
+  } = {}
+) {
+  let tempDir = null;
+  let tempFile = null;
+  let tempFileHandle = null;
+  let tempFileCreated = false;
+  let output;
+  let operationError = null;
+  let cleanupError = null;
 
   try {
-    const parsed = JSON.parse(result.stdout);
-    process.stdout.write(JSON.stringify(parsed));
-  } catch {
-    process.stderr.write('Failed to parse Azure CLI output.\n');
-    process.exit(1);
+    tempDir = fsImpl.mkdtempSync(pathImpl.join(osImpl.tmpdir(), 'kv-secret-'));
+
+    // Node's POSIX mode bits do not map to Windows ACLs. On Windows, the private
+    // directory inherits the current user's temp-directory DACL instead.
+    // See: https://nodejs.org/api/fs.html#file-modes
+    if (platform !== 'win32') {
+      fsImpl.chmodSync(tempDir, 0o700);
+    }
+
+    tempFile = pathImpl.join(tempDir, 'secret');
+    // `wx` maps to O_CREAT | O_EXCL, so an attacker-created file or symlink wins
+    // the race by making this write fail instead of redirecting the secret.
+    // See: https://nodejs.org/api/fs.html#file-system-flags
+    tempFileHandle = fsImpl.openSync(tempFile, 'wx', 0o600);
+    tempFileCreated = true;
+    fsImpl.writeFileSync(tempFileHandle, secretValue, 'utf8');
+    fsImpl.closeSync(tempFileHandle);
+    tempFileHandle = null;
+
+    const result = spawnSyncImpl('az', [
+      'keyvault', 'secret', 'set',
+      '--vault-name', vaultName,
+      '--name', secretName,
+      '--file', tempFile,
+      '--encoding', 'utf-8',
+      '--query', '{secretUri:id}',
+      '-o', 'json',
+    ], { encoding: 'utf8', timeout: 30000 });
+
+    if (result.error) {
+      const error = new Error('Failed to run Azure CLI.');
+      error.code = 'AZ_SPAWN_FAILED';
+      error.cause = result.error;
+      throw error;
+    }
+
+    if (result.status !== 0) {
+      const error = new Error(`Failed to store secret in Key Vault "${vaultName}".`);
+      error.code = 'AZ_COMMAND_FAILED';
+      error.stderr = result.stderr;
+      throw error;
+    }
+
+    try {
+      output = JSON.parse(result.stdout);
+    } catch (cause) {
+      const error = new Error('Failed to parse Azure CLI output.');
+      error.code = 'AZ_OUTPUT_INVALID';
+      error.cause = cause;
+      throw error;
+    }
+  } catch (error) {
+    operationError = error;
+  } finally {
+    try {
+      cleanupTemporarySecret(
+        fsImpl,
+        tempFileHandle,
+        tempFile,
+        tempFileCreated,
+        tempDir
+      );
+    } catch (error) {
+      cleanupError = error;
+    }
   }
-} finally {
-  // Always clean up the temp file
-  try { fs.unlinkSync(tmpFile); } catch { /* ignore cleanup errors */ }
+
+  if (operationError) {
+    if (cleanupError) operationError.cleanupError = cleanupError;
+    throw operationError;
+  }
+  if (cleanupError) throw cleanupError;
+
+  return output;
 }
+
+function runCli(
+  args = process.argv.slice(2),
+  {
+    stdin = process.stdin,
+    stdout = process.stdout,
+    stderr = process.stderr,
+  } = {},
+  dependencies
+) {
+  const { vaultName, secretName, secretValue: secretValueArg } = parseArgs(args);
+
+  if (!vaultName || !secretName) {
+    stderr.write(
+      'Usage:\n' +
+      '  printf \'%s\' \'<value>\' | node store-keyvault-secret.js --vaultName <name> --secretName <name>\n' +
+      '  node store-keyvault-secret.js --vaultName <name> --secretName <name> --secretValue <value>\n'
+    );
+    return 1;
+  }
+
+  // Azure Key Vault name: 3-24 chars, starts with letter, alphanumerics and hyphens
+  if (!/^[a-zA-Z][a-zA-Z0-9-]{1,22}[a-zA-Z0-9]$/.test(vaultName)) {
+    stderr.write(
+      'Error: --vaultName must be 3-24 characters, starting with a letter, containing only alphanumerics and hyphens.\n'
+    );
+    return 1;
+  }
+
+  // Key Vault secret name: 1-127 chars, alphanumerics and hyphens
+  if (!/^[a-zA-Z0-9]([a-zA-Z0-9-]{0,125}[a-zA-Z0-9])?$/.test(secretName)) {
+    stderr.write(
+      'Error: --secretName must be 1-127 characters, alphanumerics and hyphens only.\n'
+    );
+    return 1;
+  }
+
+  // Resolve the secret value: prefer stdin, fall back to --secretValue.
+  let secretValue = secretValueArg;
+  if (!secretValue) {
+    // Read from stdin (non-TTY only — don't block waiting for interactive input).
+    if (stdin.isTTY) {
+      stderr.write(
+        'Error: No secret value provided. Pipe the value via stdin or pass --secretValue.\n'
+      );
+      return 1;
+    }
+
+    try {
+      secretValue = fs.readFileSync(stdin.fd, 'utf8');
+    } catch {
+      stderr.write('Error: Failed to read secret value from stdin.\n');
+      return 1;
+    }
+  }
+
+  if (!secretValue) {
+    stderr.write('Error: Secret value is empty.\n');
+    return 1;
+  }
+
+  try {
+    const result = storeKeyVaultSecret(
+      { vaultName, secretName, secretValue },
+      dependencies
+    );
+    stdout.write(JSON.stringify(result));
+    return 0;
+  } catch (error) {
+    if (error.code === 'AZ_SPAWN_FAILED') {
+      stderr.write('Failed to run Azure CLI. Ensure `az` is installed and available on PATH.\n');
+    } else if (error.code === 'AZ_COMMAND_FAILED') {
+      stderr.write(
+        `Failed to store secret in Key Vault "${vaultName}". Ensure you have access and the vault exists.\n`
+      );
+      if (error.stderr) stderr.write(error.stderr);
+    } else if (error.code === 'AZ_OUTPUT_INVALID') {
+      stderr.write('Failed to parse Azure CLI output.\n');
+    } else if (error.code === 'TEMP_CLEANUP_FAILED') {
+      stderr.write(`${error.message}\n`);
+    } else {
+      stderr.write(`Failed to prepare temporary secret file: ${error.message}\n`);
+    }
+
+    if (error.cleanupError) {
+      stderr.write(`${error.cleanupError.message}\n`);
+    }
+    return 1;
+  }
+}
+
+if (require.main === module) {
+  process.exitCode = runCli();
+}
+
+module.exports = {
+  cleanupTemporarySecret,
+  parseArgs,
+  runCli,
+  storeKeyVaultSecret,
+};

--- a/plugins/power-pages/scripts/tests/store-keyvault-secret.test.js
+++ b/plugins/power-pages/scripts/tests/store-keyvault-secret.test.js
@@ -1,9 +1,12 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
 const path = require('path');
 const { spawnSync } = require('child_process');
 
 const cliPath = path.join(__dirname, '..', 'store-keyvault-secret.js');
+const { storeKeyVaultSecret } = require('../store-keyvault-secret');
 
 function runStoreKeyvaultSecret(args, opts = {}) {
   return spawnSync(process.execPath, [cliPath, ...args], {
@@ -11,6 +14,65 @@ function runStoreKeyvaultSecret(args, opts = {}) {
     timeout: 10000,
     ...opts,
   });
+}
+
+function makeFakeAzureCli(t) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'store-keyvault-secret-test-'));
+  const binDir = path.join(root, 'fake az bin');
+  const tempRoot = path.join(root, 'temporary files');
+  const reportPath = path.join(root, 'az-report.json');
+  const fakeAzPath = path.join(binDir, 'fake-az.js');
+
+  fs.mkdirSync(binDir);
+  fs.mkdirSync(tempRoot);
+  fs.writeFileSync(fakeAzPath, `
+const fs = require('fs');
+const path = require('path');
+const args = process.argv.slice(2);
+const fileIndex = args.indexOf('--file');
+const secretPath = fileIndex === -1 ? null : args[fileIndex + 1];
+const report = {
+  argv: args,
+  secret: secretPath ? fs.readFileSync(secretPath, 'utf8') : null,
+  secretPath,
+  fileMode: secretPath ? fs.statSync(secretPath).mode & 0o777 : null,
+  directoryMode: secretPath ? fs.statSync(path.dirname(secretPath)).mode & 0o777 : null,
+};
+fs.writeFileSync(process.env.FAKE_AZ_REPORT, JSON.stringify(report));
+if (process.env.FAKE_AZ_EXIT) {
+  process.stderr.write('fake Azure CLI failure\\n');
+  process.exit(Number(process.env.FAKE_AZ_EXIT));
+}
+process.stdout.write(JSON.stringify({ secretUri: 'https://example.vault.azure.net/secrets/test/version' }));
+`);
+
+  if (process.platform === 'win32') {
+    fs.writeFileSync(
+      path.join(binDir, 'az.cmd'),
+      `@"${process.execPath}" "%~dp0fake-az.js" %*\r\n`
+    );
+  } else {
+    const launcherPath = path.join(binDir, 'az');
+    fs.writeFileSync(launcherPath, '#!/usr/bin/env node\nrequire("./fake-az.js");\n', { mode: 0o755 });
+  }
+
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  return {
+    reportPath,
+    tempRoot,
+    env(overrides = {}) {
+      return {
+        ...process.env,
+        PATH: `${binDir}${path.delimiter}${process.env.PATH || ''}`,
+        TMPDIR: tempRoot,
+        TMP: tempRoot,
+        TEMP: tempRoot,
+        FAKE_AZ_REPORT: reportPath,
+        ...overrides,
+      };
+    },
+  };
 }
 
 test('store-keyvault-secret fails with no arguments', () => {
@@ -99,4 +161,231 @@ test('store-keyvault-secret rejects empty stdin', () => {
   ], { input: '' });
   assert.equal(result.status, 1);
   assert.match(result.stderr, /Secret value is empty/);
+});
+
+test('store-keyvault-secret uses a private temp directory and keeps the secret out of az argv', (t) => {
+  const fakeAzureCli = makeFakeAzureCli(t);
+  const secretValue = 'secret value with spaces';
+  const result = runStoreKeyvaultSecret([
+    '--vaultName', 'my-vault',
+    '--secretName', 'my-secret',
+  ], { input: secretValue, env: fakeAzureCli.env() });
+
+  assert.equal(result.status, 0, result.stderr);
+  const report = JSON.parse(fs.readFileSync(fakeAzureCli.reportPath, 'utf8'));
+  assert.equal(report.secret, secretValue);
+  assert.equal(report.argv.includes(secretValue), false);
+  assert.notEqual(path.dirname(report.secretPath), fakeAzureCli.tempRoot);
+  assert.equal(report.secretPath.startsWith(`${fakeAzureCli.tempRoot}${path.sep}`), true);
+  assert.equal(fs.existsSync(report.secretPath), false);
+  assert.equal(fs.existsSync(path.dirname(report.secretPath)), false);
+  if (process.platform !== 'win32') {
+    assert.equal(report.fileMode, 0o600);
+    assert.equal(report.directoryMode, 0o700);
+  }
+});
+
+test('store-keyvault-secret cleans up the private temp directory when az fails', (t) => {
+  const fakeAzureCli = makeFakeAzureCli(t);
+  const result = runStoreKeyvaultSecret([
+    '--vaultName', 'my-vault',
+    '--secretName', 'my-secret',
+  ], {
+    input: 'secret-on-failure',
+    env: fakeAzureCli.env({ FAKE_AZ_EXIT: '7' }),
+  });
+
+  assert.equal(result.status, 1);
+  const report = JSON.parse(fs.readFileSync(fakeAzureCli.reportPath, 'utf8'));
+  assert.equal(fs.existsSync(report.secretPath), false);
+  assert.equal(fs.existsSync(path.dirname(report.secretPath)), false);
+});
+
+test('store-keyvault-secret creates the secret file exclusively and cleans up partial creation', () => {
+  const calls = [];
+  const existingPathError = new Error('path already exists');
+  existingPathError.code = 'EEXIST';
+  const fsImpl = {
+    mkdtempSync(prefix) {
+      calls.push(['mkdtempSync', prefix]);
+      return '/tmp/kv-secret-private';
+    },
+    chmodSync(filePath, mode) {
+      calls.push(['chmodSync', filePath, mode]);
+    },
+    openSync(filePath, flag, mode) {
+      calls.push(['openSync', filePath, flag, mode]);
+      throw existingPathError;
+    },
+    writeFileSync() {
+      assert.fail('a pre-existing path must fail before writing');
+    },
+    closeSync() {
+      assert.fail('a file that was not opened must not be closed');
+    },
+    unlinkSync() {
+      assert.fail('a file that was not created must not be unlinked');
+    },
+    rmdirSync(filePath) {
+      calls.push(['rmdirSync', filePath]);
+    },
+  };
+
+  assert.throws(
+    () => storeKeyVaultSecret(
+      {
+        vaultName: 'my-vault',
+        secretName: 'my-secret',
+        secretValue: 'do-not-follow',
+      },
+      {
+        fsImpl,
+        osImpl: { tmpdir: () => '/tmp' },
+        pathImpl: path.posix,
+        platform: 'linux',
+        spawnSyncImpl: () => assert.fail('az must not run after exclusive creation fails'),
+      }
+    ),
+    (error) => error === existingPathError
+  );
+
+  assert.deepEqual(calls, [
+    ['mkdtempSync', '/tmp/kv-secret-'],
+    ['chmodSync', '/tmp/kv-secret-private', 0o700],
+    ['openSync', '/tmp/kv-secret-private/secret', 'wx', 0o600],
+    ['rmdirSync', '/tmp/kv-secret-private'],
+  ]);
+});
+
+test(
+  'store-keyvault-secret does not follow a pre-existing symlink',
+  { skip: process.platform === 'win32' },
+  (t) => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'store-keyvault-symlink-'));
+    const privateDir = path.join(root, 'private');
+    const targetPath = path.join(root, 'target');
+    fs.mkdirSync(privateDir, { mode: 0o700 });
+    fs.writeFileSync(targetPath, 'unchanged');
+    fs.symlinkSync(targetPath, path.join(privateDir, 'secret'));
+    t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+
+    assert.throws(
+      () => storeKeyVaultSecret(
+        {
+          vaultName: 'my-vault',
+          secretName: 'my-secret',
+          secretValue: 'must-not-reach-target',
+        },
+        {
+          fsImpl: {
+            ...fs,
+            mkdtempSync: () => privateDir,
+          },
+          osImpl: { tmpdir: () => root },
+          pathImpl: path,
+          platform: process.platform,
+          spawnSyncImpl: () => assert.fail('az must not run when the secret path is a symlink'),
+        }
+      ),
+      (error) => {
+        assert.equal(error.code, 'EEXIST');
+        assert.equal(error.cleanupError.code, 'TEMP_CLEANUP_FAILED');
+        return true;
+      }
+    );
+
+    assert.equal(fs.readFileSync(targetPath, 'utf8'), 'unchanged');
+  }
+);
+
+test('store-keyvault-secret removes a partially written file when writing fails', () => {
+  const calls = [];
+  const writeError = new Error('disk is full');
+  writeError.code = 'ENOSPC';
+  const fsImpl = {
+    mkdtempSync: () => '/tmp/kv-secret-private',
+    chmodSync: () => {},
+    openSync: () => 42,
+    writeFileSync() {
+      calls.push('write');
+      throw writeError;
+    },
+    closeSync(handle) {
+      calls.push(['close', handle]);
+    },
+    unlinkSync(filePath) {
+      calls.push(['unlink', filePath]);
+    },
+    rmdirSync(filePath) {
+      calls.push(['rmdir', filePath]);
+    },
+  };
+
+  assert.throws(
+    () => storeKeyVaultSecret(
+      {
+        vaultName: 'my-vault',
+        secretName: 'my-secret',
+        secretValue: 'partial-write-test',
+      },
+      {
+        fsImpl,
+        osImpl: { tmpdir: () => '/tmp' },
+        pathImpl: path.posix,
+        platform: 'linux',
+        spawnSyncImpl: () => assert.fail('az must not run after a partial write'),
+      }
+    ),
+    (error) => error === writeError
+  );
+
+  assert.deepEqual(calls, [
+    'write',
+    ['close', 42],
+    ['unlink', '/tmp/kv-secret-private/secret'],
+    ['rmdir', '/tmp/kv-secret-private'],
+  ]);
+});
+
+test('store-keyvault-secret preserves the az failure when cleanup also fails', () => {
+  const unlinkError = new Error('secret file is still busy');
+  unlinkError.code = 'EBUSY';
+  const directoryError = new Error('temporary directory is not empty');
+  directoryError.code = 'ENOTEMPTY';
+  const fsImpl = {
+    mkdtempSync: () => 'C:\\Temp\\kv-secret-private',
+    openSync: () => 42,
+    writeFileSync: () => {},
+    closeSync: () => {},
+    unlinkSync: () => { throw unlinkError; },
+    rmdirSync: () => { throw directoryError; },
+  };
+
+  assert.throws(
+    () => storeKeyVaultSecret(
+      {
+        vaultName: 'my-vault',
+        secretName: 'my-secret',
+        secretValue: 'cleanup-test',
+      },
+      {
+        fsImpl,
+        osImpl: { tmpdir: () => 'C:\\Temp' },
+        pathImpl: path.win32,
+        platform: 'win32',
+        spawnSyncImpl: () => ({
+          status: 1,
+          stderr: 'Azure denied the request',
+        }),
+      }
+    ),
+    (error) => {
+      assert.equal(error.code, 'AZ_COMMAND_FAILED');
+      assert.equal(error.stderr, 'Azure denied the request');
+      assert.equal(error.cleanupError.code, 'TEMP_CLEANUP_FAILED');
+      assert.match(error.cleanupError.message, /secret file is still busy/);
+      assert.match(error.cleanupError.message, /temporary directory is not empty/);
+      return true;
+    }
+  );
 });

--- a/plugins/power-pages/scripts/tests/store-keyvault-secret.test.js
+++ b/plugins/power-pages/scripts/tests/store-keyvault-secret.test.js
@@ -6,7 +6,7 @@ const path = require('path');
 const { spawnSync } = require('child_process');
 
 const cliPath = path.join(__dirname, '..', 'store-keyvault-secret.js');
-const { runCli, storeKeyVaultSecret } = require('../store-keyvault-secret');
+const { parseArgs, runCli, storeKeyVaultSecret } = require('../store-keyvault-secret');
 
 function runStoreKeyvaultSecret(args, opts = {}) {
   return spawnSync(process.execPath, [cliPath, ...args], {
@@ -177,6 +177,41 @@ for (const [name, args] of [
     assert.equal(stderr, 'Error: Secret value is empty.\n');
   });
 }
+
+test('store-keyvault-secret parses unambiguous inline secret values verbatim', () => {
+  assert.equal(
+    parseArgs(['--secretValue=--foo']).secretValue,
+    '--foo'
+  );
+  assert.equal(
+    parseArgs(['--secretValue=value with spaces=and=equals']).secretValue,
+    'value with spaces=and=equals'
+  );
+});
+
+test('store-keyvault-secret rejects empty inline --secretValue without reading stdin', () => {
+  let stderr = '';
+  const status = runCli(
+    [
+      '--vaultName', 'my-vault',
+      '--secretName', 'my-secret',
+      '--secretValue=',
+    ],
+    {
+      stdin: {
+        isTTY: false,
+        get fd() {
+          assert.fail('stdin must not be read when inline --secretValue is present');
+        },
+      },
+      stdout: { write: () => assert.fail('empty secrets must not produce output') },
+      stderr: { write: (value) => { stderr += value; } },
+    }
+  );
+
+  assert.equal(status, 1);
+  assert.equal(stderr, 'Error: Secret value is empty.\n');
+});
 
 test('store-keyvault-secret uses a private temp directory and keeps the secret out of az argv', (t) => {
   const tempRoot = makeTempRoot(t);

--- a/plugins/power-pages/scripts/tests/store-keyvault-secret.test.js
+++ b/plugins/power-pages/scripts/tests/store-keyvault-secret.test.js
@@ -136,6 +136,48 @@ test('store-keyvault-secret rejects explicit empty --secretValue without reading
   assert.equal(stderr, 'Error: Secret value is empty.\n');
 });
 
+for (const [name, args] of [
+  [
+    'bare trailing --secretValue',
+    [
+      '--vaultName', 'my-vault',
+      '--secretName', 'my-secret',
+      '--secretValue',
+    ],
+  ],
+  [
+    '--secretValue followed by another option',
+    [
+      '--vaultName', 'my-vault',
+      '--secretName', 'my-secret',
+      '--secretValue', '--unused',
+    ],
+  ],
+]) {
+  test(`store-keyvault-secret rejects ${name} without reading stdin`, () => {
+    let stderr = '';
+    const status = runCli(
+      args,
+      {
+        stdin: {
+          isTTY: false,
+          get fd() {
+            assert.fail('stdin must not be read when --secretValue is present');
+          },
+        },
+        stdout: { write: () => assert.fail('missing values must not produce output') },
+        stderr: { write: (value) => { stderr += value; } },
+      },
+      {
+        spawnSyncImpl: () => assert.fail('az must not run for a missing secret value'),
+      }
+    );
+
+    assert.equal(status, 1);
+    assert.equal(stderr, 'Error: Secret value is empty.\n');
+  });
+}
+
 test('store-keyvault-secret uses a private temp directory and keeps the secret out of az argv', (t) => {
   const tempRoot = makeTempRoot(t);
   const secretValue = 'secret value with spaces';

--- a/plugins/power-pages/scripts/tests/store-keyvault-secret.test.js
+++ b/plugins/power-pages/scripts/tests/store-keyvault-secret.test.js
@@ -16,63 +16,12 @@ function runStoreKeyvaultSecret(args, opts = {}) {
   });
 }
 
-function makeFakeAzureCli(t) {
+function makeTempRoot(t) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'store-keyvault-secret-test-'));
-  const binDir = path.join(root, 'fake az bin');
   const tempRoot = path.join(root, 'temporary files');
-  const reportPath = path.join(root, 'az-report.json');
-  const fakeAzPath = path.join(binDir, 'fake-az.js');
-
-  fs.mkdirSync(binDir);
   fs.mkdirSync(tempRoot);
-  fs.writeFileSync(fakeAzPath, `
-const fs = require('fs');
-const path = require('path');
-const args = process.argv.slice(2);
-const fileIndex = args.indexOf('--file');
-const secretPath = fileIndex === -1 ? null : args[fileIndex + 1];
-const report = {
-  argv: args,
-  secret: secretPath ? fs.readFileSync(secretPath, 'utf8') : null,
-  secretPath,
-  fileMode: secretPath ? fs.statSync(secretPath).mode & 0o777 : null,
-  directoryMode: secretPath ? fs.statSync(path.dirname(secretPath)).mode & 0o777 : null,
-};
-fs.writeFileSync(process.env.FAKE_AZ_REPORT, JSON.stringify(report));
-if (process.env.FAKE_AZ_EXIT) {
-  process.stderr.write('fake Azure CLI failure\\n');
-  process.exit(Number(process.env.FAKE_AZ_EXIT));
-}
-process.stdout.write(JSON.stringify({ secretUri: 'https://example.vault.azure.net/secrets/test/version' }));
-`);
-
-  if (process.platform === 'win32') {
-    fs.writeFileSync(
-      path.join(binDir, 'az.cmd'),
-      `@"${process.execPath}" "%~dp0fake-az.js" %*\r\n`
-    );
-  } else {
-    const launcherPath = path.join(binDir, 'az');
-    fs.writeFileSync(launcherPath, '#!/usr/bin/env node\nrequire("./fake-az.js");\n', { mode: 0o755 });
-  }
-
   t.after(() => fs.rmSync(root, { recursive: true, force: true }));
-
-  return {
-    reportPath,
-    tempRoot,
-    env(overrides = {}) {
-      return {
-        ...process.env,
-        PATH: `${binDir}${path.delimiter}${process.env.PATH || ''}`,
-        TMPDIR: tempRoot,
-        TMP: tempRoot,
-        TEMP: tempRoot,
-        FAKE_AZ_REPORT: reportPath,
-        ...overrides,
-      };
-    },
-  };
+  return tempRoot;
 }
 
 test('store-keyvault-secret fails with no arguments', () => {
@@ -164,19 +113,48 @@ test('store-keyvault-secret rejects empty stdin', () => {
 });
 
 test('store-keyvault-secret uses a private temp directory and keeps the secret out of az argv', (t) => {
-  const fakeAzureCli = makeFakeAzureCli(t);
+  const tempRoot = makeTempRoot(t);
   const secretValue = 'secret value with spaces';
-  const result = runStoreKeyvaultSecret([
-    '--vaultName', 'my-vault',
-    '--secretName', 'my-secret',
-  ], { input: secretValue, env: fakeAzureCli.env() });
+  let report;
 
-  assert.equal(result.status, 0, result.stderr);
-  const report = JSON.parse(fs.readFileSync(fakeAzureCli.reportPath, 'utf8'));
+  const result = storeKeyVaultSecret(
+    {
+      vaultName: 'my-vault',
+      secretName: 'my-secret',
+      secretValue,
+    },
+    {
+      osImpl: { tmpdir: () => tempRoot },
+      spawnSyncImpl(command, args, options) {
+        const fileIndex = args.indexOf('--file');
+        const secretPath = fileIndex === -1 ? null : args[fileIndex + 1];
+        report = {
+          command,
+          args,
+          options,
+          secret: fs.readFileSync(secretPath, 'utf8'),
+          secretPath,
+          fileMode: fs.statSync(secretPath).mode & 0o777,
+          directoryMode: fs.statSync(path.dirname(secretPath)).mode & 0o777,
+        };
+        return {
+          status: 0,
+          stdout: JSON.stringify({
+            secretUri: 'https://example.vault.azure.net/secrets/test/version',
+          }),
+          stderr: '',
+        };
+      },
+    }
+  );
+
+  assert.equal(result.secretUri, 'https://example.vault.azure.net/secrets/test/version');
+  assert.equal(report.command, 'az');
+  assert.deepEqual(report.options, { encoding: 'utf8', timeout: 30000 });
   assert.equal(report.secret, secretValue);
-  assert.equal(report.argv.includes(secretValue), false);
-  assert.notEqual(path.dirname(report.secretPath), fakeAzureCli.tempRoot);
-  assert.equal(report.secretPath.startsWith(`${fakeAzureCli.tempRoot}${path.sep}`), true);
+  assert.equal(report.args.includes(secretValue), false);
+  assert.notEqual(path.dirname(report.secretPath), tempRoot);
+  assert.equal(report.secretPath.startsWith(`${tempRoot}${path.sep}`), true);
   assert.equal(fs.existsSync(report.secretPath), false);
   assert.equal(fs.existsSync(path.dirname(report.secretPath)), false);
   if (process.platform !== 'win32') {
@@ -186,17 +164,48 @@ test('store-keyvault-secret uses a private temp directory and keeps the secret o
 });
 
 test('store-keyvault-secret cleans up the private temp directory when az fails', (t) => {
-  const fakeAzureCli = makeFakeAzureCli(t);
-  const result = runStoreKeyvaultSecret([
-    '--vaultName', 'my-vault',
-    '--secretName', 'my-secret',
-  ], {
-    input: 'secret-on-failure',
-    env: fakeAzureCli.env({ FAKE_AZ_EXIT: '7' }),
-  });
+  const tempRoot = makeTempRoot(t);
+  const secretValue = 'secret-on-failure';
+  let report;
 
-  assert.equal(result.status, 1);
-  const report = JSON.parse(fs.readFileSync(fakeAzureCli.reportPath, 'utf8'));
+  assert.throws(
+    () => storeKeyVaultSecret(
+      {
+        vaultName: 'my-vault',
+        secretName: 'my-secret',
+        secretValue,
+      },
+      {
+        osImpl: { tmpdir: () => tempRoot },
+        spawnSyncImpl(command, args) {
+          const fileIndex = args.indexOf('--file');
+          const secretPath = fileIndex === -1 ? null : args[fileIndex + 1];
+          report = {
+            command,
+            args,
+            secret: fs.readFileSync(secretPath, 'utf8'),
+            secretPath,
+          };
+          return {
+            status: 7,
+            stdout: '',
+            stderr: 'fake Azure CLI failure\n',
+          };
+        },
+      }
+    ),
+    (error) => {
+      assert.equal(error.code, 'AZ_COMMAND_FAILED');
+      assert.equal(error.stderr, 'fake Azure CLI failure\n');
+      return true;
+    }
+  );
+
+  assert.equal(report.command, 'az');
+  assert.equal(report.secret, secretValue);
+  assert.equal(report.args.includes(secretValue), false);
+  assert.notEqual(path.dirname(report.secretPath), tempRoot);
+  assert.equal(report.secretPath.startsWith(`${tempRoot}${path.sep}`), true);
   assert.equal(fs.existsSync(report.secretPath), false);
   assert.equal(fs.existsSync(path.dirname(report.secretPath)), false);
 });

--- a/plugins/power-pages/scripts/tests/store-keyvault-secret.test.js
+++ b/plugins/power-pages/scripts/tests/store-keyvault-secret.test.js
@@ -27,7 +27,14 @@ function makeTempRoot(t) {
 test('store-keyvault-secret fails with no arguments', () => {
   const result = runStoreKeyvaultSecret([]);
   assert.equal(result.status, 1);
-  assert.match(result.stderr, /Usage:/);
+  assert.match(
+    result.stderr,
+    /printf '%s' '<value>' \| node store-keyvault-secret\.js --vaultName <name> --secretName <name>/
+  );
+  assert.match(result.stderr, /--secretValue <value>/);
+  assert.match(result.stderr, /--secretValue=<value>/);
+  assert.match(result.stderr, /Prefer stdin so the secret is not visible in process arguments/);
+  assert.match(result.stderr, /Use the `=` form for values that begin with dashes/);
 });
 
 test('store-keyvault-secret fails with missing --secretName', () => {

--- a/plugins/power-pages/scripts/tests/store-keyvault-secret.test.js
+++ b/plugins/power-pages/scripts/tests/store-keyvault-secret.test.js
@@ -6,7 +6,7 @@ const path = require('path');
 const { spawnSync } = require('child_process');
 
 const cliPath = path.join(__dirname, '..', 'store-keyvault-secret.js');
-const { storeKeyVaultSecret } = require('../store-keyvault-secret');
+const { runCli, storeKeyVaultSecret } = require('../store-keyvault-secret');
 
 function runStoreKeyvaultSecret(args, opts = {}) {
   return spawnSync(process.execPath, [cliPath, ...args], {
@@ -110,6 +110,30 @@ test('store-keyvault-secret rejects empty stdin', () => {
   ], { input: '' });
   assert.equal(result.status, 1);
   assert.match(result.stderr, /Secret value is empty/);
+});
+
+test('store-keyvault-secret rejects explicit empty --secretValue without reading stdin', () => {
+  let stderr = '';
+  const status = runCli(
+    [
+      '--vaultName', 'my-vault',
+      '--secretName', 'my-secret',
+      '--secretValue', '',
+    ],
+    {
+      stdin: {
+        isTTY: false,
+        get fd() {
+          assert.fail('stdin must not be read when --secretValue is present');
+        },
+      },
+      stdout: { write: () => assert.fail('empty secrets must not produce output') },
+      stderr: { write: (value) => { stderr += value; } },
+    }
+  );
+
+  assert.equal(status, 1);
+  assert.equal(stderr, 'Error: Secret value is empty.\n');
 });
 
 test('store-keyvault-secret uses a private temp directory and keeps the secret out of az argv', (t) => {


### PR DESCRIPTION
## Summary

- create each secret in a private `fs.mkdtempSync` directory and open the file with `wx` and owner-only POSIX permissions
- clean the file descriptor, file, and directory in `finally`, including partial writes, while retaining Azure CLI and cleanup errors
- verify secret-free Azure CLI arguments, temp paths with spaces, symlink refusal, Windows permission handling, and cleanup on success and failure

## Testing

- `POWER_PLATFORM_SKILLS_TELEMETRY_POWER_PAGES_OPTOUT=1 node --test plugins/power-pages/scripts/tests/`