### PR TITLE
feat(model-apps): verify what persona security roles actually grant

### DIFF
--- a/plugins/model-apps/AGENTS.md
+++ b/plugins/model-apps/AGENTS.md
@@ -423,6 +423,9 @@ scripts/
     sdk-teardown.js            ← app-builder teardown engine (planTeardown is pure)
     sdk-http-client.js         ← az-token HttpClient for the vendored SDK
     spec-lint.js / app-spec.js ← App Spec guardrail lint + validation
+    spec-shape.js              ← shared structural normalization for both authoring gates
+    surface-resolver.js        ← pure: resolve personas[].jobs[].surfaces[] to the spec artifacts that satisfy them
+    role-privileges.js         ← pure: declared persona privileges + subset comparison against a deployed role
     odata.js                   ← OData literal escaping helpers
     genpage-cli.js             ← pac model genpage upload/list/download wrapper
     hydrate-spec.js            ← reconstruct an App Spec from a deployed app (edit flow)

--- a/plugins/model-apps/CHANGELOG.md
+++ b/plugins/model-apps/CHANGELOG.md
@@ -4,10 +4,29 @@ All notable changes to the **model-apps** plugin.
 
 ## [Unreleased] — 2.4.4
 
-Adds plugin update notices, fixes four crash paths, and corrects a smoke-eval
-assertion that could never pass live.
+Adds plugin update notices, proves what persona roles actually grant, makes
+jobs-to-be-done surfaces checkable, fixes four crash paths, and corrects a
+smoke-eval assertion that could never pass live.
 
 ### Added
