### PR TITLE
fix(canvas-apps): improve generated app functionality

### DIFF
--- a/plugins/canvas-apps/AGENTS.md
+++ b/plugins/canvas-apps/AGENTS.md
@@ -34,6 +34,7 @@ references/
   LayoutGuide.md               ← Responsive sizing, scrolling, galleries, and contrast
   GridLayoutGuide.md           ← Conditional GridLayout formulas and invariants
   PowerFxGuide.md              ← State, events, named formulas, and mock data
+  BehaviorGuide.md             ← Acceptance contracts for advanced app behavior
   DesignGuide.md               ← Aesthetic guidelines, anti-patterns, design process
   QAChecks.md                  ← Named runtime anti-pattern checks for per-screen self-QA
   PlanTemplates.md             ← Progressive index, shared plan, and screen-brief structures

--- a/plugins/canvas-apps/agents/canvas-app-planner.md
+++ b/plugins/canvas-apps/agents/canvas-app-planner.md
@@ -50,9 +50,44 @@ exactly, record an explicit approximation and reason; never silently rename butt
 "drag-style", call buttons "handles", or put copy in the app that promises an interaction
 the controls do not provide.
 
+Convert every concrete requested or approved-plan action into an Action Contract. Treat
+create, edit, delete, search, filter, flag, review, approve, reject, and similar verbs as
+separate flows with their own visible entry point, owning screen, handler, required data
+effect, and observable result. Broad words such as "manage", "maintain", or "track" do not
+require universal CRUD across every entity. However, a role-scoped requirement to manage
+all records of the app's primary entity is operational: plan a reachable management list,
+record detail, correction/update, and remove/cancel paths unless the request narrows the
+allowed operations or the domain makes a destructive action inappropriate. A review or
+approval workflow that distinguishes final approved records requires both approve and
+reject/decline decisions and visible resulting statuses unless the request explicitly
+defines a one-way review. Once included, each action must be planned end to end rather
+than represented by a screen or entity alone.
+
+Treat temporal qualifiers and outputs as behavior, not decorative copy. Quarterly,
+monthly, annual, cycle, period, or similar requirements need a shared field or derivation
+that is visible on affected forms and records and can distinguish the active period.
+Export, download, print, or report requests need their own Action Contract with the exact
+eligible-record predicate, output fields, trigger, and visible completion evidence. If
+discovered controls and data sources cannot provide the requested output mechanism, plan
+an explicit approximation rather than omitting the action.
+
+Decompose compound behavior into acceptance paths. Reordering, moving, constraints,
+derived metrics, version comparison, category management, and ranking each need an initial
+state, success path, boundary or rejection path when applicable, shared source of truth,
+and visible evidence. Record those paths in the Action Contract rather than assuming the
+builder will infer them from a feature name.
+
+Infer the minimum supporting setup actions needed to exercise requested behavior when the
+app uses local/mock mutable data. For example, an org restructuring app needs a reachable
+way to add teams and people with manager relationships before reassignment, metrics, and
+version comparison can be meaningfully tested. These supporting actions are required
+dependencies, not universal CRUD. Add them to Requirement Coverage and Action Contracts.
+
 Use `ModernTabList` only when it switches visible panels within one screen. For navigation
 between separate screen files, plan a repeated ModernButton row with direct `OnSelect:
-=Navigate(...)` actions and an explicit current-screen appearance.
+=Navigate(...)` actions and an explicit current-screen appearance. Put every primary
+destination in that row and keep it in the initial viewport at each supported breakpoint,
+or use an immediately visible menu button that exposes the complete destination set.
 
 ## 1. Read Guidance
 
@@ -62,6 +97,7 @@ Read:
 - `${PLUGIN_ROOT}/references/ControlGuide.md` — control selection, per-control properties, enums
 - `${PLUGIN_ROOT}/references/LayoutGuide.md` — responsive layout, scrolling, colour contrast
 - `${PLUGIN_ROOT}/references/PowerFxGuide.md` — state, events, named formulas, mock data
+- `${PLUGIN_ROOT}/references/BehaviorGuide.md` — advanced behavior acceptance contracts
 - `${PLUGIN_ROOT}/references/DesignGuide.md` — aesthetic direction and design process
 - `${PLUGIN_ROOT}/references/PlanTemplates.md` — the exact shape of every artifact you write
 
@@ -115,6 +151,16 @@ Before writing plans:
      If validation must wait for a submit attempt, combine one attempt flag with the
      current invalid expression; do not maintain or clear separate validity flags in each
      input's `OnChange`.
+   - For every mutation, specify how the screen reflects the new state after success.
+     Updating data without refreshing or updating the collection bound to the visible
+     list is incomplete. A success notification alone does not satisfy an outcome that
+     requires the created, edited, deleted, or transitioned record to be visible.
+   - Apply `${PLUGIN_ROOT}/references/BehaviorGuide.md` to every advanced behavior. Name
+     each required success and boundary path, the shared source of truth, and the control
+     that provides visible acceptance evidence.
+   - For every named core visualization, specify its bound source, first-render records,
+     relationship or comparison encoding, populated-state controls, and truthful empty
+     state. Do not plan blank containers or decorative rectangles as visualization content.
 7. Define data-field semantics once and reuse them. If a task has `ScheduledDate`,
    `DueDate` and `CompletedDate`, state which field drives calendar placement, which date
    the task list displays, and which field the monthly report groups by. Seed data,
@@ -165,6 +211,10 @@ For every screen brief, state explicitly:
 - That responsive layout properties derive directly from `App.Width`, `Parent.Width` or
   `Self.Width`. Do not initialize layout variables such as `varIsMobile` or `varColumns`
   in `OnVisible`; they can be unset in Studio and become stale after resize.
+- That the sole screen root always uses `Width: =Parent.Width`, `Height: =Parent.Height`,
+  `LayoutMinWidth: =0`, and `LayoutMinHeight: =0`. Breakpoint sizing belongs on children;
+  never put a narrow-width branch, button width, panel width, or fixed desktop width on
+  the root.
 - That the root container scrolls (`LayoutOverflowY: =LayoutOverflow.Scroll`).
 - That the screen-level `Children:` list contains only that root, with every visible
   section nested under the root's `Children:` list.
@@ -178,6 +228,9 @@ For every screen brief, state explicitly:
 - A `TemplateSize` for every gallery that fits its row template **at each width branch**,
   counting a `ModernCard`'s image band. A dense desktop branch is the usual place card
   titles disappear.
+- For every mutation, where its observable result appears immediately afterward. Keep the
+  result in the current viewport, navigate to the bound list/detail, or provide a visible
+  control that takes the user there. Do not place the only proof far below a long form.
 - For every GridLayout: the exact `LayoutGridColumns`, `LayoutGridRows`,
   `LayoutGridColumnMinWidth`, `LayoutGridRowMinHeight` and `Height` formulas, plus every
   explicit child row/column position. The row count and height must reuse the same column
@@ -185,6 +238,17 @@ For every screen brief, state explicitly:
 - For every fixed-height section and every horizontal row with four or more substantive
   children, include a per-breakpoint layout budget: child groups, minimum widths/heights,
   gaps, padding and the resulting section size. Presence of a breakpoint is not enough.
+- For every horizontal container, prove that visible child minimum widths plus gaps and
+  padding fit at desktop, tablet, and phone widths, or specify the wrap/stack branch that
+  makes them fit. For ManualLayout, provide bounds for every simultaneously visible
+  control and prove they neither overlap nor extend beyond the parent at each supported
+  width.
+- For every text-bearing control, state whether it is single-line or wrapping and provide
+  a width/height budget for its longest planned or data-bound value.
+- Define one shared visual contract: title, section-heading, body, and caption type roles;
+  spacing scale; surface and border treatment; primary/secondary action styling; and
+  desktop/tablet/phone content density. Builders must copy these exact values rather than
+  inventing screen-local themes.
 - Group each visible label with its corresponding input in one field container before
   the row stacks.
 - For bounded local galleries of about ten rows or fewer, size the gallery to all rows
@@ -253,6 +317,7 @@ Follow `${PLUGIN_ROOT}/references/PlanTemplates.md`.
 Write only orchestration information:
 
 - Mode and requirements
+- Requirement Coverage and Action Contracts
 - Working directory
 - Compact discovery summary
 - Dispatch table
@@ -291,6 +356,8 @@ Each brief contains only what that builder needs:
 
 - Action, logical screen, target file, YAML key, and control name prefix
 - Screen specification or exact edit list
+- Every Action Contract owned or affected by the screen, including the visible entry
+  point, exact handler behavior, data effect, and observable result
 - Relevant portions of data source schemas and API details
 - For every control type used on that screen: the complete list of valid input
   property names, plus the full `Enum name:` and the **compile-ready enum literal** for

--- a/plugins/canvas-apps/agents/canvas-screen-builder.md
+++ b/plugins/canvas-apps/agents/canvas-screen-builder.md
@@ -41,8 +41,10 @@ Do not read `canvas-app-plan.md`, other screen briefs, or other screen YAML file
 Do not call discovery tools. The assigned documents contain all required context.
 
 Before writing, verify that the screen brief includes definitions for every control type
-it asks you to add or create. If any definition or required assignment field is missing,
-do not write partial YAML. Return:
+it asks you to add or create, and that every Required Actions row names an entry point,
+control event, required formula behavior, and observable result. If any definition,
+required assignment field, or action-contract field is missing, do not write partial YAML.
+Return:
 
 ```markdown
 Screen: [logical name]
