### PR TITLE
docs(model-apps): sync the roadmap's spec-status section

### DIFF
--- a/plugins/model-apps/docs/app-builder-roadmap.md
+++ b/plugins/model-apps/docs/app-builder-roadmap.md
@@ -74,10 +74,10 @@ are in [`architecture.md`](architecture.md).
 ## 🎯 MVP gaps vs the MDA Agentic Authoring spec
 
 Evaluated 2026-08-12 against `powerplatform-modelpages-ade/docs/topics/ModelBuilder/MDA-Agentic-Authoring-spec.md`
-(§3 MVP definition + §5 stack rank). **9 of 10 core P0 _primitives_ are ✅ complete** — roles + JTBDs as
-first-class planning outputs, data model + sample data
-+ auto-number + dedup, Active/Inactive + authored views, main forms, charts, gen-page landings, custom SVG sitemap
-icons, in-app agents (`ai.appFeatures` = formFill/nlSearch/nlChart), Insight Card summaries (`ai.summaries`), and
+(§3 MVP definition + §5 stack rank). **9 of 10 core P0 _primitives_ are ✅ complete** — roles + JTBDs as first-class planning outputs,
+data model + sample data, auto-number + dedup, Active/Inactive + authored views, main forms, charts,
+gen-page landings, custom SVG sitemap icons, in-app agents (`ai.appFeatures` = formFill/nlSearch/nlChart),
+Insight Card summaries (`ai.summaries`), and
 the dedup/verify quality gates. The open MVP items:
 
 - 🔲 **Wave 2 (header/navigation refresh) enabled by default** (spec rank 3, P0) — set the app-module header/nav

--- a/plugins/model-apps/docs/app-builder-roadmap.md
+++ b/plugins/model-apps/docs/app-builder-roadmap.md
@@ -73,8 +73,9 @@ are in [`architecture.md`](architecture.md).
 
 ## 🎯 MVP gaps vs the MDA Agentic Authoring spec
 
-Evaluated 2026-07-28 against `powerplatform-modelpages-ade/docs/topics/ModelBuilder/MDA-Agentic-Authoring-spec.md`
-(§3 MVP definition + §5 stack rank). **8 of 10 core P0 _primitives_ are ✅ complete** — data model + sample data
+Evaluated 2026-08-12 against `powerplatform-modelpages-ade/docs/topics/ModelBuilder/MDA-Agentic-Authoring-spec.md`
+(§3 MVP definition + §5 stack rank). **9 of 10 core P0 _primitives_ are ✅ complete** — roles + JTBDs as
+first-class planning outputs, data model + sample data
 + auto-number + dedup, Active/Inactive + authored views, main forms, charts, gen-page landings, custom SVG sitemap
 icons, in-app agents (`ai.appFeatures` = formFill/nlSearch/nlChart), Insight Card summaries (`ai.summaries`), and
 the dedup/verify quality gates. The open MVP items:
@@ -101,8 +102,10 @@ Important, P1 (not MVP-gating; tracked here for visibility):
   **custom app theme + logo** (rank 18 — the `design` block styles gen pages, not the app theme).
 
 P0.5 stretch (not built): **modern grid visualizations by default** (rank 11, contingent on the SDK grid-customizer)
-and **MCP server + Catalyst by default** (rank 12). A status-annotated copy of the spec's §5 stack rank lives on
-branch `users/akmaloo/mda-spec-impl-status` in `powerplatform-modelpages-ade`.
+and **MCP server + Catalyst by default** (rank 12). The spec's §5 stack rank carries a status column annotated from
+this roadmap; it is refreshed on `master` in `powerplatform-modelpages-ade` (last synced 2026-08-12, plugin v2.4.3).
+**Keep the two in step** — when a row here flips, update that column in the same pass, or the spec silently goes
+stale (ranks 1 / 14 / 29 sat wrong for two weeks after the persona work shipped).
 
 ---
 


### PR DESCRIPTION
Docs-only sync, found while refreshing the [MDA Agentic Authoring spec](https://microsoft.ghe.com/bic/powerplatform-modelpages-ade/blob/master/docs/topics/ModelBuilder/MDA-Agentic-Authoring-spec.md) status column (pushed to that repo's `master` as `bde4be5`).

Two stale bits in `docs/app-builder-roadmap.md`:

1. **The "8 of 10 core P0 primitives" count contradicted its own section.** The bullet list directly below it already said roles + JTBDs as first-class planning outputs (spec rank 1) was ✅, but the count was never updated when that shipped. Now **9 of 10**, with rank 1 named in the list.
2. **The branch pointer was dead.** `users/akmaloo/mda-spec-impl-status` merged; the spec's status column lives on `master` now.

I also added an explicit *keep the two in step* note. The spec's status column had ranks **1 / 14 / 29** wrong for ~2 weeks after the persona/security work landed (2026-08-03), because nothing connected "flip a row in the roadmap" to "update the column in the spec". Naming the drift is cheaper than rediscovering it.

### On the spec side (separate repo, already pushed)

Each status change was verified against the plugin rather than inferred from this roadmap:

| Rank | Was | Now | Evidence |
|---|---|---|---|
| 1 — planning pass with roles + JTBDs | 🟡 | ✅ | `personas[]` with `jobs[]` → `privileges[]` + `surfaces[]`; captured before the data model; plan-mode gate |
| 14 — security roles per persona | ❌ | ✅ | `security` is one of the engine's 14 build phases; vendored bundle carries `createPersonaRole` / `createSecurityRole` / `deleteSecurityRole` / `associateRecords` |
| 29 — README output | 🟡 | ✅ | `model-app-plan.md` renders jobs→surfaces traceability, entity map, surfaces, access model per role, sample data, AI features |

Rows left unchanged were **re-checked, not assumed** — e.g. rank 22 (rich AI descriptions) stays ❌ because the App Spec carries `description` only on `app`, and rank 16 (role-specific forms/views) stays ❌ because forms have no persona/role linkage. That evidence is now recorded in the spec footnote so the next pass need not re-derive it.

### Verification

- Plugin suite **1427 pass / 0 fail**.
- Spec table re-parsed after editing: all 47 ranks present, no duplicates, no unknown status glyphs; tally moves 10/6/28/3 → 13/4/27/3 (Done/Partial/Missing/Platform).