+- **`verify` now proves what a persona security role GRANTS, not just that it
+  exists.** The `role` check only asserted a role row carrying the SDK ownership
+  marker, so a role built with the wrong access — or one whose privilege write
+  failed after the row landed — verified clean. The new `role-privileges` check
+  resolves every declared `(entity, access)` to its Dataverse `PrivilegeId` from
+  the same metadata source the SDK writes against, and asserts the role holds it
+  at **at least** the declared depth. A **subset** check by design: extra
+  privileges are never a finding, because `appAccess` injects `appmodule` read,
+  unioned jobs escalate a shared entity+access to the max declared scope, and
+  distinct entities can share one Dataverse privilege. Fails **closed** on an
+  unreadable role or table. Reader-gated, so existence-only callers are unchanged.
+- **`personas[].jobs[].surfaces[]` is checked instead of documentary.** Each entry
+  is now resolved against the spec's own views, forms, pages, dashboards, tables
+  and sitemap titles. `spec-lint` **warns** when a surface matches nothing — a
+  warning, not an error, because a surface may legitimately name an out-of-the-box
+  artifact this spec never authors. `verify` adds a `job-surface` rollup that
+  reports a deployed failure as the job it broke ("persona P can no longer do job
+  J"), rather than only "view X is missing".
 - **Automatic plugin update notice.** Every user-invocable skill now runs the
   non-blocking `scripts/check-version.js` preflight, which compares the installed
   Model Apps version with `origin/main` and shows update commands for the active

--- a/plugins/model-apps/docs/app-builder-roadmap.md
+++ b/plugins/model-apps/docs/app-builder-roadmap.md
@@ -231,6 +231,21 @@ Source: `IMPROVEMENTS-07-15-app-builder.md` (Project Management V1/V2 diff + a s
 - 🔲 **Spec templates** — domain starters (support desk, CRM, asset tracking) as one-shot scaffolds.
 
 ### Phase: Quality & docs
+- ✅ **Security-role and jobs-to-be-done verification (2026-08-14)** — both **metadata-only**:
+  - **`verify` now proves what a persona role GRANTS, not just that it exists.** The `role` check
+    only asserted a row carrying the SDK marker, so a role built with the wrong access — or one whose
+    privilege write failed after the row landed — verified clean. The new `role-privileges` check
+    resolves each declared `(entity, access)` to its Dataverse `PrivilegeId` from the **same
+    metadata source the SDK writes against** and asserts the role holds it at **at least** the
+    declared depth. Deliberately a **subset** check (`lib/role-privileges.js` explains why equality
+    would false-fail on `appAccess` injection, max-scope union, and shared privileges), and
+    **fail-closed** on an unreadable role or table.
+  - **`surfaces[]` is no longer documentary.** `lib/surface-resolver.js` resolves every
+    `personas[].jobs[].surfaces[]` entry against the spec's own views/forms/pages/dashboards/tables
+    /sitemap titles; `spec-lint` **warns** when one matches nothing (a warning, not an error — a
+    surface may legitimately name an OOB artifact), and `verify` adds a `job-surface` rollup that
+    reports a *deployed* failure as the job it broke ("persona P can no longer do job J") rather
+    than only "view X is missing".
 - ✅ **Sample-run UX fixes (2026-07-27, from a live Property-Listings build).**
   - ✅ **#1 live build status.** A long build now writes `<workspace>/.maker-workspace/build-status.json` (a single-object snapshot — `state`/`steps`/`lastPhase`/`lastLabel` — overwritten every step) alongside the `build-log.jsonl` trace, and prints a `▸ live progress:` path at start. So a multi-minute build is observable even when the launching shell buffers stdout. SKILL.md now tells the agent to stream (Tee, not Select-Object) and read the status file.
   - ✅ **#2 wireframes shown.** SKILL.md Phase-1 preview step now REQUIRES pasting the `preview-app.js`/`preview-form.js` wireframe output to the user (not summarizing "looks right") before the approval gate — the user must see the forms/sitemap/pages they approve.

--- a/plugins/model-apps/references/app-spec-schema.md
+++ b/plugins/model-apps/references/app-spec-schema.md
@@ -605,7 +605,7 @@ privilege removes it — the role converges to the spec).
 **Field reference**
 - `persona` (**required**) — the security role's display name; also its idempotency key. Must be unique across `personas[]`.
 - `jobs[]` (**required**, ≥1) — `{ name, description?, surfaces?, privileges[] }`. `privileges[]` is required and non-empty per job.
-- `jobs[].surfaces[]` (optional) — the view/form/page names (or page `key`s) that let this persona **do** the job. Documentary only: it is never applied to Dataverse. It renders the jobs→surfaces traceability table in `model-app-plan.md`, and a job with no `surfaces[]` is flagged by `spec-lint.js` as a design gap — nothing in the app demonstrably lets that persona do that job.
+- `jobs[].surfaces[]` (optional) — the view/form/page names (or page `key`s) that let this persona **do** the job. Never applied to Dataverse. It renders the jobs→surfaces traceability table in `model-app-plan.md`; a job with no `surfaces[]` is flagged by `spec-lint.js` as a design gap, and a surface that **matches nothing this spec builds** is flagged too (`lib/surface-resolver.js` resolves each entry against `views[]` / `forms[]` / `pages[]` (key **or** name) / `dashboards[]` / `entities[]` / sitemap subarea titles, case-insensitively). Both are **warnings**, never errors — a surface may legitimately name an out-of-the-box artifact this spec does not author. `verify-model-app` additionally rolls a *deployed* failure up to the job that depended on it (`job-surface`), so "view X is missing" also reads as "persona P can no longer do job J".
 - `privileges[].entity` (**required**) — a table **logical name** (e.g. `account`, `msdyn_workorder`). May be a table this spec doesn't author (standard/system tables are common); existence is resolved against live metadata by the build, not at lint time.
 - `privileges[].access` (**required**) — one or more of `read · create · write · delete · append · appendTo · assign · share`.
 - `privileges[].scope` (optional, default `user`) — `user` (Basic) · `businessUnit` (Local) · `parentChild` (Deep) · `organization` (Global), least→most permissive.
@@ -626,6 +626,15 @@ business unit is never touched. Because roles are keyed by (name, BU), two apps 
 of the **same name in the same business unit** share one role by design (the second build reuses the
 first's) — give personas distinct names, or a distinct `businessUnitId`, if you need separate roles. In
 `--changed-only` mode a persona change forces a **full build** (there is no partial security apply yet).
+
+**Verification.** `verify-model-app` proves the role **row** exists carrying the SDK ownership marker
+(`role`) *and* — when the reader supplies role/entity privilege access — that the role actually
+**grants** every declared privilege at **at least** the declared depth (`role-privileges`). The depth
+comparison is a **subset** check by design: extra privileges are never a finding, because `appAccess`
+injects `appmodule` read, unioned jobs escalate a shared entity+access to the max declared scope, and
+distinct entities can share one Dataverse privilege (a role holds one depth per privilege). It fails
+**closed** — an unreadable role, or a table whose privilege metadata cannot be read, is reported
+rather than skipped.
 
 **Validation rules** (`validateAppSpec`): `persona` required + unique; each job needs a `name` and a
 non-empty `privileges[]`; `access` values and `scope` must be valid tokens; `appAccess` must be a

--- a/plugins/model-apps/scripts/lib/role-privileges.js
+++ b/plugins/model-apps/scripts/lib/role-privileges.js
@@ -1,0 +1,95 @@
+// plugins/model-apps/scripts/lib/role-privileges.js
+// PURE: what privileges a persona's security role MUST hold, and whether a deployed role holds them.
+//
+// WHY this exists. `verifySpec`'s role check proved only that a role ROW exists carrying the SDK
+// ownership marker. It never looked at the role's privileges — so a role created with the wrong
+// access, or one whose privilege write silently failed after the row was created, verified clean.
+// That is a metadata read, which is why it is cheap enough to run on every verify.
+//// SUBSET, not equality. We assert the role holds AT LEAST every declared privilege at AT LEAST the
+// declared depth. Extra privileges are never a finding, and that is deliberate — three legitimate
+// sources add privileges the spec does not literally list:
+//   1. `appAccess` injects `appmodule` read (see personaRoleSpecFor).
+//   2. Several jobs unioned together escalate a shared entity+access to the MAX declared scope.
+//   3. Distinct entities can share ONE Dataverse privilege, and a role holds one depth per
+//      privilege — so the SDK raises that privilege to the highest scope any of them asked for.
+// An equality check would fail on all three while telling us nothing true.
+//
+// Dataverse reference — privilege depth (`Depth` on ReplacePrivilegesRole, `RolePrivilegeDepth`):
+// Basic (user) < Local (business unit) < Deep (parent/child) < Global (organization).
+// https://learn.microsoft.com/en-us/power-apps/developer/data-platform/security-model
+'use strict';
+
+// App Spec scope -> Dataverse depth name, and its ORDER. The order is what makes this a subset
+// check: a role holding Global satisfies a declared Basic. Mirrors the vendored SDK's own mapping
+// (verified against scripts/vendor/cds-maker-sdk.cjs) so a comparison cannot disagree with the write.
+const SCOPE_DEPTH = { user: 'Basic', businessUnit: 'Local', parentChild: 'Deep', organization: 'Global' };
+const DEPTH_RANK = { basic: 1, local: 2, deep: 3, global: 4 };
+// App Spec access token -> Dataverse PrivilegeType, again mirroring the SDK.
+const ACCESS_TYPE = { read: 'Read', create: 'Create', write: 'Write', delete: 'Delete', append: 'Append', appendTo: 'AppendTo', assign: 'Assign', share: 'Share' };
+
+const rankOf = (depth) => DEPTH_RANK[String(depth == null ? '' : depth).trim().toLowerCase()] || 0;
+
+// Flatten a persona to the (entity, access, scope) triples its role must satisfy, taking the MAX
+// scope per (entity, access) exactly as the builder's union does. `appAccess` is folded in here so
+// the expectation matches what the build actually writes rather than what the author typed.
+function declaredPrivileges(persona) {
+  const byKey = new Map(); // "<entity>|<access>" -> { entity, access, scope }
+  const addAll = (list) => {
+    for (const pr of list || []) {
+      if (!pr || !pr.entity) continue;
+      const entity = String(pr.entity).trim().toLowerCase();
+      const scope = pr.scope || 'user';
+      for (const a of pr.access || []) {
+        const access = String(a).trim();
+        if (!access) continue;
+        const key = `${entity}|${access.toLowerCase()}`;
+        const prev = byKey.get(key);
+        // Max scope wins — the same rule the builder applies when unioning jobs into one role.
+        if (!prev || rankOf(SCOPE_DEPTH[scope]) > rankOf(SCOPE_DEPTH[prev.scope])) byKey.set(key, { entity, access, scope });
+      }
+    }
+  };
+  for (const j of (persona && persona.jobs) || []) addAll(j && j.privileges);
+  addAll(persona && persona.additionalPrivileges);
+  // Mirrors personaRoleSpecFor: unless the persona opts out, the build grants appmodule read so the
+  // app actually opens for them. Verifying it matters — without it the role exists but the app does not.
+  if (!persona || persona.appAccess !== false) addAll([{ entity: 'appmodule', access: ['read'], scope: 'organization' }]);
+  return [...byKey.values()];
+}
+
+// Compare declared privileges against what the role actually holds.
+//   `entityPrivileges`: Map<entityLogical, [{ Name, PrivilegeId, PrivilegeType }]> — from
+//                       EntityDefinitions(LogicalName='x')?$select=Privileges, the SAME source the
+//                       SDK resolves against when it writes.
+//   `actualByPrivilegeId`: Map<privilegeId(lowercased), depthName>
+// Returns { ok, missing:[{ entity, access, scope, reason, privilegeName? }] }.
+// An entity whose metadata could not be read is reported as a finding, never skipped — a read
+// failure must not read as "nothing missing" (fail closed).
+function compareRolePrivileges(declared, entityPrivileges, actualByPrivilegeId) {
+  const missing = [];
+  for (const d of declared) {
+    const privs = entityPrivileges.get(d.entity);
+    if (!privs) {
+      missing.push({ ...d, reason: `could not read privilege metadata for '${d.entity}'` });
+      continue;
+    }
+    const type = ACCESS_TYPE[d.access.toLowerCase()];
+    const p = type && privs.find((x) => x && x.PrivilegeType === type);
+    if (!p) {
+      missing.push({ ...d, reason: `'${d.entity}' exposes no '${d.access}' privilege` });
+      continue;
+    }
+    const held = actualByPrivilegeId.get(String(p.PrivilegeId || '').trim().toLowerCase());
+    if (!held) {
+      missing.push({ ...d, privilegeName: p.Name, reason: `role does not hold ${p.Name}` });
+      continue;
+    }
+    const want = SCOPE_DEPTH[d.scope] || 'Basic';
+    if (rankOf(held) < rankOf(want)) {
+      missing.push({ ...d, privilegeName: p.Name, reason: `role holds ${p.Name} at ${held}, below the declared ${want}` });
+    }
+  }
+  return { ok: missing.length === 0, missing };
+}
+
+module.exports = { declaredPrivileges, compareRolePrivileges, SCOPE_DEPTH, ACCESS_TYPE, DEPTH_RANK };

--- a/plugins/model-apps/scripts/lib/spec-lint.js
+++ b/plugins/model-apps/scripts/lib/spec-lint.js
@@ -4,6 +4,7 @@
 // relationship schema-name vs lookup-name collision Dataverse rejects.
 const { relationshipSchemaName, relationshipFor, invalidChoiceSampleTokens, isPlatformIconRef } = require('./app-spec.js');
 const { normalizeSpecShape } = require('./spec-shape.js');
+const { resolveSurfaces, unresolvedSurfaceMessage } = require('./surface-resolver.js');
 
 const CHOICE_OPTION_WARN = 12;
 const SEQNUM_RE = /\{SEQNUM(:\d+)?\}/i;
@@ -390,6 +391,11 @@ function lintAppSpec(spec) {
       W(`persona "${persona}" job "${job.name}" is not mapped to a surface (jobs[].surfaces[]) — nothing in this app demonstrably lets that persona do the job.`);
     }
   }
+  // A surface that names nothing this spec builds is the NEXT failure after "no surfaces at all":
+  // the job claims coverage that does not exist. Only a warning, because a surface may legitimately
+  // name an out-of-the-box artifact this spec never authors (the same reason app-spec.js validates
+  // surfaces as shape-only) — see lib/surface-resolver.js.
+  for (const u of resolveSurfaces(spec).unresolved) W(unresolvedSurfaceMessage(u));
   if (!(Array.isArray(spec.pages) && spec.pages.length)) {
     W('no pages[] — per the genpage-first policy, non-record surfaces (overview/landing, dashboard, analytics, guided or wizard flows) should be generative pages. If this app is genuinely record-CRUD only, ignore this.');
   }

--- a/plugins/model-apps/scripts/lib/surface-resolver.js
+++ b/plugins/model-apps/scripts/lib/surface-resolver.js
@@ -1,0 +1,95 @@
+// plugins/model-apps/scripts/lib/surface-resolver.js
+// PURE: resolve each `personas[].jobs[].surfaces[]` entry to the App Spec artifact that satisfies it.
+//
+// WHY this exists. `surfaces[]` is the only machine-readable claim in the spec that says *this job is
+// satisfied by these screens*. Until now it was documentary — `app-spec.js` validates that each entry
+// is a non-empty string and stops, and `spec-lint.js` warns only when the array is EMPTY. So a job
+// could name "My Open Work Orders" when no such view existed anywhere in the spec and every gate
+// passed. That is a coherence defect the build cannot catch either: the builder never reads
+// `surfaces[]`, so nothing downstream fails.
+//
+// Deliberately a WARNING, not an error. The shape-only validation in `app-spec.js` is loose on
+// purpose — its comment says a surface "may legitimately name an artifact this spec doesn't author
+// (a stock view)". A spec that names the OOB "Active Accounts" view is correct and must keep
+// validating, so an unresolved surface is reported as a design smell for a human to judge, never a
+// hard failure.
+'use strict';
+
+const norm = (s) => String(s == null ? '' : s).trim().toLowerCase();
+
+// Every artifact kind a surface may legitimately name, with the field(s) a human would write.
+// Sitemap subareas are included because an author frequently names the NAV ENTRY ("Work Orders")
+// rather than the underlying view — that is a real answer to "what lets them do the job", so
+// treating it as unresolved would produce noise instead of signal.
+function buildIndex(spec) {
+  const index = new Map(); // normalized name -> [{ kind, name, entity? }]
+  const add = (name, entry) => {
+    const k = norm(name);
+    if (!k) return;
+    if (!index.has(k)) index.set(k, []);
+    // De-dupe identical (kind,name,entity) triples — e.g. a view named the same as its subarea title
+    // would otherwise report twice and read like two separate matches.
+    const list = index.get(k);
+    if (!list.some((e) => e.kind === entry.kind && norm(e.name) === norm(entry.name) && norm(e.entity || '') === norm(entry.entity || ''))) list.push(entry);
+  };
+
+  for (const v of spec.views || []) add(v && v.name, { kind: 'view', name: v.name, entity: v.entity });
+  for (const f of spec.forms || []) add(f && f.name, { kind: 'form', name: f.name, entity: f.entity });
+  for (const d of spec.dashboards || []) add(d && d.name, { kind: 'dashboard', name: d.name });
+  for (const p of spec.pages || []) {
+    // A page is referenced by stable KEY in schemaVersion 2 and by display name in prose, so accept
+    // either — an author writing the plan will reach for whichever they saw last.
+    add(p && p.name, { kind: 'page', name: p.name, key: p.key });
+    add(p && p.key, { kind: 'page', name: p.name, key: p.key });
+  }
+  for (const e of spec.entities || []) {
+    // A table itself is a surface when the app exposes it as a nav entry (grid + form). Accept the
+    // display name and the schema name.
+    add(e && e.displayName, { kind: 'entity', name: e.displayName || e.schemaName, entity: e.schemaName });
+    add(e && e.schemaName, { kind: 'entity', name: e.displayName || e.schemaName, entity: e.schemaName });
+  }
+  for (const a of (spec.appShell && spec.appShell.areas) || []) {
+    for (const g of (a && a.groups) || []) {
+      for (const sa of (g && g.subAreas) || []) add(sa && sa.title, { kind: 'subarea', name: sa.title });
+    }
+  }
+  return index;
+}
+
+// Flatten every (persona, job, surface) triple the spec declares. Jobs with no `surfaces[]` are NOT
+// reported here — `spec-lint.js` already warns about an unmapped job, and duplicating it would
+// double-report the same design gap.
+function declaredSurfaces(spec) {
+  const out = [];
+  for (const p of spec.personas || []) {
+    for (const j of (p && p.jobs) || []) {
+      for (const s of (j && j.surfaces) || []) {
+        if (typeof s === 'string' && s.trim()) out.push({ persona: (p.persona || '').trim(), job: (j.name || '').trim(), surface: s.trim() });
+      }
+    }
+  }
+  return out;
+}
+
+// Resolve every declared surface against the spec's own artifacts.
+// Returns { resolved: [{ persona, job, surface, matches:[{kind,...}] }], unresolved: [{ persona, job, surface }] }.
+function resolveSurfaces(spec) {
+  const resolved = [];
+  const unresolved = [];
+  if (!spec || typeof spec !== 'object') return { resolved, unresolved };
+  const index = buildIndex(spec);
+  for (const d of declaredSurfaces(spec)) {
+    const matches = index.get(norm(d.surface));
+    if (matches && matches.length) resolved.push({ ...d, matches: matches.slice() });
+    else unresolved.push({ ...d });
+  }
+  return { resolved, unresolved };
+}
+
+// The lint/verify message for an unresolved surface. Shared so the two gates cannot word the same
+// finding differently — a maker who sees it twice should see it identically.
+function unresolvedSurfaceMessage(u) {
+  return `persona "${u.persona}" job "${u.job}": surface "${u.surface}" does not match any view, form, page, dashboard, table or sitemap entry in this spec — either it names an out-of-the-box artifact (fine) or the job is not actually covered by anything this app builds.`;
+}
+
+module.exports = { resolveSurfaces, declaredSurfaces, unresolvedSurfaceMessage };

--- a/plugins/model-apps/scripts/lib/verify-spec.js
+++ b/plugins/model-apps/scripts/lib/verify-spec.js
@@ -9,6 +9,8 @@ const { normalizePageSource, relationshipSchemaName, manyToManySchemaName, SDK_R
 const { resolveExistingFormId, resolveRoleBusinessUnit, roleBuClause, appUniqueName } = require('./sdk-build.js');
 const { extractNavTargets } = require('./pageref-resolver.js');
 const { AI_APP_SETTING, resolveAiFlags, featureWantValue, sameSettingValue, resolveAppModuleId, proveAppOverride } = require('./ai-app-settings.js');
+const { declaredPrivileges, compareRolePrivileges } = require('./role-privileges.js');
+const { resolveSurfaces } = require('./surface-resolver.js');
 
 // The PER-APP setting each AI feature writes now lives in ./ai-app-settings.js, together with the
 // flag-resolution and override-proof helpers the BUILD uses — see that module for why one source of
@@ -261,6 +263,37 @@ async function verifySpec(spec, read, opts = {}) {
       }
     } catch { row = undefined; }
     add('role', roleName, row, row ? '' : 'persona security role not found (or its business unit could not be resolved)');
+
+    // Privilege depth check — reader-gated (see `entityRelationships` / `commandBar` above for the
+    // same pattern), so an existence-only reader behaves exactly as before. Proving the role ROW
+    // exists says nothing about what it GRANTS: a role created with the wrong access, or one whose
+    // privilege write failed after the row landed, verified clean until this check existed.
+    // SUBSET semantics — see lib/role-privileges.js for why equality would be wrong.
+    if (row && typeof read.rolePrivileges === 'function' && typeof read.entityPrivileges === 'function') {
+      const declared = declaredPrivileges(p);
+      let actual = null;
+      try {
+        actual = await read.rolePrivileges(row.roleid);
+      } catch { actual = null; }
+      if (!Array.isArray(actual)) {
+        // Fail CLOSED: an unreadable role is not a role we can call correct.
+        add('role-privileges', roleName, false, 'could not read the role\'s privileges');
+      } else {
+        const actualByPrivilegeId = new Map(actual.map((a) => [String((a && a.privilegeId) || '').trim().toLowerCase(), a && a.depth]));
+        const entityPrivileges = new Map();
+        for (const entity of new Set(declared.map((d) => d.entity))) {
+          try {
+            const privs = await read.entityPrivileges(entity);
+            if (Array.isArray(privs)) entityPrivileges.set(entity, privs);
+          } catch { /* left absent → reported as a finding by compareRolePrivileges */ }
+        }
+        const cmp = compareRolePrivileges(declared, entityPrivileges, actualByPrivilegeId);
+        const detail = cmp.ok
+          ? `${declared.length} declared privilege(s) held`
+          : cmp.missing.map((m) => `${m.entity}.${m.access}: ${m.reason}`).join('; ');
+        add('role-privileges', roleName, cmp.ok, detail);
+      }
+    }
   }
 
   // AI app features. The verifier previously had NO awareness of `spec.ai` at all, so a build whose