@@ -87,6 +89,39 @@ Do not fix unrelated pre-existing issues.
 
 ### Both
 
+- Implement every row in `## Required Actions`. The entry point must be visible and
+  reachable, the named event must contain the required behavior, and the observable
+  result must be rendered from the same source or state changed by the action.
+- Keep primary navigation and management actions in the initial viewport or behind an
+  immediately visible menu or scroll affordance. A control that exists only below an
+  unscrollable or ambiguous container is not reachable.
+- For search and filter actions, bind the named input directly into the target list's
+  `Items` formula and include every field or state named by the brief.
+- For mutations, update or refresh the collection/source used by the visible list or
+  detail after success. A `Notify()` call without a visible data result is not a complete
+  implementation when the brief requires the changed record to appear, disappear, or
+  move state.
+- Make the mutation's observable result visible immediately after the handler runs. Keep
+  it in the current viewport, navigate to the bound list/detail, or expose an immediately
+  visible action that opens it. Do not leave the only changed row below a long form.
+- Implement every success, boundary, rejection, persistence, and recalculation path named
+  in `## Required Actions`. Reordering, constraints, metrics, versions, categories, and
+  rankings are incomplete when only their happy-path control or display exists.
+- Implement role-scoped management actions on the primary-record surface named by the
+  brief. Edit must load and update the selected record, delete/remove must have a
+  confirmation or cancel path, and approve/reject controls must visibly update status.
+- Persist period or cycle values in the shared record source and render them wherever the
+  brief requires period-aware review. Export/report actions must apply the exact eligibility
+  predicate and fields from the brief and show completion evidence; a notification without
+  an output is incomplete.
+- Implement supporting setup actions from `## Required Actions` against the same shared
+  source used by the requested behavior. Seeded rows do not substitute for reachable
+  creation of the minimum records needed to exercise the behavior.
+- Render every specified core visualization with bound content. Do not ship empty filled
+  containers, disabled-looking input blocks, or decorative placeholders where the brief
+  requires a hierarchy, chart, comparison, board, timeline, or map.
+- Follow the shared Visual Contract exactly. Do not introduce screen-local palette,
+  typography, spacing, surface, or action styles.
 - Every control you **add** carries your assigned control name prefix. Control names are
   unique across the whole app, and you cannot see the other screens — the prefix is the
   only thing preventing a collision. This applies to repeated UI blocks such as nav bars
@@ -154,6 +189,7 @@ the first builder returns, so return promptly rather than polishing indefinitely
 Screen: [logical name]
 Action: [Create / Modify]
 File: [absolute target file]
+Actions: [implemented count]/[required count]
 QA: 1 [outcome] · 2 [outcome] · …
 - [fix summary, or "clean"]
 Status: Done
@@ -161,6 +197,8 @@ Status: Done
 
 The `QA:` line must list every check in `${PLUGIN_ROOT}/references/QAChecks.md`. A return
 without it is incomplete, and the orchestrator will send the screen back.
+The `Actions:` count must cover every Required Actions row. A lower implemented count
+means `Status: Blocked` with the unresolved action and reason.
 
 ## Constraints
 
@@ -173,6 +211,13 @@ without it is incomplete, and the orchestrator will send the screen back.
   unquoted — `DecimalPrecision.'1'`, not `DecimalPrecision.1`.
 - Never leave a `ModernCard` slot unset. For text-only cards set `Image: =Blank()` and,
   when supported by the control definition, `HeaderImage: =Blank()`.
+- The sole responsive screen root always sets `Width: =Parent.Width`,
+  `Height: =Parent.Height`, `LayoutMinWidth: =0`, and `LayoutMinHeight: =0`. Never copy a
+  child control's fixed or conditional width onto the root during a repair.
+- A bounded Gallery's `Height` and empty-state visibility count the same source/filter
+  expression used by `Items`. Never size or classify an empty gallery from
+  `Self.AllItems`, `Self.AllItemsCount`, or rendered `AllItemsCount`; those values can
+  create a zero-height materialization cycle.
 - Every multiword ModernButton or link that is a direct child of a vertical AutoLayout
   container sets `Width: =Parent.Width`; `LayoutMinWidth` and stretch alignment alone do
   not make the rendered control fill the row.