@@ -328,6 +361,38 @@ async function verifySpec(spec, read, opts = {}) {
           : !proof.exists
             ? `requested '${want}' but this app has NO app-scope override for '${setting}' (it is in effect as '${inForce}' only by environment fallback, so the app was never configured)`
             : `requested '${want}' but the app-scope override for '${setting}' holds '${proof.value === '' || proof.value === undefined ? '(empty)' : proof.value}'`);
+    }
+  }
+
+  // JTBD rollup — translates a technical failure into the business impact it caused. Every other
+  // check answers "is this artifact deployed?"; this one answers "can this persona still do this
+  // job?".
+  //
+  // Deliberately a PURE ROLLUP over checks already computed — no extra reads, so it costs nothing
+  // and cannot fail independently. A job fails when a surface it names resolves to a spec artifact
+  // whose own check failed. An UNRESOLVED surface is NOT failed here: it may name an out-of-the-box
+  // artifact this spec never authors (see lib/surface-resolver.js), and spec-lint already warns at
+  // authoring time — failing it here would turn a plan-time smell into a deploy-time error.
+  const failedNames = new Set(checks.filter((c) => !c.present).map((c) => String(c.name).toLowerCase()));
+  if (failedNames.size) {
+    // Each check kind names itself differently (a view is `<entity>.<name>`, a form/page/subarea is
+    // its bare name, an entity is its schemaName), so a resolved surface is mapped to the candidate
+    // check-name(s) its kind would have produced. Derived here rather than in the resolver because
+    // the naming convention belongs to THIS file — a resolver that guessed it would silently rot
+    // the moment a check kind renamed itself.
+    const candidatesFor = (m) => {
+      const name = String(m.name || '');
+      if (m.kind === 'view') return [`${String(m.entity || '').toLowerCase()}.${name}`];
+      if (m.kind === 'entity') return [String(m.entity || name)];
+      return [name]; // form · page · subarea · dashboard
+    };
+    for (const r of resolveSurfaces(spec).resolved) {
+      const broken = r.matches
+        .flatMap(candidatesFor)
+        .filter((n) => n && failedNames.has(n.toLowerCase()));
+      if (broken.length) {
+        add('job-surface', `${r.persona} → ${r.job}`, false, `surface "${r.surface}" is not deployed (${[...new Set(broken)].join(', ')})`);
+      }
     }
   }
 