--- a/plugins/canvas-apps/references/BehaviorGuide.md
+++ b/plugins/canvas-apps/references/BehaviorGuide.md
@@ -1,0 +1,188 @@
+# Canvas App Behavior Acceptance Guide
+
+Use this guide to turn advanced prompt requirements into implementation contracts that can
+be verified from the generated YAML. A control, collection, or screen existing is not proof
+that the behavior works.
+
+## General acceptance contract
+
+For every requested behavior, the plan must identify:
+
+1. The initial state and visible entry point.
+2. The exact control event and state or data operation.
+3. The success path and its visible evidence.
+4. Any required blocked or boundary path and its visible evidence.
+5. The source of truth that subsequent screens, filters, and metrics read.
+
+Keep a single source of truth for each concept. Do not update one collection while a visible
+gallery, metric, or selector reads another.
+
+The visible evidence must be reachable in the immediate post-action state. Keep it in the
+current viewport, navigate to its bound list/detail, or show an immediately visible control
+that opens it. A changed row placed only below a long form is not observable evidence.
+
+## Navigation and action reachability
+
+- Put every primary destination in a repeated navigation region that is visible in the
+  initial viewport, or behind an immediately visible menu control.
+- Keep record-level management actions on the management row/detail surface or behind a
+  visible overflow control. Do not rely on clicking non-interactive text or cards.
+- A required action below the fold needs an obvious, working scroll affordance and must not
+  be trapped inside nested fixed-height containers.
+- Repeat the same destination set and ordering across screens so an evaluator or user does
+  not need to rediscover navigation after each action.
+
+## Role-scoped record management and review
+
+A request for a named role to manage all records of the app's primary entity is an
+operational lifecycle requirement, not a request for a read-only list. It does not imply
+CRUD for supporting entities.
+
+- Provide a reachable management list and a visible way to select a record.
+- Provide a correction/update path that loads the selected record, saves changes to the
+  shared source, and displays the updated values in the management list.
+- Provide remove/cancel with a visible confirmation or cancel path. After confirmation,
+  the record must disappear or visibly enter the requested canceled state.
+- When review distinguishes final approved records, provide both approve and reject/decline
+  decisions unless the request explicitly defines a one-way workflow.
+- Keep decision controls together and render the resulting status from the same field they
+  mutate. An Approve-only queue is not a complete review workflow when rejected records are
+  a meaningful outcome.
+
+## Program periods and recurrence
+
+- Represent quarterly, monthly, annual, cycle, season, or period requirements with a shared
+  field or deterministic derivation, not only a heading.
+- Give new records the active period and show it in the relevant form, list, detail, or
+  review surface.
+- When users need to distinguish periods, provide a visible selector or filter and bind it
+  directly to the rendered source.
+- Use one period meaning everywhere. Do not label a date as a quarter in one screen while
+  filtering a different field elsewhere.
+
+## Export and report output
+
+- Give every explicit export, download, print, or report request a visible action.
+- Define the eligible-record predicate and output columns exactly. For example, an approved
+  list export must exclude pending and rejected records using the same status field shown
+  in review.
+- Use an output mechanism supported by discovered controls, connectors, and data sources,
+  and provide visible evidence that output was prepared or delivered.
+- If exact file export is unavailable, label and implement an explicit approximation such
+  as a copyable report view. Do not present a notification that claims a file was exported
+  when no output exists.
+
+## Operational setup for requested behavior
+
+A prompt can request moving, comparing, ranking, scheduling, or measuring records without
+explicitly saying "add a create form." When the generated app uses local/mock data and the
+requested behavior needs mutable records to be exercised, provide the minimum visible setup
+actions needed to create those records.
+
+- Add only the supporting create actions needed to exercise requested behavior; this is not
+  permission to generate universal CRUD.
+- For relationship-based features, provide inputs for the entity name, group/team, and
+  parent/manager relationship needed to create at least two levels.
+- New records must enter the same shared source used by the visualization, metrics,
+  selectors, mutations, and snapshots.
+- Keep meaningful seed data so the app is useful on first load, but do not make seeded rows
+  the only records the user can operate on.
+- After creation, show the new record in the core visualization without navigation, reload,
+  or app restart.
+
+## Search and filtering
+
+- Bind the visible input or selector directly into the target list's `Items` formula.
+- Include every requested searchable field and combine simultaneous filters explicitly.
+- Provide a reachable clear/reset action when more than one filter can be active.
+- Show the active filter state and a zero-result state; a blank gallery is ambiguous.
+
+## Reordering, moving, and drag interactions
+
+- Define the source item, destination position or group, ordering field, and visible list
+  that proves the result.
+- Update every affected row when order values must remain unique and contiguous.
+- Bind the rendered list to the ordering field with an explicit sort.
+- Preserve the changed order when navigating away and back by storing it in the shared
+  mutable source, not screen-local initialization.
+- Use real drag and drop only when a discovered control exposes that event contract. If it
+  does not, plan explicit Move up, Move down, Move to, or Apply reassignment controls and
+  mark the interaction as an approximation. Never label click controls as drag handles.
+
+## Limits and validation constraints
+
+- Derive the limit from the same source and predicate used by the visible list or count.
+- Enforce the rule twice: disable or explain the unavailable action before submission, and
+  guard the mutation event so stale UI state cannot bypass it.
+- Define both boundary paths: the last allowed operation succeeds, and the next operation
+  is rejected without changing data.
+- Display the current count, limit, and rejection reason close to the action.
+
+## Metrics and dashboards
+
+- Derive metrics from the current shared source or a named formula, not a copied value
+  initialized during navigation.
+- State the exact field semantics, filters, grouping, and denominator.
+- Every mutation that should affect a metric must change the source the metric reads.
+- For relationship data, calculate layer depth, direct-report counts, and group totals from
+  the same current parent/group fields rendered by the hierarchy.
+- Show both aggregate values and the requested breakdown. A heading or empty metric card is
+  not a metric.
+- Provide meaningful zero and empty states; never divide by zero or display a stale seeded
+  total after records change.
+
+## Versions and comparison
+
+- A save-version action creates an immutable snapshot with a unique identifier, timestamp,
+  and the fields needed for comparison.
+- Store version metadata separately from snapshot rows. Copy every compared entity into
+  snapshot rows keyed by `VersionId`; do not store a reference to the live collection or
+  derive both comparison panels from current state.
+- Saving a later version must not mutate the earlier snapshot.
+- Version selectors bind to the snapshot source and prevent comparing one version to itself.
+- The comparison view identifies both selected versions and renders two populated, labeled
+  panels at the same time. When the requirement says side by side, do not replace this with
+  a single panel, tabs, or vertically stacked states; choose a wide dashboard composition or
+  an intentional horizontal comparison region.
+- Derive field-level differences by matching stable entity IDs across the two selected
+  snapshot sets. Highlight added, removed, moved, and changed records from that derivation.
+- Do not show "no changes" unless the selected snapshots are distinct and the derived
+  difference set is actually empty.
+- Persistence claims must match the actual source. An in-memory collection persists only
+  during the current app session; do not describe it as durable storage.
+
+## Core visualizations
+
+- A named org chart, timeline, comparison, dashboard, board, chart, or map must render bound
+  content. A filled rectangle, empty container, disabled input, or heading over blank space
+  is a placeholder, not a visualization.
+- Provide meaningful first-render data or a visible, truthful empty state with a reachable
+  setup action.
+- Relationship visualizations must expose the relationship, not only a flat list. Show
+  parent/group labels, layer or depth, and a visible reporting/connection treatment.
+- Keep required controls outside decorative overlays and ensure empty-state surfaces do not
+  cover populated content.
+
+## Category management
+
+- Category creation updates the same shared category source used by forms, filters, and
+  management lists.
+- Prevent or visibly handle blank and duplicate category names.
+- A newly added category must become visible in every requested selector without requiring
+  app restart or reseeding.
+- Deletion or rename behavior must define what happens to records that reference the
+  affected category.
+
+## Leaderboards and ranked lists
+
+- Define the score formula, eligible population, sort direction, tie behavior, and displayed
+  rank.
+- Sort from the current source rather than storing a separate stale leaderboard.
+- Use a deterministic secondary sort for ties.
+- Recalculate visibly after any action that changes the ranking inputs.
+
+## Completion rule
+
+If any required success path, boundary path, source-of-truth binding, or visible evidence
+cannot be implemented with discovered controls and data sources, mark the action blocked or
+an explicit approximation. Do not ship placeholder UI or claim completion.

--- a/plugins/canvas-apps/references/LayoutGuide.md
+++ b/plugins/canvas-apps/references/LayoutGuide.md
@@ -74,7 +74,7 @@ For flexible, responsive designs:
 ```
 
 1. **Dynamic gallery height:**
-   `Height: =Self.AllItemsCount * Self.TemplateHeight + ((Self.AllItemsCount + 1) * Self.TemplatePadding)`
+   `Height: =With({rowCount: CountRows(<same source/filter used by Items>)}, rowCount * Self.TemplateHeight + ((rowCount + 1) * Self.TemplatePadding))`
 2. **Container scrolling:** `LayoutOverflowY: =LayoutOverflow.Scroll`
 3. **AutoLayout child properties:** `AlignInContainer`, `FillPortions`,
    `LayoutMinWidth/Height`, `LayoutMaxWidth/Height`
@@ -207,11 +207,16 @@ directly.
 
 Small bounded lists should not create a second hidden scroll region. For a local roster
 of roughly ten or fewer rows inside a scrollable root, include every row and its template
-padding in the gallery height, then let the root scroll:
+padding in the gallery height, then let the root scroll. Count the gallery's source
+expression, not `Self.AllItemsCount`: rendered-item counts depend on the gallery having a
+non-zero height and can create a zero-height cycle.
 
 ```yaml