--- a/plugins/model-apps/scripts/tests/role-privileges.test.js
+++ b/plugins/model-apps/scripts/tests/role-privileges.test.js
@@ -1,0 +1,164 @@
+'use strict';
+// `verifySpec`'s role check proved only that a role ROW exists carrying the SDK marker, never what
+// it GRANTS. A role created with the wrong access — or one whose privilege write failed after the
+// row landed — verified clean. This is a metadata read, not a runtime check.
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { declaredPrivileges, compareRolePrivileges } = require('../lib/role-privileges.js');
+const { verifySpec } = require('../lib/verify-spec.js');
+
+// A realistic privilege set as EntityDefinitions returns it.
+const privsFor = (entity, id) => [
+  { Name: `prvRead${entity}`, PrivilegeId: `${id}-read`, PrivilegeType: 'Read' },
+  { Name: `prvWrite${entity}`, PrivilegeId: `${id}-write`, PrivilegeType: 'Write' },
+  { Name: `prvCreate${entity}`, PrivilegeId: `${id}-create`, PrivilegeType: 'Create' },
+];
+
+const persona = (over = {}) => ({
+  persona: 'Field Technician',
+  jobs: [{ name: 'Complete work orders', privileges: [{ entity: 'msdyn_workorder', access: ['read', 'write'], scope: 'businessUnit' }] }],
+  ...over,
+});
+
+test('declaredPrivileges flattens jobs and folds in the appmodule read appAccess injects', () => {
+  const d = declaredPrivileges(persona());
+  assert.deepStrictEqual(d.sort((a, b) => `${a.entity}${a.access}`.localeCompare(`${b.entity}${b.access}`)), [
+    { entity: 'appmodule', access: 'read', scope: 'organization' },
+    { entity: 'msdyn_workorder', access: 'read', scope: 'businessUnit' },
+    { entity: 'msdyn_workorder', access: 'write', scope: 'businessUnit' },
+  ]);
+});
+
+test('appAccess:false drops the appmodule privilege (a data-only role)', () => {
+  assert.ok(!declaredPrivileges(persona({ appAccess: false })).some((d) => d.entity === 'appmodule'));
+});
+
+// Mirrors the builder's union rule, so the expectation matches what is actually written.
+test('the MAX scope wins when several jobs declare the same entity+access', () => {
+  const p = persona({ jobs: [
+    { name: 'a', privileges: [{ entity: 'account', access: ['read'], scope: 'user' }] },
+    { name: 'b', privileges: [{ entity: 'account', access: ['read'], scope: 'organization' }] },
+  ] });
+  const acct = declaredPrivileges(p).filter((d) => d.entity === 'account');
+  assert.deepStrictEqual(acct, [{ entity: 'account', access: 'read', scope: 'organization' }]);
+});
+
+test('additionalPrivileges are folded in like a job\'s privileges', () => {
+  const d = declaredPrivileges(persona({ additionalPrivileges: [{ entity: 'product', access: ['read'], scope: 'organization' }] }));
+  assert.ok(d.some((x) => x.entity === 'product' && x.access === 'read'));
+});
+
+// --- comparison ---------------------------------------------------------------------------------
+
+const entityPrivs = () => new Map([['msdyn_workorder', privsFor('Workorder', 'wo')], ['appmodule', privsFor('AppModule', 'app')]]);
+const heldAll = () => new Map([['wo-read', 'Local'], ['wo-write', 'Local'], ['app-read', 'Global']]);
+
+test('a role holding every declared privilege at the declared depth passes', () => {
+  const r = compareRolePrivileges(declaredPrivileges(persona()), entityPrivs(), heldAll());
+  assert.deepStrictEqual(r, { ok: true, missing: [] });
+});
+
+// SUBSET semantics: a deeper grant satisfies a shallower declaration. Equality would false-fail on
+// the builder's own max-scope union and on shared Dataverse privileges.
+test('a DEEPER grant than declared still passes', () => {
+  const held = new Map([['wo-read', 'Global'], ['wo-write', 'Global'], ['app-read', 'Global']]);
+  assert.strictEqual(compareRolePrivileges(declaredPrivileges(persona()), entityPrivs(), held).ok, true);
+});
+
+test('extra privileges the spec never declared are NOT a finding', () => {
+  const held = heldAll();
+  held.set('some-other-privilege', 'Global');
+  assert.strictEqual(compareRolePrivileges(declaredPrivileges(persona()), entityPrivs(), held).ok, true);
+});
+
+// THE regression this check exists for.
+test('a privilege the role does not hold is reported by name', () => {
+  const held = heldAll();
+  held.delete('wo-write');
+  const r = compareRolePrivileges(declaredPrivileges(persona()), entityPrivs(), held);
+  assert.strictEqual(r.ok, false);
+  assert.strictEqual(r.missing.length, 1);
+  assert.strictEqual(r.missing[0].access, 'write');
+  assert.match(r.missing[0].reason, /role does not hold prvWriteWorkorder/);
+});
+
+test('a privilege held at too SHALLOW a depth is reported with both depths', () => {
+  const held = heldAll();
+  held.set('wo-write', 'Basic'); // declared businessUnit => Local
+  const r = compareRolePrivileges(declaredPrivileges(persona()), entityPrivs(), held);
+  assert.strictEqual(r.ok, false);
+  assert.match(r.missing[0].reason, /at Basic, below the declared Local/);
+});
+
+// Fail closed: an unreadable table must not read as "nothing missing".
+test('an entity whose privilege metadata could not be read is a finding, not a skip', () => {
+  const r = compareRolePrivileges(declaredPrivileges(persona()), new Map(), heldAll());
+  assert.strictEqual(r.ok, false);
+  assert.ok(r.missing.every((m) => /could not read privilege metadata/.test(m.reason)));
+});
+
+test('an access level the table does not expose is reported', () => {
+  const p = persona({ jobs: [{ name: 'a', privileges: [{ entity: 'msdyn_workorder', access: ['delete'] }] }], appAccess: false });
+  const r = compareRolePrivileges(declaredPrivileges(p), entityPrivs(), heldAll());
+  assert.strictEqual(r.ok, false);
+  assert.match(r.missing[0].reason, /exposes no 'delete' privilege/);
+});
+
+// --- verifySpec wiring --------------------------------------------------------------------------
+
+const SDK_MARKER = 'Authored by @maker-studio/cds-maker-sdk (persona/security role).';
+const specWith = (p) => ({ solution: { uniqueName: 'S' }, app: { name: 'A' }, entities: [], views: [], charts: [], forms: [], appShell: { areas: [] }, personas: [p] });
+
+function readerWith({ rolePrivileges, entityPrivileges } = {}) {
+  const base = {
+    findTable: async () => null,
+    findColumns: async () => [],
+    sitemapXml: async () => '',
+    queryRecords: async (set) => {
+      if (set === 'businessunit') return [{ businessunitid: '11111111-1111-1111-1111-111111111111' }];
+      if (set === 'role') return [{ roleid: 'role-1', description: SDK_MARKER, ismanaged: false }];
+      return [];
+    },
+  };
+  if (rolePrivileges) base.rolePrivileges = rolePrivileges;
+  if (entityPrivileges) base.entityPrivileges = entityPrivileges;
+  return base;
+}
+
+// Reader-gated, exactly like entityRelationships / commandBar: an existence-only reader must behave
+// as it did before this check existed.
+test('verifySpec does NOT emit a role-privileges check when the reader lacks the methods', async () => {
+  const r = await verifySpec(specWith(persona()), readerWith());
+  assert.ok(r.checks.some((c) => c.kind === 'role'), 'the existing role check still runs');
+  assert.ok(!r.checks.some((c) => c.kind === 'role-privileges'), 'no privilege check without the readers');
+});
+
+test('verifySpec PASSES the privilege check when the role holds everything declared', async () => {
+  const r = await verifySpec(specWith(persona()), readerWith({
+    rolePrivileges: async () => [{ privilegeId: 'wo-read', depth: 'Local' }, { privilegeId: 'wo-write', depth: 'Local' }, { privilegeId: 'app-read', depth: 'Global' }],
+    entityPrivileges: async (e) => entityPrivs().get(e) || null,
+  }));
+  const c = r.checks.find((x) => x.kind === 'role-privileges');
+  assert.ok(c && c.present, JSON.stringify(c));
+});
+
+test('verifySpec FAILS when the role is missing a declared privilege', async () => {
+  const r = await verifySpec(specWith(persona()), readerWith({
+    rolePrivileges: async () => [{ privilegeId: 'wo-read', depth: 'Local' }, { privilegeId: 'app-read', depth: 'Global' }],
+    entityPrivileges: async (e) => entityPrivs().get(e) || null,
+  }));
+  const c = r.checks.find((x) => x.kind === 'role-privileges');
+  assert.ok(c && !c.present);
+  assert.match(c.detail, /msdyn_workorder\.write/);
+  assert.strictEqual(r.ok, false);
+});
+
+test('verifySpec fails CLOSED when the role privileges cannot be read', async () => {
+  const r = await verifySpec(specWith(persona()), readerWith({
+    rolePrivileges: async () => { throw new Error('429 throttled'); },
+    entityPrivileges: async (e) => entityPrivs().get(e) || null,
+  }));
+  const c = r.checks.find((x) => x.kind === 'role-privileges');
+  assert.ok(c && !c.present);
+  assert.match(c.detail, /could not read/);
+});