-Height: =Self.AllItemsCount * Self.TemplateHeight + ((Self.AllItemsCount + 1) * Self.TemplatePadding)
+Height: =With({rowCount: CountRows(<same source/filter used by Items>)}, rowCount * Self.TemplateHeight + ((rowCount + 1) * Self.TemplatePadding))
 ```
+
+Use that same source count for empty-state visibility. Do not derive either property from
+`Self.AllItems`, `Self.AllItemsCount`, or another rendered gallery property.
 
 ## Give labelled controls room for their longest value
 

--- a/plugins/canvas-apps/references/PlanTemplates.md
+++ b/plugins/canvas-apps/references/PlanTemplates.md
@@ -30,6 +30,23 @@ CREATE
 |-------------|--------------------|----------|
 | [Concrete noun or interaction from the request] | [Visible control and exact behavior] | Exact / Approximation: [reason] |
 
+## Action Contracts
+| Requested action | Entry point | Owner screen | Control and event | Required behavior | Observable result |
+|------------------|-------------|--------------|-------------------|-------------------|-------------------|
+| [Concrete prompt- or approved-plan-derived action] | [Visible control the user starts from] | [Screen] | [PrefixedControl.OnSelect / OnChange] | [Exact navigation, filter, search, mutation, or state transition] | [Visible persisted outcome in a list, detail, filter, dashboard, or confirmation] |
+
+[Include only actions stated by the request or approved plan. Do not infer universal CRUD
+for every supporting entity from broad words such as "manage". However, role-scoped
+management of all primary records implies reachable list/detail, correction/update, and
+remove/cancel flows for those records. Decompose each included action into its complete
+reachable flow; do not combine create, edit, delete, search, filter, review, or approval
+into one row. A meaningful review workflow requires separate approve and reject/decline
+contracts. A requested period or cycle requires a visible selector/filter and period-bound
+results. A requested export or report requires a visible trigger and observable output
+whose contents match the requested view. Include minimum supporting setup actions when
+they are necessary to exercise an explicitly requested mutation, metric, relationship,
+comparison, or ranking over local/mock data.]
+
 ## Working Directory
 [absolute working directory]
 
@@ -60,6 +77,16 @@ EDIT
 | Requirement | Planned affordance | Fidelity |
 |-------------|--------------------|----------|
 | [Concrete noun or interaction from the request] | [Visible control and exact behavior] | Exact / Approximation: [reason] |
+
+## Action Contracts
+| Requested action | Entry point | Owner screen | Control and event | Required behavior | Observable result |
+|------------------|-------------|--------------|-------------------|-------------------|-------------------|
+| [Concrete prompt- or approved-plan-derived action] | [Visible control the user starts from] | [Screen] | [PrefixedControl.OnSelect / OnChange] | [Exact navigation, filter, search, mutation, or state transition] | [Visible persisted outcome in a list, detail, filter, dashboard, or confirmation] |
+
+[Include only actions stated by the request or approved plan. Preserve unaffected existing
+actions, and do not expand the edit into universal CRUD. Preserve the semantic contracts
+for role-scoped primary-record management, paired review decisions, requested periods or
+cycles, and requested export/report output.]
 
 ## Working Directory
 [absolute working directory]
@@ -95,6 +122,13 @@ seed data — or "None"]
 - Text primary: RGBA([...])
 - Text secondary: RGBA([...])
 - Typography: [scale and weights]
+
+## Visual Contract
+- Type roles: [exact title, section-heading, body, caption sizes and weights]
+- Spacing scale: [approved gap and padding values]
+- Surfaces: [page, panel, card, border, and shadow treatment]
+- Actions: [exact primary, secondary, destructive, and disabled treatment]
+- Density: [desktop, tablet, and phone composition rules]
 
 ## Layout Strategy
 [Shared layout rules and target-device rationale. Record the breakpoint formulas and the
@@ -137,7 +171,18 @@ for cross-screen navigation; reserve ModernTabList for panels within one screen.
 - Purpose: [description]
 - Layout: [root and child structure. For each fixed-height section and horizontal row
   with four or more substantive children, include a desktop/narrow/phone budget with
-  child grouping, minimum widths/heights, gaps, padding and resulting section size.]
+  child grouping, minimum widths/heights, gaps, padding and resulting section size.
+  Prove all visible children remain inside their parent and do not overlap at each target
+  width. The sole responsive root must use exact `Width: =Parent.Width`,
+  `Height: =Parent.Height`, `LayoutMinWidth: =0`, and `LayoutMinHeight: =0`; breakpoint
+  sizing belongs only on descendants.]
+- Text fit: [single-line or wrapping behavior and longest-value width/height budget for
+  each text-bearing control]
+- Visual hierarchy: [title, section, body, caption, primary action, and focal content
+  roles copied from the shared Visual Contract]
+- Core visualization: [bound source, meaningful first-render records, relationship or
+  comparison encoding, populated controls, and truthful empty state; omit only when this
+  screen owns no core visualization]
 - Grid contract: [for each GridLayout, exact columns, rows, column minimum, row minimum,
   height and child-position formulas; omit when there is no GridLayout]
 - Controls: [prefixed control names and purpose]
@@ -151,6 +196,22 @@ for cross-screen navigation; reserve ModernTabList for panels within one screen.
   view and ensure displayed labels, seed data and filters use that same meaning.]
 - Navigation: [targets and triggers]
 - State: [OnVisible initialization]
+
+## Required Actions
+| Action | Entry point | Control and event | Required formula behavior | Observable result |
+|--------|-------------|-------------------|---------------------------|-------------------|
+| [Action copied from the plan index] | [Visible local entry point] | [PrefixedControl.OnSelect / OnChange] | [Exact formula operation or binding] | [What the user sees after completion] |
+
+[Copy every Action Contract owned by this screen. For search and filter actions, name the
+input and the Items formula fields it affects. For mutations, name the data operation, target
+source or collection, refresh/update behavior, and visible control that proves the result.
+For constraints and advanced behaviors, include separate rows for every required success,
+boundary, rejection, persistence, and recalculation path from the plan. Give approve and
+reject/decline separate rows. For period/cycle actions, name the selector, bound field, and
+result control. For export/report actions, name the trigger, exported scope, output format,
+and visible success or download evidence. For every mutation, state how its bound
+observable result is visible immediately after the handler: in the current viewport,
+through handler navigation, or through an immediately visible entry control.]
 
 ## Relevant Data Source Schemas
 [Only the fields this screen reads or writes; omit if none]
@@ -190,6 +251,12 @@ then fails to compile.]
 ## Changes
 1. [Exact required change]
 
+## Layout and Visual Impact
+- Responsive bounds: [desktop, tablet, and phone width/height budgets for changed regions]
+- Text fit: [longest-value budget for changed text-bearing controls]
+- Visual contract: [shared type, spacing, surface, and action roles that changed controls
+  must preserve]
+
 ## Controls to Add
 [Name, type, placement, properties; or "None"]
 
@@ -198,6 +265,18 @@ then fails to compile.]
 
 ## Properties to Update
 [Control -> property -> exact value; or "None"]
+
+## Required Actions
+| Action | Entry point | Control and event | Required formula behavior | Observable result |
+|--------|-------------|-------------------|---------------------------|-------------------|
+| [Action copied from the plan index] | [Visible local entry point] | [Prefixed or preserved Control.OnSelect / OnChange] | [Exact formula operation or binding] | [What the user sees after completion] |
+
+[Copy every Action Contract affected by this screen. Preserve unaffected actions. For
+mutations, identify the target source or collection and the visible post-action result.
+For constraints and advanced behaviors, include separate rows for every changed success,
+boundary, rejection, persistence, and recalculation path. For every mutation, state how
+the changed record is visible in the immediate post-action state or reached by explicit
+navigation in the handler.]
 
 ## Relevant Data Source Schemas
 [Only the fields this edit reads or writes; omit if none]

--- a/plugins/canvas-apps/references/QAChecks.md
+++ b/plugins/canvas-apps/references/QAChecks.md
@@ -59,6 +59,16 @@ are not part of the identifier.
 - Check 31 — `QACHK-SEMANTIC-VALUE-BINDING` — semantic display control missing its visible
   value binding
 - Check 32 — `QACHK-ACTION-LABEL-FIT` — multiword action label does not fit its control
+- Check 33 — `QACHK-ACTION-CONTRACT` — required action or navigation is missing,
+  unreachable, or not wired
+- Check 34 — `QACHK-MUTATION-OUTCOME` — data changes without a visible post-action result
+- Check 35 — `QACHK-BEHAVIOR-ACCEPTANCE` — advanced behavior omits a required acceptance path
+- Check 36 — `QACHK-HORIZONTAL-BUDGET` — row content exceeds its available width
+- Check 37 — `QACHK-MANUAL-BOUNDS` — visible ManualLayout controls overlap or leave the parent
+- Check 38 — `QACHK-TEXT-CONTENT-FIT` — text control cannot fit its longest visible value
+- Check 39 — `QACHK-VISUAL-CONTRACT` — screen styling diverges from the shared visual system
+- Check 40 — `QACHK-EXCESS-WHITESPACE` — layout sizing creates unintended empty regions
+- Check 41 — `QACHK-CORE-VISUALIZATION` — core visualization is blank, static, or incomplete
 
 Agents that write `.pa.yaml` files MUST run these checks against their own
 output before returning, and fix every issue inline. Report the outcome of
@@ -88,7 +98,8 @@ QA: 1 PASS · 2 PASS · 3 PASS · 4 FIXED(7) · 5 PASS · 6 FIXED(2) · 7 FIXED(
     8 PASS · 9 PASS · 10 PASS · 11 PASS · 12 PASS · 13 PASS · 14 PASS · 15 PASS ·
     16 PASS · 17 PASS · 18 FIXED(4) · 19 PASS · 20 PASS · 21 PASS · 22 FIXED(3) ·
     23 FIXED(4) · 24 PASS · 25 N/A · 26 N/A · 27 PASS · 28 N/A · 29 PASS ·
-    30 N/A · 31 PASS · 32 PASS
+    30 N/A · 31 PASS · 32 PASS · 33 PASS · 34 PASS · 35 PASS · 36 PASS ·
+    37 N/A · 38 PASS · 39 PASS · 40 PASS · 41 PASS
 ```
 
 - `PASS` — you inspected every control the check applies to and found nothing.