--- a/plugins/model-apps/scripts/tests/surface-resolver.test.js
+++ b/plugins/model-apps/scripts/tests/surface-resolver.test.js
@@ -1,0 +1,148 @@
+'use strict';
+// `surfaces[]` was documentary only, so a job could claim a screen that exists nowhere in the spec
+// and every gate stayed green. These tests pin the resolution and — just as importantly — pin that
+// an unresolved surface stays a WARNING, because a surface may legitimately name an out-of-the-box
+// artifact this spec never authors.
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { resolveSurfaces, declaredSurfaces, unresolvedSurfaceMessage } = require('../lib/surface-resolver.js');
+const { lintAppSpec } = require('../lib/spec-lint.js');
+const { validateAppSpec } = require('../lib/app-spec.js');
+
+const base = () => ({
+  schemaVersion: 2,
+  solution: { uniqueName: 'S', publisherPrefix: 'new' },
+  app: { name: 'Field Service' },
+  entities: [{
+    schemaName: 'new_workorder',
+    displayName: 'Work Order',
+    primaryAttribute: { schemaName: 'new_name', displayName: 'Name' },
+    columns: [{ schemaName: 'new_status', displayName: 'Status', type: 'Text' }],
+  }],
+  views: [{ entity: 'new_workorder', name: 'My Open Work Orders', columns: ['new_name'] }],
+  forms: [{ entity: 'new_workorder', type: 'main', name: 'Work Order' }],
+  pages: [{ key: 'overview', name: 'Overview', purpose: 'KPIs', source: { kind: 'tsx', codeFile: 'overview.tsx' } }],
+  dashboards: [],
+  appShell: { areas: [{ label: 'Main', groups: [{ label: 'Work', subAreas: [{ entity: 'new_workorder', title: 'Work Orders' }, { page: 'overview', title: 'Overview' }] }] }] },
+  personas: [],
+});
+
+const withJob = (surfaces) => {
+  const s = base();
+  s.personas = [{ persona: 'Technician', jobs: [{ name: 'Complete work orders', surfaces, privileges: [{ entity: 'new_workorder', access: ['read', 'write'] }] }] }];
+  return s;
+};
+
+test('declaredSurfaces flattens every (persona, job, surface) triple', () => {
+  const spec = withJob(['My Open Work Orders', 'Work Order']);
+  assert.deepStrictEqual(declaredSurfaces(spec), [
+    { persona: 'Technician', job: 'Complete work orders', surface: 'My Open Work Orders' },
+    { persona: 'Technician', job: 'Complete work orders', surface: 'Work Order' },
+  ]);
+});
+
+test('a surface resolves against every artifact kind an author might name', () => {
+  for (const [surface, kind] of [
+    ['My Open Work Orders', 'view'],
+    ['Overview', 'page'],       // page by display name
+    ['overview', 'page'],       // page by stable key
+    ['Work Order', 'form'],     // also matches the entity display name — see the multi-match test
+    ['Work Orders', 'subarea'], // the NAV entry is a legitimate answer to "what lets them do the job"
+    ['new_workorder', 'entity'],
+  ]) {
+    const r = resolveSurfaces(withJob([surface]));
+    assert.deepStrictEqual(r.unresolved, [], `${surface} should resolve`);
+    assert.ok(r.resolved[0].matches.some((m) => m.kind === kind), `${surface} should match kind ${kind}, got ${JSON.stringify(r.resolved[0].matches)}`);
+  }
+});
+
+// Precedence is deliberately NOT invented: a name that legitimately identifies two artifacts reports
+// both, so a human sees the ambiguity instead of the resolver silently picking one.
+test('a name matching several artifacts reports every match rather than picking one', () => {
+  const r = resolveSurfaces(withJob(['Work Order']));
+  const kinds = r.resolved[0].matches.map((m) => m.kind).sort();
+  assert.deepStrictEqual(kinds, ['entity', 'form']);
+});
+
+test('matching is case- and whitespace-insensitive', () => {
+  const r = resolveSurfaces(withJob(['  mY oPeN wOrK oRdErS  ']));
+  assert.deepStrictEqual(r.unresolved, []);
+  assert.strictEqual(r.resolved[0].matches[0].kind, 'view');
+});
+
+// THE case this check exists for.
+test('a surface naming nothing in the spec is reported as unresolved', () => {
+  const r = resolveSurfaces(withJob(['Overdue Escalations']));
+  assert.deepStrictEqual(r.resolved, []);
+  assert.strictEqual(r.unresolved.length, 1);
+  assert.strictEqual(r.unresolved[0].surface, 'Overdue Escalations');
+  assert.match(unresolvedSurfaceMessage(r.unresolved[0]), /surface "Overdue Escalations" does not match/);
+});
+
+test('a job with no surfaces[] contributes nothing (spec-lint already warns about it)', () => {
+  const spec = base();
+  spec.personas = [{ persona: 'Tech', jobs: [{ name: 'j', privileges: [{ entity: 'new_workorder', access: ['read'] }] }] }];
+  assert.deepStrictEqual(resolveSurfaces(spec), { resolved: [], unresolved: [] });
+});
+
+test('resolveSurfaces tolerates a malformed spec without throwing', () => {
+  for (const bad of [null, undefined, 'x', 42, []]) {
+    assert.doesNotThrow(() => resolveSurfaces(bad));
+  }
+  assert.deepStrictEqual(resolveSurfaces({ personas: [null, { jobs: [null, { surfaces: [null, '', 'x'] }] }] }).unresolved.length, 1);
+});
+
+// --- wiring -------------------------------------------------------------------------------------
+
+test('spec-lint WARNS on an unresolved surface and does not block the spec', () => {
+  const spec = withJob(['Overdue Escalations']);
+  const r = lintAppSpec(spec);
+  assert.strictEqual(r.errors.filter((e) => /Overdue Escalations/.test(e)).length, 0, 'must not be a blocking error');
+  assert.strictEqual(r.warnings.filter((w) => /surface "Overdue Escalations" does not match/.test(w)).length, 1);
+});
+
+// An out-of-the-box artifact is the documented reason validation is loose; it must keep validating.
+test('a spec naming an OOB surface still VALIDATES (warning only)', () => {
+  const spec = withJob(['Active Accounts']);
+  assert.strictEqual(validateAppSpec(spec).ok, true, 'an unresolved surface is never a hard error');
+  assert.ok(lintAppSpec(spec).warnings.some((w) => /Active Accounts/.test(w)));
+});
+
+test('spec-lint stays silent when every surface resolves', () => {
+  const r = lintAppSpec(withJob(['My Open Work Orders', 'Overview']));
+  assert.deepStrictEqual(r.warnings.filter((w) => /does not match any view/.test(w)), []);
+});
+
+// --- verifySpec job-surface rollup ---------------------------------------------------------------
+// A PURE rollup over checks already computed: it translates a technical failure ("view X missing")
+// into the business impact it caused ("Technician cannot Complete work orders").
+const { verifySpec } = require('../lib/verify-spec.js');
+
+const reader = (present) => ({
+  findTable: async () => ({ LogicalName: 'new_workorder' }),
+  findColumns: async () => [{ logicalName: 'new_status' }],
+  // The view exists only when `present`; that is the failure the rollup must attribute to the job.
+  queryRecords: async (set) => (set === 'savedquery' && present ? [{ savedqueryid: 'v1' }] : []),
+  sitemapXml: async () => '',
+});
+
+test('a job whose surface failed to deploy is reported as a job-surface failure', async () => {
+  const spec = withJob(['My Open Work Orders']);
+  const r = await verifySpec(spec, reader(false));
+  const c = r.checks.find((x) => x.kind === 'job-surface');
+  assert.ok(c && !c.present, JSON.stringify(r.checks.filter((x) => x.kind === 'job-surface')));
+  assert.strictEqual(c.name, 'Technician → Complete work orders');
+  assert.match(c.detail, /surface "My Open Work Orders" is not deployed/);
+});
+
+test('no job-surface check is emitted when every surface deployed', async () => {
+  const r = await verifySpec(withJob(['My Open Work Orders']), reader(true));
+  assert.deepStrictEqual(r.checks.filter((x) => x.kind === 'job-surface'), []);
+});
+
+// An unresolved surface may name an out-of-the-box artifact, so it must NOT become a deploy-time
+// failure — spec-lint already warns about it at authoring time.
+test('an UNRESOLVED surface does not fail verify', async () => {
+  const r = await verifySpec(withJob(['Active Accounts']), reader(true));
+  assert.deepStrictEqual(r.checks.filter((x) => x.kind === 'job-surface'), []);
+});