@@ -107,6 +118,18 @@ QA: 1 PASS · 2 PASS · 3 PASS · 4 FIXED(7) · 5 PASS · 6 FIXED(2) · 7 FIXED(
   surface.
 - `QACHK-ROOT-CONTAINMENT` is `N/A` only when the brief explicitly requires fixed
   ManualLayout with deliberate screen-level overlays.
+- `QACHK-BEHAVIOR-ACCEPTANCE` is `N/A` when the screen owns no advanced behavior named
+  by Check 35.
+- `QACHK-HORIZONTAL-BUDGET` is `N/A` when the changed scope has no horizontal AutoLayout
+  container.
+- `QACHK-MANUAL-BOUNDS` is `N/A` when the changed scope has no ManualLayout container.
+- `QACHK-TEXT-CONTENT-FIT` is `N/A` only when the changed scope has no visible text.
+- `QACHK-VISUAL-CONTRACT` applies to every created screen and every visually changed
+  region.
+- `QACHK-EXCESS-WHITESPACE` is `N/A` for a Modify action that changes no layout sizing,
+  spacing, or visibility.
+- `QACHK-CORE-VISUALIZATION` is `N/A` only when the screen brief names no hierarchy,
+  chart, comparison, board, timeline, map, or other core visualization.
 
 `PASS` is valid when every applicable control was inspected and no defect was found.
 Never infer that a check was skipped solely from the number of controls on the screen.
@@ -968,23 +991,29 @@ action is not duplicate UI.
 
 ---
 
-## Check 27 — `QACHK-ROOT-CONTAINMENT` (responsive screen content outside its root container)
+## Check 27 — `QACHK-ROOT-CONTAINMENT` (responsive root malformed or content outside it)
 
-**Problem:** A responsive screen can compile with a correctly configured root AutoLayout
-container while the actual header, sections and galleries are mis-indented as sibling
-entries in the screen's top-level `Children:` list. The root is then empty. Those siblings
-use screen-level positioning instead of AutoLayout, overlap one another, intercept pointer
-events and leave large blank areas. Every property on the individual controls can be
-valid, so no compile diagnostic reports the failure.
+**Problem:** A responsive screen can compile with a root AutoLayout that was accidentally
+given a button, panel, or breakpoint width, producing a narrow strip of clipped content.
+It can also compile while the actual header, sections and galleries are mis-indented as
+sibling entries in the screen's top-level `Children:` list. Those siblings use
+screen-level positioning instead of AutoLayout, overlap one another, intercept pointer
+events and leave large blank areas. No compile diagnostic reports either failure.
 
 **Detect:** When the screen brief names a responsive root container, inspect the
-`Children:` list directly under the screen key. It must contain exactly that root
-container. Then confirm every visible section named in the brief is nested under the
-root's `Children:` list. A root followed by another screen-level `- [Prefix]Header`,
-`- [Prefix]Panel`, gallery or stage is a failure, not a second layout region.
+`Children:` list directly under the screen key:
 
-**Fix:** Move every screen-level sibling under the root container's `Children:` key,
-preserving their order and existing properties:
+1. It must contain exactly that root container.
+2. The root must set exact `Width: =Parent.Width`, `Height: =Parent.Height`,
+   `LayoutMinWidth: =0`, and `LayoutMinHeight: =0`. Flag fixed values, breakpoint
+   branches, or any other formulas for those four properties.
+3. Every visible section named in the brief must be nested under the root's `Children:`
+   list. A root followed by another screen-level `- [Prefix]Header`, `- [Prefix]Panel`,
+   gallery or stage is a failure, not a second layout region.
+
+**Fix:** Restore the root's exact full-screen sizing and move every screen-level sibling
+under the root container's `Children:` key, preserving their order and existing
+properties:
 
 ```yaml
 Screens:
@@ -1101,22 +1130,27 @@ four of six people and have no cue that more exist.
 **Detect:** For every Gallery inside a root scroll container:
 
 1. If its Items source is a bounded local collection with roughly ten or fewer rows,
-   compare `Height` with
-   `AllItemsCount * TemplateHeight + ((AllItemsCount + 1) * TemplatePadding)`.
+   compare `Height` with the count of the same source/filter used by `Items`, multiplied
+   by `TemplateHeight` with template padding included.
 2. Flag it when the fixed height is smaller than the full list, regardless of
    `ShowScrollbar`.
 3. Flag a list that can open at a non-zero internal scroll position without an explicit
    reset-to-top behavior.
+4. Flag `Height` or empty-state `Visible` formulas that read `Self.AllItems`,
+   `Self.AllItemsCount`, or the gallery's rendered `AllItemsCount`. Those values depend
+   on materialized rows; when height begins at zero, the formula can keep the gallery at
+   zero height even though its `Items` source contains records.
 
 **Fix:** Let small bounded lists grow and rely on the root scroll:
 
 ```yaml
-Height: =Self.AllItemsCount * Self.TemplateHeight + ((Self.AllItemsCount + 1) * Self.TemplatePadding)
+Height: =With({rowCount: CountRows(<same source/filter used by Items>)}, rowCount * Self.TemplateHeight + ((rowCount + 1) * Self.TemplatePadding))
 ShowScrollbar: =false
 ```
 
-For genuinely large or unbounded data, keep the internal scroll region but provide a
-visible affordance and reset it to the first row on screen entry.
+Drive the empty-state control from that same source/filter count. For genuinely large or
+unbounded data, keep the internal scroll region but provide a visible affordance and reset
+it to the first row on screen entry.
 
 **Exception:** Large/unbounded datasets where virtualization and internal scrolling are
 intentional and visibly discoverable.
@@ -1184,3 +1218,263 @@ For four-item phone navigation, allocate equal widths that fit the parent withou
 wrapping; shorten labels or use icons when the full labels cannot fit.
 
 **Exception:** A deliberately compact icon-only action whose visible text is omitted.
+
+---
+
+## Check 33 — `QACHK-ACTION-CONTRACT` (required action is missing, unreachable, or not wired)
+
+**Problem:** A screen can display the expected entity while omitting the action the user
+requested. Common failures are an Add, Edit, Delete, Search, Filter, Flag, Review, Approve,
+Reject, Export, or period-selection flow with no visible entry control, a permanently
+hidden or disabled control, or an event handler that does not perform the behavior named
+by the screen brief.
+
+**Detect:** For every row in the screen brief's `## Required Actions` table:
+
+1. Find the named entry point and action control.
+2. Confirm the entry point is visible, non-zero-sized, and reachable from the screen's
+   normal state. If it depends on a local variable, find a reachable control that sets
+   that variable.
+   - A primary destination must be in the initial viewport or behind an immediately
+     visible navigation/menu control.
+   - An action below the fold must have a visible working scroll affordance and cannot be
+     trapped in a nested fixed-height container.
+   - Record actions cannot depend on clicking a text/card control with no matching event.
+3. Confirm the action is not permanently disabled and is not under a read-only ancestor.
+4. Inspect the named event and confirm it contains the required navigation, data
+   operation, state transition, or search/filter binding.
+5. For search and filter actions, confirm the input value participates in the target
+   list's `Items` formula and the formula covers the fields or state named by the brief.
+
+**Fix:** Add or surface the planned entry control and implement the exact handler behavior
+from the brief. Do not invent actions absent from `## Required Actions`, and do not add
+universal CRUD across supporting entities merely because the app contains them.
+
+**Exception:** None for a Required Actions row. If the brief cannot be implemented with
+the discovered controls or data source, return `Status: Blocked` rather than shipping a
+placeholder.
+
+---
+
+## Check 34 — `QACHK-MUTATION-OUTCOME` (data changes without a visible post-action result)
+
+**Problem:** A create, edit, delete, or state-transition formula can run successfully while
+the app continues to show stale or incomplete data. A success notification alone does not
+prove that the requested outcome occurred.
+
+**Detect:** For every Required Actions row whose handler uses `Patch`, `SubmitForm`,
+`Collect`, `Remove`, `RemoveIf`, `UpdateIf`, or a connector mutation:
+
+1. Identify the source, collection, or state changed by the handler.
+2. Identify the control named as the Observable result.
+3. Confirm that control reads from the changed source, collection, or state.
+4. When the visible control uses a local collection or cached source, confirm the success
+   path updates or refreshes it.
+5. Confirm the relevant changed value is visible: the new or edited record appears, the
+   deleted record disappears, or the transitioned record appears in the requested
+   status/filter/dashboard.
+6. Confirm that evidence is visible in the immediate post-action state, reached by
+   navigation in the handler, or opened by an immediately visible control. Flag a result
+   that exists only below a long form or inside an off-screen clipped panel.
+
+**Fix:** Refresh or update the visible binding after success and expose the changed field
+or state in the result control. Navigate to the bound list/detail when necessary. Keep
+success feedback, but do not use `Notify()` as the only observable outcome.
+
+**Exception:** A mutation whose Action Contract explicitly defines navigation to a detail
+screen as the observable result, when that screen binds directly to the changed record.
+
+---
+
+## Check 35 — `QACHK-BEHAVIOR-ACCEPTANCE` (advanced behavior omits an acceptance path)
+
+**Problem:** Advanced behavior can look complete while implementing only its easiest
+surface. Examples include a capacity label with no guard, move buttons that do not update
+sort order, a metric copied during `OnVisible`, mutable "versions", a category added to a
+management list but not its selectors, a leaderboard that never recalculates, an Approve
+button with no Reject decision, a quarterly heading with no period field, or an export
+notification that produces no output.
+
+**Detect:** Apply this check to every Required Actions row for search/filtering, moving or
+reordering, limits, metrics, versions, category management, ranking, role-scoped record
+management, review decisions, program periods, or export/report output:
+
+1. Match every success, boundary, rejection, persistence, or recalculation path named by
+   the brief to a reachable control event or binding.
+2. Confirm every path reads and writes the source of truth named by the brief.
+3. Confirm the visible evidence reads that same source rather than seeded or copied state.
+4. For limits, require both proactive UI state and a guard in the mutation event.
+5. For ordering and ranking, require an explicit sort and deterministic order.
+6. For versions, confirm a later save cannot overwrite an earlier snapshot and the
+   comparison identifies two distinct selections.
+7. For role-scoped management, confirm edit loads the selected record, remove/cancel has a
+   confirmation path, and the visible list reflects each completed mutation.
+8. For review, confirm every planned decision is reachable and updates the shared status
+   field rendered by the management list.
+9. For program periods, confirm the period is stored or deterministically derived and is
+   visible wherever the brief requires period-aware creation, review, or filtering.
+10. For export/report output, confirm the eligible-record predicate and fields match the
+    brief and that the action produces visible output rather than only a notification.
+
+**Fix:** Implement the missing path from the brief and bind its evidence to the shared
+source of truth. Do not replace a missing behavior with explanatory text.
+
+**Exception:** None for a path named in `## Required Actions`. Return `Status: Blocked`
+when the discovered controls or source cannot implement it.
+
+---
+
+## Check 36 — `QACHK-HORIZONTAL-BUDGET` (row content exceeds its available width)
+
+**Problem:** A row can have a breakpoint and still overflow. Child minimum widths, gaps,
+and padding may total more than the parent, clipping right-side controls or forcing them
+off-canvas.
+
+**Detect:** For every horizontal AutoLayout container at each desktop, tablet, and phone
+branch:
+
+1. Add the minimum or fixed widths of all visible children.
+2. Add `LayoutGap` for every gap and left/right padding.
+3. Compare the total with the parent width available in that branch.
+4. If flexible children use `FillPortions`, confirm their `LayoutMinWidth` values still
+   fit before remaining width is distributed.
+5. If the total does not fit, require a wrap or vertical-stack branch and repeat the
+   calculation for each resulting row.
+
+**Fix:** Stack or wrap the row, reduce justified minimum widths, group related fields, or
+move secondary actions to another reachable region. Do not shrink interactive controls
+below 44px or hide required actions.
+
+**Exception:** A deliberately horizontally scrolling region with an obvious visible
+scroll affordance and a brief that explicitly requires it.
+
+---
+
+## Check 37 — `QACHK-MANUAL-BOUNDS` (visible ManualLayout controls overlap or leave the parent)
+
+**Problem:** Absolute `X`, `Y`, `Width`, and `Height` formulas can place controls on top of
+one another or outside the parent at narrower widths. The compiler accepts both.
+
+**Detect:** For every pair of simultaneously visible children in a ManualLayout container,
+evaluate their rectangular bounds at each supported width branch. Flag:
+
+- rectangles with intersecting interiors unless the brief explicitly defines the pair as
+  an overlay;
+- `X < 0`, `Y < 0`, `X + Width > Parent.Width`, or
+  `Y + Height > Parent.Height`;
+- an overlay that covers a required interactive control or intercepts its input.
+
+**Fix:** Move the composition into AutoLayout, add breakpoint-specific bounds, or resize
+and reposition the controls so their rectangles fit without intersection.
+
+**Exception:** Intentional overlays such as badges, modal scrims, or decorative layers
+that are named in the screen brief and do not block required controls.
+
+---
+
+## Check 38 — `QACHK-TEXT-CONTENT-FIT` (text control cannot fit its longest visible value)
+
+**Problem:** Correct text can be clipped, truncated, or reduced to one unreadable line
+because its width or height was sized for a shorter seed value.
+
+**Detect:** For every visible text-bearing control:
+
+1. Identify the longest literal, status, field value, or composed caption specified by
+   the brief.
+2. For single-line text, require enough width and `Wrap: =false`.
+3. For wrapping text, require `AutoHeight: =true` or a height budget covering all lines,
+   vertical padding, and line spacing.
+4. A fixed-height text control must be at least `Size * 1.5` plus vertical padding for
+   each planned line.
+5. Confirm the containing row, card, gallery template, or section is tall enough for the
+   resulting control; `AutoHeight` does not grow a fixed parent.
+
+**Fix:** Allocate responsive width, enable wrapping with sufficient height, shorten
+nonessential copy, or enlarge the containing section/template. Do not solve clipping by
+reducing body text below 14px.
+
+**Exception:** Deliberate ellipsis in a secondary preview when the full value is reachable
+in a detail view named by the brief.
+
+---
+
+## Check 39 — `QACHK-VISUAL-CONTRACT` (screen styling diverges from the shared visual system)
+
+**Problem:** Independently built screens drift into different type scales, accent colors,
+spacing, surfaces, and action styles. A screen can also lack hierarchy when every label
+has equal weight and every action looks primary.
+
+**Detect:** Compare the screen with `canvas-app-shared.md`:
+
+1. Map the page title, section headings, body, captions, and KPI values to the exact shared
+   type roles.
+2. Confirm gaps and padding use the shared spacing scale.
+3. Confirm page, panel, card, border, and shadow treatments match the shared surfaces.
+4. Confirm primary, secondary, destructive, and disabled actions use their shared styles.
+5. Require one clear page title and focal region. Do not allow all headings, cards, and
+   actions to have equal visual weight.
+
+**Fix:** Replace screen-local styling values with the shared contract and restore the
+intended hierarchy. Do not introduce another palette or spacing increment.
+
+**Exception:** A deliberate exceptional state, such as an error or destructive
+confirmation, whose distinct treatment is defined in the shared contract.
+
+---
+
+## Check 40 — `QACHK-EXCESS-WHITESPACE` (layout sizing creates unintended empty regions)
+
+**Problem:** `FillPortions: =1`, oversized fixed heights, `SpaceBetween`, or empty spacer
+controls can create large blank bands that push useful content below the fold and make the
+screen look unfinished.
+
+**Detect:** At each supported width:
+
+1. Flag empty spacer controls or gaps larger than the shared spacing scale permits.
+2. Flag content-sized sections with `FillPortions: =1` when they do not intentionally
+   absorb remaining viewport space.
+3. Flag vertical `LayoutJustifyContent.SpaceBetween` when it separates ordinary content
+   into distant islands.
+4. Compare each fixed section height with child heights, gaps, and padding. Unassigned
+   space greater than one approved spacing increment needs an explicit purpose.
+5. Confirm blank space does not push a required action or primary result below the initial
+   viewport unnecessarily.
+
+**Fix:** Size the section to content, set `FillPortions: =0`, use an approved gap, or
+assign remaining space to the primary gallery/content region rather than empty controls.
+
+**Exception:** Deliberate negative space defined by the shared Visual Contract around a
+hero, empty state, or focused form.
+
+---
+
+## Check 41 — `QACHK-CORE-VISUALIZATION` (core visualization is blank, static, or incomplete)
+
+**Problem:** A screen can contain a correctly titled "Org chart", "Version Compare",
+"Timeline", or "Dashboard" region that renders only a blank rectangle, disabled-looking
+inputs, or decorative cards. This passes compilation and keyword checks while the core
+experience is missing or broken.
+
+**Detect:** For every core visualization named by the screen brief:
+
+1. Identify the populated-state controls and confirm they bind to the specified shared
+   source. A background container or title is not populated-state content.
+2. Confirm meaningful seed or guaranteed source data makes the visualization non-empty on
+   first render. Otherwise require a truthful empty state and reachable setup action.
+3. For relationship visualizations, confirm visible records expose their group/parent,
+   layer/depth, and reporting or connection relationship rather than rendering a flat list.
+4. For comparisons, confirm two distinct selected sources render simultaneously with
+   visible labels. If the requirement says side by side, reject tabs, a single reused
+   panel, and vertical stacking.
+5. Confirm differences are derived by stable record identity across the selected sources
+   and that added, removed, moved, or changed states have a visible treatment.
+6. Confirm empty-state, overlay, and input controls cannot cover populated content or
+   intercept its interactions.
+
+**Fix:** Bind real populated-state controls to the shared source, add meaningful first-load
+data or a truthful setup path, and implement the relationship/comparison encoding required
+by the brief. Remove placeholder surfaces and overlays that obscure the result.
+
+**Exception:** None when the screen brief names a core visualization. If the discovered
+controls cannot implement the requested interaction exactly, render the strongest truthful
+approximation and report it as blocked or approximate; never ship a blank region.

--- a/plugins/canvas-apps/skills/canvas-app/SKILL.md
+++ b/plugins/canvas-apps/skills/canvas-app/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: canvas-app
-version: 3.0.1
+version: 3.0.4
 description: Creates or edits a Power Apps Canvas App through the Canvas Authoring MCP coauthoring session. Handles new app generation, direct targeted edits, complex multi-screen changes, responsive layout, per-screen self-QA, and compile-error convergence. Trigger on requests to create, build, generate, modify, update, change, fix, or edit a Canvas App or .pa.yaml files.
 author: Microsoft Corporation
 user-invocable: true
@@ -48,7 +48,20 @@ CREATE and complex EDIT workflows return here after the planner finishes.
 2. Verify its `## Requirement Coverage` table maps every concrete requested noun and
    interaction to a visible affordance. Any approximation must be explicit and must not
    use UI copy that claims the unavailable interaction is exact.
-3. Verify its `## Dispatch` table:
+3. Verify its `## Action Contracts` table:
+   - Every concrete requested or approved-plan action has its own row.
+   - Each row names a visible entry point, owner screen, control event, required behavior,
+     and observable result.
+   - Broad words such as "manage" have not been expanded into universal CRUD across every
+     entity. A role-scoped requirement to manage all primary records still includes
+     reachable list/detail, correction/update, and remove/cancel paths unless narrowed by
+     the request or prohibited by the domain.
+   - A review or approval workflow that distinguishes final approved records includes
+     both approve and reject/decline outcomes unless explicitly defined as one-way.
+   - Temporal program requirements and explicit export/report requests have operational
+     contracts, shared source fields or predicates, and visible evidence.
+   - Every Exact interaction in Requirement Coverage maps to at least one Action Contract.
+4. Verify its `## Dispatch` table:
    - Every row has `Action`, `Screen`, `Target File`, `YAML Key`, `Name Prefix`, and
      `Screen Brief`.
    - CREATE rows use `Create`; EDIT rows use `Modify` or `Create`.
@@ -56,16 +69,17 @@ CREATE and complex EDIT workflows return here after the planner finishes.
    - No two rows target the same file.
    - No two rows share a `Name Prefix`.
    - In CREATE mode the first row targets `Screen1.pa.yaml` with YAML key `Screen1`.
-4. Confirm `canvas-app-shared.md` and every dispatch row's screen brief exist. Verify each
-   brief's assignment matches its dispatch row.
-5. In EDIT mode, apply the `### Before builders` group of `## App Changes` to
+5. Confirm `canvas-app-shared.md` and every dispatch row's screen brief exist. Verify each
+   brief's assignment matches its dispatch row and contains every Action Contract owned
+   or affected by that screen.
+6. In EDIT mode, apply the `### Before builders` group of `## App Changes` to
    `App.pa.yaml` now. Screens bind to those collections, formulas and variables, and
    compiling them against a stale app file produces false name errors.
-6. Confirm the planner reported a clean `compile_canvas` for CREATE-mode `App.pa.yaml`.
+7. Confirm the planner reported a clean `compile_canvas` for CREATE-mode `App.pa.yaml`.
    If it did not, compile now and resolve every App-level diagnostic before dispatching.
    For EDIT mode, compile after applying the before-builder app changes and resolve
    App-level diagnostics before dispatching.
-7. Invoke `canvas-screen-builder` once per dispatch row, in parallel waves of at most
+8. Invoke `canvas-screen-builder` once per dispatch row, in parallel waves of at most
    three. Wait for the whole wave to return before dispatching the next.
 
 Never dispatch more than three builders at once. Larger fan-outs can hang, and waves of
@@ -99,6 +113,39 @@ unrecognized. Confirm it matches a remaining dispatch row and leave it in place.
 
 After all builders finish:
 
+- Verify every Action Contract against the generated YAML:
+  - the entry control exists and is not permanently hidden, disabled, zero-sized, or
+    trapped behind an entry point that does not exist;
+  - the named event is non-empty and contains the required navigation, search/filter
+    binding, data operation, or state transition;
+  - the observable-result control reads from the source or state changed by the action,
+    with refresh or collection update where required.
+  A screen or entity existing is not evidence that its actions work. Return only the
+  owning screen to its builder to repair a failed contract in place.
+- Verify every responsive screen's sole root has exact full-screen sizing:
+  `Width: =Parent.Width`, `Height: =Parent.Height`, `LayoutMinWidth: =0`, and
+  `LayoutMinHeight: =0`. Reject any breakpoint, fixed width, or child-control width on a
+  root even when the screen compiles.
+- Verify bounded Gallery height and empty-state formulas count the same source/filter used
+  by `Items`. Reject `Self.AllItems`, `Self.AllItemsCount`, or rendered
+  `AllItemsCount` dependencies that can keep a populated gallery at zero height.
+- Verify every mutation's observable result is visible in the immediate post-action state
+  or reached by explicit navigation in the handler. A changed row hidden below a long
+  form does not satisfy the contract.
+- For reordering, constraints, metrics, versions, categories, and rankings, verify every
+  success, boundary, rejection, persistence, and recalculation path named by the planner.
+  Confirm all paths use the same shared source of truth as their visible evidence.
+- For role-scoped record management, verify the primary-record list exposes reachable
+  detail, update, and remove/cancel controls and that review workflows expose every planned
+  decision. Verify period fields and export predicates read the same source as the lists
+  and statuses shown to the user.
+- Verify that local/mock-data apps include the minimum supporting setup actions needed to
+  exercise requested mutations, relationships, metrics, comparisons, and rankings. This
+  is not universal CRUD: require only records and fields that the requested behavior needs.
+- Reject a named core visualization when its region has no bound populated-state controls,
+  meaningful first-render data, relationship/comparison encoding, or truthful empty state.
+- For side-by-side comparison requirements, verify two distinct labeled snapshot sources
+  render simultaneously and that highlighted differences derive from stable entity IDs.
 - Check each builder's `QA:` line. It must list an outcome for every check in
   `${PLUGIN_ROOT}/references/QAChecks.md`. Treat these as unrun and return the existing
   screen to the builder for self-QA only:
@@ -109,9 +156,25 @@ After all builders finish:
     `QACHK-ACCESSIBLE-LABEL-MISSING` `N/A` despite content controls,
     `QACHK-LOW-CONTRAST-TEXT` `N/A` despite a coloured surface, or
     `QACHK-ROOT-CONTAINMENT` `PASS` while a responsive root has screen-level siblings;
+  - `QACHK-ROOT-CONTAINMENT` `PASS` while the root does not use exact full-screen width,
+    height, and zero minimum-size formulas;
   - `QACHK-GALLERY-ROW-FITS-CONTENT` `N/A` despite the screen containing a Gallery;
   - `QACHK-ACTION-LABEL-FIT` `PASS` while a multiword action directly under vertical
-    AutoLayout lacks `Width: =Parent.Width`.
+    AutoLayout lacks `Width: =Parent.Width`;
+  - `QACHK-HORIZONTAL-BUDGET` `PASS` without per-branch width arithmetic for a
+    horizontal row;
+  - `QACHK-MANUAL-BOUNDS` `N/A` despite simultaneously visible ManualLayout children;
+  - `QACHK-TEXT-CONTENT-FIT` `PASS` without checking the longest planned or bound value;
+  - `QACHK-VISUAL-CONTRACT` `PASS` when the screen introduces values outside the shared
+    typography, spacing, surface, or action system;
+  - `QACHK-CORE-VISUALIZATION` `PASS` when a named visualization has no bound
+    populated-state controls or a comparison renders fewer than two labeled sources.
+- Reject viewport-fit QA when a horizontal row's minimum widths, gaps, and padding exceed
+  its parent in any supported branch, or when simultaneously visible ManualLayout bounds
+  intersect.
+- Compare each screen against the shared Visual Contract and return only divergent screens
+  for repair. Typography roles, spacing scale, surfaces, and action styling must remain
+  consistent across the app.
 - A self-QA follow-up is not a rebuild. Ask the builder to inspect and repair the existing
   target file, then return the corrected `QA:` line.
 - Compare every repeated navigation block against `canvas-app-shared.md`: same items,
@@ -152,3 +215,7 @@ After all builders finish:
     file is written.
 11. Do not report completion until the workspace compiles clean or remaining diagnostics
     are explicitly reported.
+12. Require only prompt- or approved-plan-derived actions. Never add universal CRUD across
+    every entity as a default. Treat role-scoped management of all primary records as a
+    lifecycle requirement, and never omit or hide an action once it is included in an
+    Action Contract.


### PR DESCRIPTION
## Summary

Improve generic Canvas App planning, building, and runtime QA so requested functionality is implemented as reachable, observable behavior rather than only represented by screens, controls, or successful compilation.

## What went wrong

Generated apps compiled successfully but still missed or hid required runtime behavior:

- Broad requirements such as “HR can manage all nominations” could produce a read-only list without complete edit and remove paths.
- Review workflows could expose Approve without Reject, while period and export requirements could appear only as labels or notifications without operational behavior.
- Mutation handlers could update data but leave the result off-screen, below a long form, or bound to a different collection, making success impossible to verify.
- Responsive roots could inherit fixed or breakpoint widths intended for child controls, leaving blank or clipped screens.
- Bounded galleries used `Self.AllItemsCount` to calculate their own height. Because rendered item count depends on the gallery already having height, populated galleries could remain at zero height and appear empty.
- Compilation could not detect these failures because the formulas and control properties were syntactically valid.

## Why these changes are needed

The planner, screen builder, and orchestrator did not share a strict end-to-end contract for requested actions and their visible outcomes. Runtime QA also checked individual controls and layout properties without consistently proving that a user could reach an action, complete it, and immediately observe the correct result.

Q15 exposed these gaps through nomination management, review decisions, filtering, category management, reporting, and leaderboard scenarios. The fixes are generic: they contain no Q15-specific entities or formulas and apply only when equivalent behavior is requested by any Canvas App prompt.

## What this solves

- Adds end-to-end Action Contracts for requested create, edit, delete, search, filter, review, approve, reject, period, export, and similar behaviors.
- Treats role-scoped management of the primary entity as an operational lifecycle requirement while avoiding universal CRUD for supporting entities.
- Requires actions and navigation to be reachable and mutation results to be immediately visible from the same source of truth.
- Requires exact full-screen responsive root formulas so child sizing cannot accidentally collapse the app surface.
- Sizes bounded galleries from `CountRows(<the same source/filter used by Items>)`, eliminating zero-height materialization cycles caused by rendered-item counts.
- Adds runtime QA checks for missing actions, hidden outcomes, incomplete acceptance paths, malformed roots, and unsafe gallery sizing.

## Evaluation examples

| Pipeline | Q15 result | Notes |
|---|---:|---|
| [177334619](https://dev.azure.com/msazure/One/_build/results?buildId=177334619) | 6/10 canonical scenarios (60%) | Preview was valid with 28 rendered controls. Edit, delete, category filter, and add-category failed. The published aggregate records 8/12 (66.7%) with no skipped scenarios. |
| [177026671](https://dev.azure.com/msazure/One/_build/results?buildId=177026671) | 6/12 scenarios (50%) | Earlier Q15 run using the same scenario-set version, with no skipped scenarios. |

These runs demonstrate the failure modes and are not a strict A/B comparison because they used different eval versions and pipeline source revisions.