--- a/plugins/model-apps/scripts/verify-model-app.js
+++ b/plugins/model-apps/scripts/verify-model-app.js
@@ -24,7 +24,10 @@ function makeProvision(env, workspaceDir) {
   fs.mkdirSync(workspaceDir, { recursive: true });
   const sdk = createMakerSdk({ workspacePath: workspaceDir, instanceUrl: env, httpClient });
   sdk.initWorkspace();
-  return sdk;
+  // The httpClient is returned alongside the SDK because one read has no SDK surface: the role
+  // privilege check needs `EntityDefinitions(...)?$select=Privileges`, and `fetchEntityMetadata`
+  // projects that field away (see the `entityPrivileges` reader below).
+  return { sdk, httpClient };
 }
 
 // Resolve the app's sitemap XML: appmodule (by unique name) -> appmodulecomponents (type 62) ->
@@ -88,6 +91,41 @@ function readerFor(sdk, appUnique, opts) {
     commandBar: async (entity) => {
       const items = await sdk.resolveArtifact('command', { entity: String(entity).toLowerCase() });
       return !!(items && items[0] && items[0].id);
+    },
+    // rolePrivileges(roleId): what the deployed role actually GRANTS, as [{ privilegeId, depth }].
+    // The `roleprivileges` intersect row carries `privilegedepthmask` — a BITMASK (1 Basic /
+    // 2 Local / 4 Deep / 8 Global), which is NOT the same encoding as the `Depth` name the SDK
+    // writes via ReplacePrivilegesRole, so it is translated here into the depth NAME the pure
+    // comparison speaks in. A role with no privileges legitimately returns [];  a READ FAILURE
+    // must propagate (verify-spec turns a non-array into a fail-closed finding) rather than look
+    // like an empty grant.
+    // See: https://learn.microsoft.com/en-us/power-apps/developer/data-platform/reference/entities/roleprivileges
+    rolePrivileges: async (roleId) => {
+      const DEPTH_BY_MASK = { 1: 'Basic', 2: 'Local', 4: 'Deep', 8: 'Global' };
+      const rows = await sdk.queryRecords('roleprivileges', {
+        select: ['privilegeid', 'privilegedepthmask'],
+        filter: `roleid eq ${roleId}`,
+        top: 5000,
+      });
+      return (rows || []).map((r) => ({
+        privilegeId: String((r && r.privilegeid) || ''),
+        depth: DEPTH_BY_MASK[Number(r && r.privilegedepthmask)] || '',
+      }));
+    },
+    // entityPrivileges(logical): the privilege set a table exposes. Read from the SAME source the
+    // SDK resolves against when it WRITES the role — `EntityDefinitions(LogicalName='x')` with
+    // `$select=Privileges` — so the comparison cannot disagree with the write about which
+    // PrivilegeId means "Read on account".
+    // Deliberately NOT `sdk.fetchEntityMetadata`: that returns a PROJECTED shape
+    // ({logicalName, attributes, relationships, …}) which drops `Privileges` entirely, so routing
+    // through it would silently report every privilege as unreadable.
+    // Returns null on any failure — verify-spec turns that into a finding rather than a pass.
+    entityPrivileges: async (logical) => {
+      const name = String(logical).toLowerCase();
+      const url = `/EntityDefinitions(LogicalName='${odataLit(name)}')?$select=LogicalName,Privileges`;
+      const res = await opts.httpClient.get(url);
+      if (!res || res.status < 200 || res.status >= 300) return null;
+      return (res.body && res.body.Privileges) || null;
     },
     // retrieveSetting(name, { appUniqueName }): the EFFECTIVE app-scoped value of a Dataverse setting,
     // for the AI app-feature reconcile. Wired here (not in the pure core) so the reader stays injectable
@@ -179,9 +217,9 @@ async function main() {
   const v = validateAppSpec(spec, { profile: 'deploy' });
   if (!v.ok) { emitResult(false, { ok: false, errors: v.errors }); return; }
   const workspaceDir = workspaceArg || path.join(path.dirname(specPath), '.maker-workspace');
-  const sdk = makeProvision(env, workspaceDir);
+  const { sdk, httpClient } = makeProvision(env, workspaceDir);
   const genpageCli = makeGenpageCli(env);
-  const r = await verifySpec(spec, readerFor(sdk, appUniqueName(spec), { genpageCli, workspaceDir }));
+  const r = await verifySpec(spec, readerFor(sdk, appUniqueName(spec), { genpageCli, workspaceDir, httpClient }));
   // Show `detail` on a failing check. Without it a READ that failed (throttling, auth expiry, a 5xx)
   // is indistinguishable from an artifact that is genuinely absent — verifySpec records the cause
   // but the operator saw only "✗ view: Active Orders" and would chase a phantom deployment drift.


### PR DESCRIPTION
Two verification gaps in `/app-builder`, both **metadata-only** — no new infrastructure, no live-browser dependency.

## 1. `verify` now proves what a persona security role GRANTS

The `role` check asserted only that a role **row** exists carrying the SDK ownership marker. It never looked at privileges — so a role created with the wrong access, or one whose privilege write failed after the row landed, **verified clean**.

The new `role-privileges` check resolves each declared `(entity, access)` to its Dataverse `PrivilegeId` from the **same metadata source the SDK writes against**, and asserts the role holds it at **at least** the declared depth.

**Subset, not equality** — `lib/role-privileges.js` records why. Equality would false-fail on three legitimate causes:
- `appAccess` injects `appmodule` read
- unioned jobs escalate a shared entity+access to the max declared scope
- distinct entities can share **one** Dataverse privilege (a role holds one depth per privilege)

**Fails closed** on an unreadable role or table.

> Implementation note for reviewers: the read deliberately does **not** go through `sdk.fetchEntityMetadata`. That returns a projected shape which drops `Privileges` entirely, so routing through it would have silently reported every privilege as unreadable.

## 2. `personas[].jobs[].surfaces[]` is checked instead of documentary

`app-spec.js` validated each entry as a non-empty string and stopped; `spec-lint` warned only when the array was **empty**. So a job could name `"My Open Work Orders"` when no such view existed anywhere in the spec — and every gate passed.

`lib/surface-resolver.js` now resolves each entry against the spec's own views, forms, pages (key *or* name), dashboards, tables and sitemap titles.

- `spec-lint` **warns** on no match — a warning, never an error, because `app-spec.js` is loose *on purpose*: a surface may legitimately name an out-of-the-box artifact this spec does not author.
- `verify` adds a **`job-surface` rollup** — a *pure* rollup over checks already computed, so **no extra reads** — reporting a deployed failure as the job it broke (*"persona P can no longer do job J"*) rather than only *"view X is missing"*.

## Compatibility

Both wire into `verifySpec`'s existing **reader-gated** seam — the pattern `entityRelationships` / `commandBar` already use — so an existence-only reader behaves **exactly** as it did before.

## Verification

- **1474 plugin tests pass** (1446 → 1474; **28 new**), 0 fail
- **Both features red-green verified**: disabling the lint wiring fails 2 tests; disabling the privilege check fails 3
- **159 eval tests**, **6/6 repo validators**
- Docs updated per the AGENTS.md map: schema, roadmap, CHANGELOG, file tree
