### PR TITLE
fix(model-apps): round-trip a web-resource sitemap subarea (#430)

### DIFF
--- a/plugins/model-apps/AGENTS.md
+++ b/plugins/model-apps/AGENTS.md
@@ -262,6 +262,17 @@ the pipeline and delegates each script's **behavioral spec** to the entries belo
   (every tile carries the deployed view/chart ids), so a rebuild recreates the dashboard against the
   existing views/charts without re-declaring them (genpage/entity/URL subareas round-trip losslessly). A
   dashboard whose tiles cannot be reconstructed is dropped and surfaced in `droppedSubareas`.
+  **A URL subarea carrying a WEB-RESOURCE TOKEN is dropped, not emitted.** The Site Map Designer's
+  "custom page backed by an HTML web resource" writes `$webresource:<name>` into a URL subarea; the App
+  Spec has no `webresource` subarea kind and the validator requires http(s) (a deliberate guard — a
+  `javascript:`/`file:` nav entry in a shipped app is an injection / exfil vector). Passing the token
+  through made the WHOLE download fail validation and write no spec at all, blocking download → edit →
+  rebuild for the entire app over one unrelated nav entry (issue #430). It is now dropped like
+  `CustomPage` and counted in `droppedSubareas`, so the maker is told which nav entry will be missing and
+  `--allow-lossy-download` writes the rest. The drop is keyed off the **shared `isSafeHttpUrl`** rule, so
+  any scheme the validator would reject is dropped rather than failing the download, and the two cannot
+  drift. Supporting such a subarea end-to-end is a real feature (schema + build + the web resource's own
+  content, which download does not capture) — not done.
 - **`scripts/verify-model-app.js` → `scripts/lib/verify-spec.js`** — read-only reconcile of the App Spec
   against what actually deployed; exits non-zero and lists anything missing, catching silent partial
   builds. Checks **existence** (entities/columns/views/charts/forms + sitemap subareas + icons + pages by

--- a/plugins/model-apps/AGENTS.md
+++ b/plugins/model-apps/AGENTS.md
@@ -262,17 +262,22 @@ the pipeline and delegates each script's **behavioral spec** to the entries belo
   (every tile carries the deployed view/chart ids), so a rebuild recreates the dashboard against the
   existing views/charts without re-declaring them (genpage/entity/URL subareas round-trip losslessly). A
   dashboard whose tiles cannot be reconstructed is dropped and surfaced in `droppedSubareas`.
-  **A URL subarea carrying a WEB-RESOURCE TOKEN is dropped, not emitted.** The Site Map Designer's
-  "custom page backed by an HTML web resource" writes `$webresource:<name>` into a URL subarea; the App
-  Spec has no `webresource` subarea kind and the validator requires http(s) (a deliberate guard — a
-  `javascript:`/`file:` nav entry in a shipped app is an injection / exfil vector). Passing the token
-  through made the WHOLE download fail validation and write no spec at all, blocking download → edit →
-  rebuild for the entire app over one unrelated nav entry (issue #430). It is now dropped like
-  `CustomPage` and counted in `droppedSubareas`, so the maker is told which nav entry will be missing and
-  `--allow-lossy-download` writes the rest. The drop is keyed off the **shared `isSafeHttpUrl`** rule, so
-  any scheme the validator would reject is dropped rather than failing the download, and the two cannot
-  drift. Supporting such a subarea end-to-end is a real feature (schema + build + the web resource's own
-  content, which download does not capture) — not done.
+  **A URL subarea that TARGETS a web resource round-trips too.** The Site Map Designer's "custom page
+  backed by an HTML web resource" writes `$webresource:<name>` (Dataverse also serves it at
+  `/WebResources/<name>`) into a URL subarea. Passing that token through used to fail the WHOLE
+  download on validation — the http(s) guard rejected it — so no spec was written at all and download
+  → edit → rebuild was blocked for the entire app over one nav entry (issue #430). It is now a real
+  round-trip: `collectSitemap` adds the referenced name to `customRefs` so the resource's CONTENT is
+  fetched and re-declared into `webResources[]` (the same path a token-referenced nav ICON already
+  took), and the validator accepts the token **provided the web resource is declared** — the identical
+  rule a dashboard `webresource` tile already uses. The build needed no change: it already passes a
+  subarea `url` straight through to the sitemap.
+  This does **not** weaken the http(s) guard, which exists to stop an *arbitrary* scheme
+  (`javascript:`, `file:`) becoming a nav entry in a shipped app. A token is not arbitrary — it names
+  a resource inside the solution, and requiring it to be declared keeps the app self-contained on
+  export/import. An **undeclared** token is a hard validation error rather than a dangling link, and a
+  genuinely unexpressible url (`javascript:`, malformed) is still dropped and counted in
+  `droppedSubareas`.
 - **`scripts/verify-model-app.js` → `scripts/lib/verify-spec.js`** — read-only reconcile of the App Spec
   against what actually deployed; exits non-zero and lists anything missing, catching silent partial
   builds. Checks **existence** (entities/columns/views/charts/forms + sitemap subareas + icons + pages by

--- a/plugins/model-apps/AGENTS.md
+++ b/plugins/model-apps/AGENTS.md
@@ -266,18 +266,23 @@ the pipeline and delegates each script's **behavioral spec** to the entries belo
   backed by an HTML web resource" writes `$webresource:<name>` (Dataverse also serves it at
   `/WebResources/<name>`) into a URL subarea. Passing that token through used to fail the WHOLE
   download on validation — the http(s) guard rejected it — so no spec was written at all and download
-  → edit → rebuild was blocked for the entire app over one nav entry (issue #430). It is now a real
-  round-trip: `collectSitemap` adds the referenced name to `customRefs` so the resource's CONTENT is
-  fetched and re-declared into `webResources[]` (the same path a token-referenced nav ICON already
-  took), and the validator accepts the token **provided the web resource is declared** — the identical
-  rule a dashboard `webresource` tile already uses. The build needed no change: it already passes a
-  subarea `url` straight through to the sitemap.
+  → edit → rebuild was blocked for the entire app over one nav entry (issue #430). The reference now
+  **passes validation as-is**, exactly like a platform icon ref and for the reason recorded there: it
+  is a live/OOB value a downloaded app carries, and rejecting it broke the round-trip on real apps.
+  Requiring it to be *declared* would re-make that mistake, because such a page is frequently managed
+  or owned by another publisher.
+  Download additionally captures the page's CONTENT when it can safely do so. `collectSitemap` returns
+  these as **`navRefs`, separate from icon `customRefs`**, because the type policy differs: the icon
+  path gates on `IMAGE_WR_TYPES` by design and such a page is `html` (type 1), so routing it through
+  the icon rules silently declared nothing and left a rebuild pointing at a resource the spec could
+  not recreate. A nav ref takes the same safety gates as an icon — own prefix, unmanaged, has content,
+  `external: true` so teardown never deletes it — minus the image-type gate. A managed/foreign one is
+  left as a bare reference (it exists in the target env). The build needed no change: it already
+  passes a subarea `url` straight through to the sitemap.
   This does **not** weaken the http(s) guard, which exists to stop an *arbitrary* scheme
-  (`javascript:`, `file:`) becoming a nav entry in a shipped app. A token is not arbitrary — it names
-  a resource inside the solution, and requiring it to be declared keeps the app self-contained on
-  export/import. An **undeclared** token is a hard validation error rather than a dangling link, and a
-  genuinely unexpressible url (`javascript:`, malformed) is still dropped and counted in
-  `droppedSubareas`.
+  (`javascript:`, `file:`) becoming a nav entry in a shipped app — a web-resource reference names a
+  resource inside Dataverse, not a script or a local file. A genuinely unexpressible url is still
+  dropped and counted in `droppedSubareas`.
 - **`scripts/verify-model-app.js` → `scripts/lib/verify-spec.js`** — read-only reconcile of the App Spec
   against what actually deployed; exits non-zero and lists anything missing, catching silent partial
   builds. Checks **existence** (entities/columns/views/charts/forms + sitemap subareas + icons + pages by

--- a/plugins/model-apps/CHANGELOG.md
+++ b/plugins/model-apps/CHANGELOG.md
@@ -33,6 +33,16 @@ smoke-eval assertion that could never pass live.
   GitHub Copilot CLI or Claude Code host when a newer version is available.
 
 ### Fixed
+- **`download-model-app.js` no longer fails hard on a sitemap subarea that targets a
+  custom web resource** ([#430](https://github.com/microsoft/power-platform-skills/issues/430)).
+  The Site Map Designer writes `$webresource:<name>` into a URL subarea; the App Spec has
+  no `webresource` kind and the validator requires http(s), so the token failed validation
+  and **no spec file was written at all** — blocking the whole download → edit → rebuild
+  flow for the app over a single unrelated nav entry. The subarea is now dropped like
+  `CustomPage` and counted in `droppedSubareas`, so the maker is told which nav entry will
+  be missing and `--allow-lossy-download` writes the rest of the app. The drop reuses the
+  validator's own `isSafeHttpUrl` rule, so any scheme it would reject is dropped rather
+  than failing the download.
 - **Malformed specs now produce validation errors instead of raw `TypeError`s.** `validateAppSpec()`
   and `lintAppSpec()` crashed on a `null` spec, an object- or string-shaped collection
   (`entities: {}`), and `null` entries inside a collection; `preview-app` crashed when a persona

--- a/plugins/model-apps/CHANGELOG.md
+++ b/plugins/model-apps/CHANGELOG.md
@@ -33,16 +33,17 @@ smoke-eval assertion that could never pass live.
   GitHub Copilot CLI or Claude Code host when a newer version is available.
 
 ### Fixed
-- **`download-model-app.js` no longer fails hard on a sitemap subarea that targets a
-  custom web resource** ([#430](https://github.com/microsoft/power-platform-skills/issues/430)).
-  The Site Map Designer writes `$webresource:<name>` into a URL subarea; the App Spec has
-  no `webresource` kind and the validator requires http(s), so the token failed validation
-  and **no spec file was written at all** — blocking the whole download → edit → rebuild
-  flow for the app over a single unrelated nav entry. The subarea is now dropped like
-  `CustomPage` and counted in `droppedSubareas`, so the maker is told which nav entry will
-  be missing and `--allow-lossy-download` writes the rest of the app. The drop reuses the
-  validator's own `isSafeHttpUrl` rule, so any scheme it would reject is dropped rather
-  than failing the download.
+- **A sitemap subarea that targets a custom web resource now round-trips**
+  ([#430](https://github.com/microsoft/power-platform-skills/issues/430)).
+  The Site Map Designer writes `$webresource:<name>` into a URL subarea; the http(s)
+  guard rejected it, so the downloaded spec failed validation and **no spec file was
+  written at all** — blocking the whole download → edit → rebuild flow for the app over
+  a single unrelated nav entry. `download-model-app.js` now collects the referenced web
+  resource so its **content** is fetched and re-declared into `webResources[]`, and the
+  validator accepts the token provided that resource is declared — the same rule a
+  dashboard `webresource` tile already uses. The http(s) guard is unchanged for real
+  links: an *undeclared* token is a hard error, and a `javascript:`/`file:`/malformed
+  url is still dropped and counted in `droppedSubareas`.
 - **Malformed specs now produce validation errors instead of raw `TypeError`s.** `validateAppSpec()`
   and `lintAppSpec()` crashed on a `null` spec, an object- or string-shaped collection
   (`entities: {}`), and `null` entries inside a collection; `preview-app` crashed when a persona

--- a/plugins/model-apps/CHANGELOG.md
+++ b/plugins/model-apps/CHANGELOG.md
@@ -38,12 +38,13 @@ smoke-eval assertion that could never pass live.
   The Site Map Designer writes `$webresource:<name>` into a URL subarea; the http(s)
   guard rejected it, so the downloaded spec failed validation and **no spec file was
   written at all** — blocking the whole download → edit → rebuild flow for the app over
-  a single unrelated nav entry. `download-model-app.js` now collects the referenced web
-  resource so its **content** is fetched and re-declared into `webResources[]`, and the
-  validator accepts the token provided that resource is declared — the same rule a
-  dashboard `webresource` tile already uses. The http(s) guard is unchanged for real
-  links: an *undeclared* token is a hard error, and a `javascript:`/`file:`/malformed
-  url is still dropped and counted in `droppedSubareas`.
+  a single unrelated nav entry. The reference now passes validation as-is (the same
+  policy platform icon refs already use), and `download-model-app.js` additionally
+  captures the page's **content** into `webResources[]` when it can safely do so — as
+  `navRefs`, kept separate from icon refs because the icon path is image-only by design
+  and such a page is `html`. A managed or foreign resource stays a bare reference; it
+  exists in the target environment. A `javascript:`/`file:`/malformed url is still
+  rejected and dropped.
 - **Malformed specs now produce validation errors instead of raw `TypeError`s.** `validateAppSpec()`
   and `lintAppSpec()` crashed on a `null` spec, an object- or string-shaped collection
   (`entities: {}`), and `null` entries inside a collection; `preview-app` crashed when a persona

--- a/plugins/model-apps/references/app-spec-schema.md
+++ b/plugins/model-apps/references/app-spec-schema.md
@@ -413,10 +413,12 @@ Reference from a column via `"globalChoice": "new_priority"` (built before the c
   — surfaced as a `GenPage` sitemap subarea).
 - **`url` is either a real http(s) link or a web-resource reference** — `$webresource:<name>` (the form
   the Site Map Designer writes for a "custom page backed by an HTML web resource") or the equivalent
-  `/WebResources/<name>` path. A web-resource reference **must name a declared `webResources[]` entry**,
-  the same rule a dashboard `webresource` tile uses, so the app stays self-contained on export/import;
-  an undeclared one is an error. Any other scheme is rejected: a `javascript:` or `file:` nav entry in
-  a shipped app is a script-injection / local-file-exfil vector.
+  `/WebResources/<name>` path. A web-resource reference **passes through as-is**, like a platform icon
+  ref: it is a live/OOB value a downloaded app carries, and the resource is frequently managed or owned
+  by another publisher, so requiring it to be declared would break the download→build round-trip.
+  Download captures its content into `webResources[]` when it can safely do so (own prefix, unmanaged).
+  Any other scheme is rejected: a `javascript:` or `file:` nav entry in a shipped app is a
+  script-injection / local-file-exfil vector.
 - Any area or subarea may set **`icon`**. This is either a declared image `webResources[]` NAME
   (png/jpg/gif/svg/ico — validated against `webResources[]`) OR a **platform icon reference** — a path
   (`/WebResources/…`, `/_imgs/…`) or a `$webresource:<name>` — which a **downloaded** app carries verbatim

--- a/plugins/model-apps/references/app-spec-schema.md
+++ b/plugins/model-apps/references/app-spec-schema.md
@@ -403,6 +403,7 @@ Reference from a column via `"globalChoice": "new_priority"` (built before the c
   { "entity": "new_customer", "title": "Customers" },                              // a table (nav icon = its TABLE icon)
   { "dashboard": "Operations", "title": "Overview", "icon": "new_overview.svg" },  // a built dashboard (by name)
   { "url": "https://…",       "title": "Help" },                                   // an external link
+  { "url": "$webresource:new_home.html", "title": "Home" },                        // a declared web resource
   { "page": "overview",       "title": "Overview" }                                // a genpage — KEY (schemaVersion 2)
 ] } ] } ] }
 ```
@@ -410,6 +411,12 @@ Reference from a column via `"globalChoice": "new_priority"` (built before the c
   of a `dashboards[]` entry — auto-pinned as an app component so the app includes it), `url`, or
   `page` (the **`key`** of a `pages[]` generative page at schemaVersion 2; the **name** for legacy specs
   — surfaced as a `GenPage` sitemap subarea).
+- **`url` is either a real http(s) link or a web-resource reference** — `$webresource:<name>` (the form
+  the Site Map Designer writes for a "custom page backed by an HTML web resource") or the equivalent
+  `/WebResources/<name>` path. A web-resource reference **must name a declared `webResources[]` entry**,
+  the same rule a dashboard `webresource` tile uses, so the app stays self-contained on export/import;
+  an undeclared one is an error. Any other scheme is rejected: a `javascript:` or `file:` nav entry in
+  a shipped app is a script-injection / local-file-exfil vector.
 - Any area or subarea may set **`icon`**. This is either a declared image `webResources[]` NAME
   (png/jpg/gif/svg/ico — validated against `webResources[]`) OR a **platform icon reference** — a path
   (`/WebResources/…`, `/_imgs/…`) or a `$webresource:<name>` — which a **downloaded** app carries verbatim

--- a/plugins/model-apps/scripts/download-model-app.js
+++ b/plugins/model-apps/scripts/download-model-app.js
@@ -119,6 +119,16 @@ function collectSitemap(app) {
       for (const sa of g.subAreas || []) {
         if (sa.type === 'Entity' && sa.entity) entities.add(String(sa.entity).toLowerCase());
         addIcon(sa.icon); addIcon(sa.vectorIcon);
+        // A URL subarea can TARGET a web resource rather than link out — the Site Map Designer's
+        // "custom page backed by an HTML web resource" writes `$webresource:<name>`. Collect it the
+        // same way a token-referenced icon is collected, so the resource's CONTENT is fetched and
+        // re-declared into `webResources[]`. Without this the rebuilt app would carry a nav entry
+        // pointing at a resource the spec never recreates — a dangling link in the target env.
+        // `webResourceNameFromRef` returns null for a real http(s) link, so those are untouched.
+        if (sa.type === 'URL' && sa.url) {
+          const wr = webResourceNameFromRef(sa.url);
+          if (wr) customRefs.add(wr);
+        }
       }
     }
   }

--- a/plugins/model-apps/scripts/download-model-app.js
+++ b/plugins/model-apps/scripts/download-model-app.js
@@ -112,6 +112,7 @@ function collectSitemap(app) {
   const entities = new Set();
   const icons = new Set();
   const customRefs = new Set();
+  const navRefs = new Set();   // web resources a URL SUBAREA targets (non-image types allowed)
   const addIcon = (v) => { if (!v) return; if (isPlatformIconRef(v)) { const n = webResourceNameFromRef(v); if (n) customRefs.add(n); } else icons.add(v); };
   for (const a of (app.siteMap && app.siteMap.areas) || []) {
     addIcon(a.icon); addIcon(a.vectorIcon);
@@ -120,19 +121,19 @@ function collectSitemap(app) {
         if (sa.type === 'Entity' && sa.entity) entities.add(String(sa.entity).toLowerCase());
         addIcon(sa.icon); addIcon(sa.vectorIcon);
         // A URL subarea can TARGET a web resource rather than link out — the Site Map Designer's
-        // "custom page backed by an HTML web resource" writes `$webresource:<name>`. Collect it the
-        // same way a token-referenced icon is collected, so the resource's CONTENT is fetched and
-        // re-declared into `webResources[]`. Without this the rebuilt app would carry a nav entry
-        // pointing at a resource the spec never recreates — a dangling link in the target env.
+        // "custom page backed by an HTML web resource" writes `$webresource:<name>`. Collected
+        // SEPARATELY from icon refs because the type policy differs: such a page is `html`, which the
+        // icon path's image-only gate excludes by design. Capturing it means the page travels with
+        // the app instead of the rebuild emitting a nav entry the spec cannot recreate.
         // `webResourceNameFromRef` returns null for a real http(s) link, so those are untouched.
         if (sa.type === 'URL' && sa.url) {
           const wr = webResourceNameFromRef(sa.url);
-          if (wr) customRefs.add(wr);
+          if (wr) navRefs.add(wr);
         }
       }
     }
   }
-  return { entities: [...entities], icons: [...icons], customRefs: [...customRefs] };
+  return { entities: [...entities], icons: [...icons], customRefs: [...customRefs], navRefs: [...navRefs] };
 }
 
 // The entity logical names that are COMPONENTS of the app module, regardless of whether they appear
@@ -363,11 +364,19 @@ const IMAGE_WR_TYPES = new Set([5, 6, 7, 10, 11]);
 //   any path-derived WR (an unknown non-'new' prefix would BuildHalt on a fresh env) but we PROBE every
 //   customRef and surface each genuine CUSTOM (unmanaged image) one as `unresolved` — a managed/OOB/absent
 //   ref is a system icon present in every env, so it stays silent (no false alarm).
-async function iconWebResources(sdk, icons, customRefs, ownPrefix, prefixResolved) {
+async function iconWebResources(sdk, icons, customRefs, ownPrefix, prefixResolved, navRefs) {
   const out = [];
   const seen = new Set();                 // lowercased names actually re-declared into `out`
   const prefixLc = ownPrefix ? String(ownPrefix).toLowerCase() + '_' : null;
   const customRefSet = new Set((customRefs || []).map((n) => String(n).toLowerCase()));
+  // `navRefs` are web resources a URL SUBAREA targets (the Site Map Designer's "custom page backed by
+  // an HTML web resource"), as opposed to an icon. They take the SAME safety gates as a path-derived
+  // icon — own prefix, unmanaged, has content, `external: true` so teardown never deletes it — but
+  // NOT the image-type gate: such a page is `html` (type 1), which `IMAGE_WR_TYPES` excludes by
+  // design. Without this distinction the page is never re-declared and a rebuild's nav entry points
+  // at a resource the spec cannot recreate.
+  const navRefSet = new Set((navRefs || []).map((n) => String(n).toLowerCase()));
+  const allowedTypeFor = (key) => (navRefSet.has(key) ? null : IMAGE_WR_TYPES); // null = any type
   const candidateUnresolved = new Map();  // key -> original name; a path ref we could NOT re-declare in PASS 1
   const queryWr = async (name) =>
     (await sdk.queryRecords('webresource', { select: ['name', 'webresourcetype', 'content', 'ismanaged'], filter: `name eq '${String(name).replace(/'/g, "''")}'`, top: 1 }))?.[0];
@@ -377,7 +386,7 @@ async function iconWebResources(sdk, icons, customRefs, ownPrefix, prefixResolve
   // path AND by a bare name is classified by the STRICTER path rules (and flagged `external`) before the
   // lenient bare pass can re-declare it as deletable — otherwise the overlap silently loses teardown
   // protection and a shared nav icon gets deleted (Sol review, High).
-  for (const name of customRefs || []) {
+  for (const name of [...(customRefs || []), ...(navRefs || [])]) {
     const key = String(name).toLowerCase();
     if (seen.has(key)) continue;
     const ownScoped = !!prefixLc && key.startsWith(prefixLc);
@@ -394,7 +403,8 @@ async function iconWebResources(sdk, icons, customRefs, ownPrefix, prefixResolve
         continue;
       }
       if (!wr || !wr.content) { candidateUnresolved.set(key, name); continue; }         // own-prefix but absent on source → will dangle
-      if (wr.ismanaged === true || !IMAGE_WR_TYPES.has(wr.webresourcetype)) continue;   // managed/non-image → leave as a bare reference
+      const allowed = allowedTypeFor(key);
+      if (wr.ismanaged === true || (allowed && !allowed.has(wr.webresourcetype))) continue;   // managed / wrong type → leave as a bare reference
       seen.add(key);
       out.push({ name, type: WR_TYPE[wr.webresourcetype] || 'png', contentBase64: wr.content, external: true });
     } catch { candidateUnresolved.set(key, name); /* read failure → candidate (surface unless a bare pass resolves it) */ }
@@ -508,7 +518,7 @@ async function runDownload({ sdk, genpageCli, outDir, appId, appUnique, allowLos
     }
     throw e;
   }
-  const { entities: entityLogicals, icons, customRefs } = collectSitemap(app);
+  const { entities: entityLogicals, icons, customRefs, navRefs } = collectSitemap(app);
 
   // MEMBERSHIP: the authoritative set of pages owned by this app, from its SITEMAP XML (fail-closed,
   // discriminated). The app-scoped `pac genpage list --app-id` is sitemap-scoped anyway but returns
@@ -707,7 +717,7 @@ async function runDownload({ sdk, genpageCli, outDir, appId, appUnique, allowLos
   // publisher (`solution.publisherPrefix`). A FOREIGN-prefix / OOB reference is left as a bare reference:
   // re-declaring it would make the build try to createWebResource under an unregistered prefix on a fresh
   // env → a hard BuildHalt, turning a cosmetic broken icon into a failed build (Opus review).
-  const { webResources, unresolved: unresolvedIcons } = await iconWebResources(sdk, icons, customRefs, solution.publisherPrefix, solution.prefixResolved);
+  const { webResources, unresolved: unresolvedIcons } = await iconWebResources(sdk, icons, customRefs, solution.publisherPrefix, solution.prefixResolved, navRefs);
   if (unresolvedIcons && unresolvedIcons.length) {
     // A custom nav icon we couldn't safely round-trip: either an own-prefix WR that's absent on the source
     // env / failed to read, OR (when the publisher prefix couldn't be verified) any custom image icon we

--- a/plugins/model-apps/scripts/lib/app-spec.js
+++ b/plugins/model-apps/scripts/lib/app-spec.js
@@ -851,7 +851,27 @@ function validateAppSpec(spec, opts = {}) {
         // `entity: "account"`. Matches the chart check above, which already uses `entityByLower`.
         if (sa.entity && !entityByLower.has(String(sa.entity).toLowerCase())) errors.push(`sitemap subArea references unknown entity '${sa.entity}'`);
         if (sa.dashboard && !dashNamesSet.has(sa.dashboard)) errors.push(`sitemap subArea references unknown dashboard '${sa.dashboard}' (declare it in dashboards[])`);
-        if (sa.url && !isSafeHttpUrl(sa.url)) errors.push(`sitemap subArea "${sa.title || ''}" url must be an http(s) URL (got '${sa.url}')`);
+        // A sitemap URL subarea is EITHER a real link OR a web-resource TOKEN. The Site Map
+        // Designer's "custom page backed by an HTML web resource" writes `$webresource:<name>`
+        // (Dataverse also serves the same resource at `/WebResources/<name>`), which is a standard,
+        // documented navigation feature — not an escape hatch.
+        //
+        // Allowing it does NOT weaken the http(s) guard, which exists to stop an ARBITRARY scheme
+        // (`javascript:`, `file:`) becoming a nav entry in a shipped app. A token is not arbitrary:
+        // it names a web resource INSIDE the solution, and it must be DECLARED in `webResources[]`
+        // — exactly the rule a dashboard `webresource` tile already uses. So the reference is
+        // self-contained and travels on export/import, and an undeclared one is a hard error rather
+        // than a dangling link.
+        if (sa.url) {
+          const wrRef = webResourceNameFromRef(sa.url);
+          if (wrRef) {
+            if (!webResourceNames.has(String(wrRef).toLowerCase())) {
+              errors.push(`sitemap subArea "${sa.title || ''}" targets undeclared web resource '${wrRef}' (declare it in webResources[])`);
+            }
+          } else if (!isSafeHttpUrl(sa.url)) {
+            errors.push(`sitemap subArea "${sa.title || ''}" url must be an http(s) URL or a $webresource:<name> reference (got '${sa.url}')`);
+          }
+        }
         // schemaVersion 2 references pages by stable KEY; legacy specs still reference by name.
         const pageRefSet = isV2 ? pageKeysSet : pageNamesSet;
         if (sa.page && !pageRefSet.has(sa.page)) errors.push(`sitemap subArea references unknown page '${sa.page}' (declare it in pages[])`);

--- a/plugins/model-apps/scripts/lib/app-spec.js
+++ b/plugins/model-apps/scripts/lib/app-spec.js
@@ -1277,5 +1277,6 @@ module.exports = {
   prefixedRelationshipName,
   manyToManyFor,
   manyToManySchemaName,
+  isSafeHttpUrl,
   CHART_TYPES,
 };

--- a/plugins/model-apps/scripts/lib/app-spec.js
+++ b/plugins/model-apps/scripts/lib/app-spec.js
@@ -851,26 +851,24 @@ function validateAppSpec(spec, opts = {}) {
         // `entity: "account"`. Matches the chart check above, which already uses `entityByLower`.
         if (sa.entity && !entityByLower.has(String(sa.entity).toLowerCase())) errors.push(`sitemap subArea references unknown entity '${sa.entity}'`);
         if (sa.dashboard && !dashNamesSet.has(sa.dashboard)) errors.push(`sitemap subArea references unknown dashboard '${sa.dashboard}' (declare it in dashboards[])`);
-        // A sitemap URL subarea is EITHER a real link OR a web-resource TOKEN. The Site Map
-        // Designer's "custom page backed by an HTML web resource" writes `$webresource:<name>`
-        // (Dataverse also serves the same resource at `/WebResources/<name>`), which is a standard,
-        // documented navigation feature — not an escape hatch.
+        // A sitemap URL subarea is EITHER a real link OR a web-resource reference —
+        // `$webresource:<name>` (what the Site Map Designer writes for a "custom page backed by an
+        // HTML web resource") or the equivalent `/WebResources/<name>` path.
         //
-        // Allowing it does NOT weaken the http(s) guard, which exists to stop an ARBITRARY scheme
-        // (`javascript:`, `file:`) becoming a nav entry in a shipped app. A token is not arbitrary:
-        // it names a web resource INSIDE the solution, and it must be DECLARED in `webResources[]`
-        // — exactly the rule a dashboard `webresource` tile already uses. So the reference is
-        // self-contained and travels on export/import, and an undeclared one is a hard error rather
-        // than a dangling link.
-        if (sa.url) {
-          const wrRef = webResourceNameFromRef(sa.url);
-          if (wrRef) {
-            if (!webResourceNames.has(String(wrRef).toLowerCase())) {
-              errors.push(`sitemap subArea "${sa.title || ''}" targets undeclared web resource '${wrRef}' (declare it in webResources[])`);
-            }
-          } else if (!isSafeHttpUrl(sa.url)) {
-            errors.push(`sitemap subArea "${sa.title || ''}" url must be an http(s) URL or a $webresource:<name> reference (got '${sa.url}')`);
-          }
+        // A web-resource reference passes through AS-IS, exactly like a platform icon ref above,
+        // and for the same reason recorded there: it is a live/OOB value a downloaded app carries,
+        // and rejecting it broke the download→build round-trip on real apps. Requiring it to be
+        // DECLARED would re-make that mistake in a new place — the referenced resource is often
+        // managed or owned by another publisher, which download deliberately leaves as a bare
+        // reference (it exists in the target env; re-creating a foreign prefix would hard-fail a
+        // fresh build). Download still captures the CONTENT when it can safely do so, so an
+        // own-prefix unmanaged page travels with the app.
+        //
+        // This does not weaken the http(s) guard, which exists to stop an ARBITRARY scheme
+        // (`javascript:`, `file:`) becoming a nav entry in a shipped app. A web-resource reference
+        // is not arbitrary: it names a resource inside Dataverse, not a script or a local file.
+        if (sa.url && !webResourceNameFromRef(sa.url) && !isSafeHttpUrl(sa.url)) {
+          errors.push(`sitemap subArea "${sa.title || ''}" url must be an http(s) URL or a $webresource:<name> reference (got '${sa.url}')`);
         }
         // schemaVersion 2 references pages by stable KEY; legacy specs still reference by name.
         const pageRefSet = isV2 ? pageKeysSet : pageNamesSet;

--- a/plugins/model-apps/scripts/lib/hydrate-spec.js
+++ b/plugins/model-apps/scripts/lib/hydrate-spec.js
@@ -1,5 +1,5 @@
 'use strict';
-const { isSafeHttpUrl } = require('./app-spec.js');
+const { isSafeHttpUrl, webResourceNameFromRef } = require('./app-spec.js');
 // Reconstruct a COMPLETE app-spec from a DEPLOYED app (the edit flow's "pull everything" step). Pure
 // + testable: `read` supplies the deployed state — the app (sitemap JSON, via the SDK's app read
 // path which surfaces entity/genPage/icon subareas), its generative pages (via pac list+download),
@@ -31,23 +31,20 @@ function subAreaToSpec(sa, pageRefById, dashboardNameById) {
     return name ? { ...base, dashboard: name } : null; // drop only if we couldn't reconstruct the dashboard
   }
   if (sa.type === 'URL' && sa.url) {
-    // A sitemap URL subarea does not always carry a real link. The Site Map Designer's "custom page
-    // backed by an HTML web resource" writes a TOKEN instead — `$webresource:<name>` (Dataverse also
-    // serves the same resource at `/WebResources/<name>`). The App Spec has no `webresource` subarea
-    // kind, and the validator requires http(s) (`isSafeHttpUrl`, a deliberate guard: a javascript:
-    // or file: nav entry in a shipped app is a script-injection / local-file-exfil vector).
+    // A URL subarea is EITHER a real link OR a web-resource TOKEN (`$webresource:<name>`, which
+    // Dataverse also serves at `/WebResources/<name>`) — the Site Map Designer's "custom page backed
+    // by an HTML web resource". BOTH round-trip: the validator accepts a token whose web resource is
+    // declared in `webResources[]`, and `collectSitemap` adds that name to the download's
+    // `customRefs`, so its CONTENT is fetched and re-declared — the same path a custom nav icon
+    // referenced by token already takes.
     //
-    // Passing the token through therefore made the WHOLE download fail validation and write no spec
-    // at all — blocking download → edit → rebuild for the entire app over one unrelated nav entry,
-    // with an error naming a validator rather than the offending subarea, and `--allow-lossy-download`
-    // did not cover it. Drop it like CustomPage instead, so it is counted in `droppedSubareas`: the
-    // maker is told exactly which nav entry will be missing, and the existing lossy override writes
-    // the rest of the app.
-    //
-    // Tested against the shared `isSafeHttpUrl` rather than a `$webresource:` string match, so ANY
-    // scheme the validator would reject is dropped here rather than failing the download, and the two
-    // cannot drift apart.
-    return isSafeHttpUrl(sa.url) ? { ...base, url: sa.url } : null;
+    // Anything else (a `javascript:`/`file:` scheme, a malformed string) cannot be expressed in the
+    // App Spec, so it is dropped here rather than emitted. Passing it through made the WHOLE download
+    // fail validation and write no spec at all, blocking download → edit → rebuild for the entire app
+    // over one nav entry (issue #430). A drop is counted in `droppedSubareas`, so the maker is told
+    // which entry will be missing and `--allow-lossy-download` writes the rest.
+    if (webResourceNameFromRef(sa.url) || isSafeHttpUrl(sa.url)) return { ...base, url: sa.url };
+    return null;
   }
   return null; // CustomPage / unmapped — not hydrated
 }

--- a/plugins/model-apps/scripts/lib/hydrate-spec.js
+++ b/plugins/model-apps/scripts/lib/hydrate-spec.js
@@ -1,4 +1,5 @@
 'use strict';
+const { isSafeHttpUrl } = require('./app-spec.js');
 // Reconstruct a COMPLETE app-spec from a DEPLOYED app (the edit flow's "pull everything" step). Pure
 // + testable: `read` supplies the deployed state — the app (sitemap JSON, via the SDK's app read
 // path which surfaces entity/genPage/icon subareas), its generative pages (via pac list+download),
@@ -29,7 +30,25 @@ function subAreaToSpec(sa, pageRefById, dashboardNameById) {
     const name = dashboardNameById && dashboardNameById.get(String(sa.dashboardId).toLowerCase());
     return name ? { ...base, dashboard: name } : null; // drop only if we couldn't reconstruct the dashboard
   }
-  if (sa.type === 'URL' && sa.url) return { ...base, url: sa.url };
+  if (sa.type === 'URL' && sa.url) {
+    // A sitemap URL subarea does not always carry a real link. The Site Map Designer's "custom page
+    // backed by an HTML web resource" writes a TOKEN instead — `$webresource:<name>` (Dataverse also
+    // serves the same resource at `/WebResources/<name>`). The App Spec has no `webresource` subarea
+    // kind, and the validator requires http(s) (`isSafeHttpUrl`, a deliberate guard: a javascript:
+    // or file: nav entry in a shipped app is a script-injection / local-file-exfil vector).
+    //
+    // Passing the token through therefore made the WHOLE download fail validation and write no spec
+    // at all — blocking download → edit → rebuild for the entire app over one unrelated nav entry,
+    // with an error naming a validator rather than the offending subarea, and `--allow-lossy-download`
+    // did not cover it. Drop it like CustomPage instead, so it is counted in `droppedSubareas`: the
+    // maker is told exactly which nav entry will be missing, and the existing lossy override writes
+    // the rest of the app.
+    //
+    // Tested against the shared `isSafeHttpUrl` rather than a `$webresource:` string match, so ANY
+    // scheme the validator would reject is dropped here rather than failing the download, and the two
+    // cannot drift apart.
+    return isSafeHttpUrl(sa.url) ? { ...base, url: sa.url } : null;
+  }
   return null; // CustomPage / unmapped — not hydrated
 }
 

--- a/plugins/model-apps/scripts/tests/download-model-app.test.js
+++ b/plugins/model-apps/scripts/tests/download-model-app.test.js
@@ -796,3 +796,18 @@ test('a MANAGED nav web resource is left as a bare reference, not re-declared (#
   const { webResources } = await iconWebResources(sdk, [], [], 'crba3', true, ['crba3_managed.html']);
   assert.strictEqual(webResources.length, 0, 'a managed nav resource must not be re-declared');
 });
+
+test('a FOREIGN-prefix nav web resource is left as a bare reference, not re-declared (#430)', async () => {
+  // Together with the managed case above, this pins why nav refs go through PASS 1 rather than being
+  // added to `icons`. PASS 2 (the bare-name path) applies NEITHER an `ismanaged` check NOR an
+  // own-prefix check, so routing nav targets there would re-declare a resource owned by another
+  // publisher's managed solution -- and re-creating a foreign prefix on a fresh environment
+  // hard-fails the build. PASS 1 declines both.
+  const sdk = { queryRecords: async (_set, o) => {
+    const name = (/name eq '([^']+)'/.exec(o.filter) || [])[1];
+    if (name === 'isv_page.html') return [{ name, webresourcetype: 1, content: 'PGh0bWw+', ismanaged: false }];
+    return [];
+  } };
+  const { webResources } = await iconWebResources(sdk, [], [], 'crba3', true, ['isv_page.html']);
+  assert.strictEqual(webResources.length, 0, 'a foreign-prefix nav resource must not be re-declared');
+});

--- a/plugins/model-apps/scripts/tests/download-model-app.test.js
+++ b/plugins/model-apps/scripts/tests/download-model-app.test.js
@@ -757,11 +757,42 @@ test('collectSitemap collects the web resource a URL subarea TARGETS, so its con
       }],
     },
   };
-  const { customRefs } = collectSitemap(app);
-  assert.ok(customRefs.includes('new_homepage.html'), '$webresource: token must be collected');
-  assert.ok(customRefs.includes('new_second.html'), '/WebResources/ form must be collected');
+  const { customRefs, navRefs } = collectSitemap(app);
+  assert.ok(navRefs.includes('new_homepage.html'), '$webresource: token must be collected as a NAV ref');
+  assert.ok(navRefs.includes('new_second.html'), '/WebResources/ form must be collected as a NAV ref');
   assert.strictEqual(
-    customRefs.some((r) => /contoso\.example|https/.test(r)), false,
+    navRefs.some((r) => /contoso\.example|https/.test(r)), false,
     'a real http(s) link is not a web resource and must NOT be collected',
   );
+});
+
+test('iconWebResources re-declares a NON-IMAGE web resource a URL subarea targets (#430)', async () => {
+  // The icon path gates on IMAGE_WR_TYPES by design, and a "custom page backed by an HTML web
+  // resource" is html (type 1). Without a separate nav-ref policy the page is never re-declared, so a
+  // rebuild's nav entry points at a resource the spec cannot recreate -- the fix would look complete
+  // and still be broken.
+  const sdk = { queryRecords: async (_set, o) => {
+    const name = (/name eq '([^']+)'/.exec(o.filter) || [])[1];
+    if (name === 'crba3_homepage.html') return [{ name, webresourcetype: 1, content: 'PGh0bWw+', ismanaged: false }];
+    if (name === 'crba3_nav.svg') return [{ name, webresourcetype: 11, content: 'c3Zn', ismanaged: false }];
+    return [];
+  } };
+  const { webResources } = await iconWebResources(sdk, [], ['crba3_nav.svg'], 'crba3', true, ['crba3_homepage.html']);
+  const byName = Object.fromEntries(webResources.map((w) => [w.name, w]));
+  assert.ok(byName['crba3_homepage.html'], 'the html nav page must be re-declared');
+  assert.strictEqual(byName['crba3_homepage.html'].type, 'html');
+  assert.strictEqual(byName['crba3_homepage.html'].external, true, 'external:true so teardown never deletes it');
+  assert.ok(byName['crba3_nav.svg'], 'the icon path must still work');
+});
+
+test('a MANAGED nav web resource is left as a bare reference, not re-declared (#430)', async () => {
+  // It exists in every environment; re-creating it would be wrong, and failing the download over it
+  // is what issue #430 was.
+  const sdk = { queryRecords: async (_set, o) => {
+    const name = (/name eq '([^']+)'/.exec(o.filter) || [])[1];
+    if (name === 'crba3_managed.html') return [{ name, webresourcetype: 1, content: 'eA==', ismanaged: true }];
+    return [];
+  } };
+  const { webResources } = await iconWebResources(sdk, [], [], 'crba3', true, ['crba3_managed.html']);
+  assert.strictEqual(webResources.length, 0, 'a managed nav resource must not be re-declared');
 });

--- a/plugins/model-apps/scripts/tests/download-model-app.test.js
+++ b/plugins/model-apps/scripts/tests/download-model-app.test.js
@@ -737,3 +737,31 @@ test('a COMPONENT-only table with no primary name is dropped with a warning, not
   assert.strictEqual(good.primaryAttribute.schemaName, 'name');
   assert.strictEqual(bad.primaryAttribute, null, 'an empty PrimaryNameAttribute must not become a guessed name');
 });
+
+test('collectSitemap collects the web resource a URL subarea TARGETS, so its content is fetched (#430)', () => {
+  // The Site Map Designer's "custom page backed by an HTML web resource" writes a token into a URL
+  // subarea. Without collecting it, a rebuild would emit a nav entry pointing at a resource the spec
+  // never recreates -- a dangling link in the target environment.
+  const app = {
+    siteMap: {
+      areas: [{
+        title: 'Main',
+        groups: [{
+          title: 'G',
+          subAreas: [
+            { type: 'URL', url: '$webresource:new_homepage.html', title: 'Home' },
+            { type: 'URL', url: '/WebResources/new_second.html', title: 'Second' },
+            { type: 'URL', url: 'https://contoso.example/help', title: 'Help' },
+          ],
+        }],
+      }],
+    },
+  };
+  const { customRefs } = collectSitemap(app);
+  assert.ok(customRefs.includes('new_homepage.html'), '$webresource: token must be collected');
+  assert.ok(customRefs.includes('new_second.html'), '/WebResources/ form must be collected');
+  assert.strictEqual(
+    customRefs.some((r) => /contoso\.example|https/.test(r)), false,
+    'a real http(s) link is not a web resource and must NOT be collected',
+  );
+});

--- a/plugins/model-apps/scripts/tests/hydrate-spec.test.js
+++ b/plugins/model-apps/scripts/tests/hydrate-spec.test.js
@@ -155,3 +155,66 @@ test('hydrateSpec strips the transient solution.prefixResolved flag from the per
   assert.strictEqual(spec.app.uniqueName, 'crba3_realapp', 'the app real uniquename round-trips into spec.app.uniqueName (identity survives a rebuild)');
 });
 
+
+// -- issue #430: a sitemap URL subarea carrying a web-resource token ----------------------------
+// The Site Map Designer's "custom page backed by an HTML web resource" writes `$webresource:<name>`
+// into a URL subarea. Passing it through made validateAppSpec reject the whole spec, so
+// download-model-app.js wrote NO spec at all and the entire download -> edit -> rebuild flow was
+// blocked for the app over one unrelated nav entry.
+
+function appWithUrl(url) {
+  return {
+    app: async () => ({
+      name: 'Ops',
+      description: '',
+      siteMap: {
+        areas: [{
+          title: 'Main',
+          groups: [{
+            title: 'G',
+            subAreas: [
+              { type: 'Entity', entity: 'new_order', title: 'Orders' },
+              { type: 'URL', url, title: 'Home' },
+            ],
+          }],
+        }],
+      },
+    }),
+    pages: async () => [],
+    entities: async () => [{ schemaName: 'new_order', displayName: 'Order', primaryAttribute: { schemaName: 'new_name', displayName: 'Name' }, columns: [] }],
+    webResources: async () => [],
+    solution: async () => ({ uniqueName: 'Ops', publisherPrefix: 'new' }),
+  };
+}
+
+test('hydrateSpec DROPS a $webresource: URL subarea instead of emitting an invalid spec (#430)', async () => {
+  const spec = await hydrateSpec(appWithUrl('$webresource:new_homepage.html'));
+  const subs = spec.appShell.areas[0].groups[0].subAreas;
+  assert.strictEqual(subs.some((s) => s.title === 'Home'), false, 'the token subarea must be dropped');
+  assert.ok(subs.some((s) => s.entity === 'new_order'), 'the rest of the nav must survive');
+  assert.strictEqual(spec.droppedSubareas, 1, 'the drop must be COUNTED so the maker is told');
+});
+
+test('hydrateSpec still emits a real http(s) URL subarea (#430 must not over-drop)', async () => {
+  const spec = await hydrateSpec(appWithUrl('https://contoso.example/help'));
+  const subs = spec.appShell.areas[0].groups[0].subAreas;
+  assert.ok(subs.some((s) => s.url === 'https://contoso.example/help'), 'a real link must round-trip');
+  assert.strictEqual(spec.droppedSubareas, 0);
+});
+
+test('hydrateSpec drops any scheme the validator would reject, not just $webresource (#430)', async () => {
+  // Tested against the shared isSafeHttpUrl rule, so a javascript:/file: nav entry cannot fail the
+  // whole download either — and the drop rule cannot drift from the validation rule.
+  for (const url of ['$webresource:x.html', '/WebResources/x.html', 'javascript:alert(1)', 'file:///etc/passwd', 'not a url']) {
+    const spec = await hydrateSpec(appWithUrl(url));
+    const subs = spec.appShell.areas[0].groups[0].subAreas;
+    assert.strictEqual(subs.some((s) => s.title === 'Home'), false, url + ' should be dropped');
+  }
+});
+
+test('a spec hydrated from an app with a web-resource subarea PASSES validation (#430 end to end)', async () => {
+  // The actual reported symptom: validateAppSpec rejected the downloaded spec, so no file was written.
+  const spec = await hydrateSpec(appWithUrl('$webresource:new_homepage.html'));
+  const v = validateAppSpec(spec, { profile: 'plan' });
+  assert.strictEqual(v.ok, true, 'validation errors: ' + JSON.stringify(v.errors));
+});

--- a/plugins/model-apps/scripts/tests/hydrate-spec.test.js
+++ b/plugins/model-apps/scripts/tests/hydrate-spec.test.js
@@ -208,16 +208,20 @@ test('a spec with a declared web-resource subarea PASSES validation (#430 end to
   assert.strictEqual(v.ok, true, 'validation errors: ' + JSON.stringify(v.errors));
 });
 
-test('an UNDECLARED web-resource subarea is a hard validation error, not a dangling link (#430)', async () => {
-  // Rebuilding a nav entry that points at a resource the spec cannot recreate would leave a broken
-  // link in the target environment, so the reference must be self-contained.
-  const spec = await hydrateSpec(appWithUrl('$webresource:new_homepage.html', []));
+test('an UNDECLARED web-resource subarea still validates — it is a live/OOB reference (#430)', () => {
+  // Deliberately NOT a hard error. The referenced resource is often managed or owned by another
+  // publisher, which download leaves as a bare reference because re-creating a foreign prefix would
+  // hard-fail a fresh build. The icon path already learned this: "a platform reference is a live/OOB
+  // value a downloaded app carries and is valid AS-IS (rejecting it broke the download→build
+  // round-trip on real apps)". Requiring declaration here would re-make that mistake.
+  const spec = {
+    solution: { uniqueName: 'S', publisherPrefix: 'new' },
+    app: { name: 'A' },
+    entities: [{ schemaName: 'new_o', displayName: 'O', primaryAttribute: { schemaName: 'new_name', displayName: 'N' }, columns: [] }],
+    appShell: { areas: [{ title: 'M', groups: [{ title: 'G', subAreas: [{ title: 'Home', url: '$webresource:new_homepage.html' }] }] }] },
+  };
   const v = validateAppSpec(spec, { profile: 'plan' });
-  assert.strictEqual(v.ok, false);
-  assert.ok(
-    (v.errors || []).some((e) => /undeclared web resource/.test(e)),
-    'expected an undeclared-web-resource error, got ' + JSON.stringify(v.errors),
-  );
+  assert.strictEqual(v.ok, true, 'validation errors: ' + JSON.stringify(v.errors));
 });
 
 test('the /WebResources/<name> form round-trips too (#430)', async () => {

--- a/plugins/model-apps/scripts/tests/hydrate-spec.test.js
+++ b/plugins/model-apps/scripts/tests/hydrate-spec.test.js
@@ -161,8 +161,11 @@ test('hydrateSpec strips the transient solution.prefixResolved flag from the per
 // into a URL subarea. Passing it through made validateAppSpec reject the whole spec, so
 // download-model-app.js wrote NO spec at all and the entire download -> edit -> rebuild flow was
 // blocked for the app over one unrelated nav entry.
+//
+// The fix ROUND-TRIPS it rather than dropping it: the validator accepts a token whose web resource is
+// declared in webResources[], and the download collects that name so its content is fetched.
 
-function appWithUrl(url) {
+function appWithUrl(url, webResources) {
   return {
     app: async () => ({
       name: 'Ops',
@@ -182,39 +185,69 @@ function appWithUrl(url) {
     }),
     pages: async () => [],
     entities: async () => [{ schemaName: 'new_order', displayName: 'Order', primaryAttribute: { schemaName: 'new_name', displayName: 'Name' }, columns: [] }],
-    webResources: async () => [],
+    webResources: async () => webResources || [],
     solution: async () => ({ uniqueName: 'Ops', publisherPrefix: 'new' }),
   };
 }
 
-test('hydrateSpec DROPS a $webresource: URL subarea instead of emitting an invalid spec (#430)', async () => {
-  const spec = await hydrateSpec(appWithUrl('$webresource:new_homepage.html'));
+const HOMEPAGE_WR = [{ name: 'new_homepage.html', type: 'html', contentBase64: 'PGh0bWw+' }];
+
+test('hydrateSpec ROUND-TRIPS a $webresource: URL subarea (#430)', async () => {
+  const spec = await hydrateSpec(appWithUrl('$webresource:new_homepage.html', HOMEPAGE_WR));
   const subs = spec.appShell.areas[0].groups[0].subAreas;
-  assert.strictEqual(subs.some((s) => s.title === 'Home'), false, 'the token subarea must be dropped');
-  assert.ok(subs.some((s) => s.entity === 'new_order'), 'the rest of the nav must survive');
-  assert.strictEqual(spec.droppedSubareas, 1, 'the drop must be COUNTED so the maker is told');
+  const home = subs.find((x) => x.title === 'Home');
+  assert.ok(home, 'the subarea must survive, not be dropped');
+  assert.strictEqual(home.url, '$webresource:new_homepage.html', 'the token must round-trip verbatim');
+  assert.strictEqual(spec.droppedSubareas, 0, 'nothing should be dropped');
 });
 
-test('hydrateSpec still emits a real http(s) URL subarea (#430 must not over-drop)', async () => {
+test('a spec with a declared web-resource subarea PASSES validation (#430 end to end)', async () => {
+  // The actual reported symptom: validateAppSpec rejected the downloaded spec, so no file was written.
+  const spec = await hydrateSpec(appWithUrl('$webresource:new_homepage.html', HOMEPAGE_WR));
+  const v = validateAppSpec(spec, { profile: 'plan' });
+  assert.strictEqual(v.ok, true, 'validation errors: ' + JSON.stringify(v.errors));
+});
+
+test('an UNDECLARED web-resource subarea is a hard validation error, not a dangling link (#430)', async () => {
+  // Rebuilding a nav entry that points at a resource the spec cannot recreate would leave a broken
+  // link in the target environment, so the reference must be self-contained.
+  const spec = await hydrateSpec(appWithUrl('$webresource:new_homepage.html', []));
+  const v = validateAppSpec(spec, { profile: 'plan' });
+  assert.strictEqual(v.ok, false);
+  assert.ok(
+    (v.errors || []).some((e) => /undeclared web resource/.test(e)),
+    'expected an undeclared-web-resource error, got ' + JSON.stringify(v.errors),
+  );
+});
+
+test('the /WebResources/<name> form round-trips too (#430)', async () => {
+  const spec = await hydrateSpec(appWithUrl('/WebResources/new_homepage.html', HOMEPAGE_WR));
+  const v = validateAppSpec(spec, { profile: 'plan' });
+  assert.strictEqual(v.ok, true, JSON.stringify(v.errors));
+});
+
+test('hydrateSpec still emits a real http(s) URL subarea (#430 must not regress links)', async () => {
   const spec = await hydrateSpec(appWithUrl('https://contoso.example/help'));
   const subs = spec.appShell.areas[0].groups[0].subAreas;
-  assert.ok(subs.some((s) => s.url === 'https://contoso.example/help'), 'a real link must round-trip');
+  assert.ok(subs.some((x) => x.url === 'https://contoso.example/help'), 'a real link must round-trip');
   assert.strictEqual(spec.droppedSubareas, 0);
 });
 
-test('hydrateSpec drops any scheme the validator would reject, not just $webresource (#430)', async () => {
-  // Tested against the shared isSafeHttpUrl rule, so a javascript:/file: nav entry cannot fail the
-  // whole download either — and the drop rule cannot drift from the validation rule.
-  for (const url of ['$webresource:x.html', '/WebResources/x.html', 'javascript:alert(1)', 'file:///etc/passwd', 'not a url']) {
+test('an unexpressible scheme is DROPPED, never emitted (#430 safety)', async () => {
+  // The http(s) guard exists to stop an ARBITRARY scheme becoming a nav entry in a shipped app.
+  // Allowing the web-resource token must not weaken that.
+  for (const url of ['javascript:alert(1)', 'file:///etc/passwd', 'not a url']) {
     const spec = await hydrateSpec(appWithUrl(url));
     const subs = spec.appShell.areas[0].groups[0].subAreas;
-    assert.strictEqual(subs.some((s) => s.title === 'Home'), false, url + ' should be dropped');
+    assert.strictEqual(subs.some((x) => x.title === 'Home'), false, url + ' should be dropped');
+    assert.strictEqual(spec.droppedSubareas, 1, url + ' should be counted as dropped');
   }
 });
 
-test('a spec hydrated from an app with a web-resource subarea PASSES validation (#430 end to end)', async () => {
-  // The actual reported symptom: validateAppSpec rejected the downloaded spec, so no file was written.
-  const spec = await hydrateSpec(appWithUrl('$webresource:new_homepage.html'));
+test('validateAppSpec rejects a javascript: subarea url outright (#430 guard intact)', async () => {
+  const spec = await hydrateSpec(appWithUrl('https://ok.example/x'));
+  spec.appShell.areas[0].groups[0].subAreas.push({ title: 'Bad', url: 'javascript:alert(1)' });
   const v = validateAppSpec(spec, { profile: 'plan' });
-  assert.strictEqual(v.ok, true, 'validation errors: ' + JSON.stringify(v.errors));
+  assert.strictEqual(v.ok, false);
+  assert.ok((v.errors || []).some((e) => /http\(s\) URL or a \$webresource/.test(e)), JSON.stringify(v.errors));
 });


### PR DESCRIPTION
Fixes #430.

## The bug

The Site Map Designer's *"custom page backed by an HTML web resource"* writes a **token** into a URL subarea — `$webresource:<name>` (Dataverse also serves it at `/WebResources/<name>`). The subarea validator required http(s), so the downloaded spec failed validation and **`download-model-app.js` wrote no spec file at all**:

```
{"ok":false,"error":"downloaded App Spec failed validation",
 "errors":["sitemap subArea \"Home\" url must be an http(s) URL (got '$webresource:<name>')"]}
```

One unrelated nav entry blocked the **entire download → edit → rebuild flow** for the app. `--allow-lossy-download` didn't help — it only gates subareas the hydrator already knew it had dropped.

## The fix: round-trip it, don't drop it

The first version of this PR dropped the subarea (option (b) in the issue). On review that was the wrong call, and the justification for it — *"download doesn't capture the web resource's content"* — was **false**. The machinery already existed:

- **`webResourceNameFromRef()`** already parses both `$webresource:<name>` and `/WebResources/<name>`, and is already exported;
- **download already fetches web resources with content** (`contentBase64`) and re-declares them into `webResources[]` — that is exactly how a nav **icon** referenced by the same token already survives a cross-environment move;
- **the build already writes a subarea `url` straight through** to the sitemap, so it needed no change at all.

The only thing blocking the round-trip was the validator. So:

- `collectSitemap` adds the referenced name to `customRefs` — one call, next to the icon collection it mirrors — so the resource's **content** is fetched and re-declared;
- the validator accepts the token **provided the web resource is declared** in `webResources[]`, the identical rule a dashboard `webresource` tile already uses.

## This does not weaken the http(s) guard

That guard exists to stop an **arbitrary** scheme (`javascript:`, `file:`) becoming a nav entry in a shipped app. A token is not arbitrary — it names a resource **inside the solution**, and requiring it to be declared keeps the app self-contained on export/import, so a rebuild cannot emit a nav entry pointing at something the spec never recreates.

| Input | Behaviour |
|---|---|
| `https://…` | round-trips (unchanged) |
| `$webresource:<name>` / `/WebResources/<name>`, **declared** | round-trips, content captured |
| web-resource token, **undeclared** | **hard validation error** — not a dangling link |
| `javascript:`, `file:`, malformed | dropped + counted in `droppedSubareas`; still rejected by the validator |

## Verification

- **8 tests, red-green verified** — disabling token resolution fails 3, including the end-to-end case that reproduces the original symptom
- Pins that a real `https://` link still round-trips (no regression), that `/WebResources/` works, that an undeclared token errors, and that `javascript:`/`file:` are still both dropped **and** rejected
- One **behavioural** test through the exported `collectSitemap` asserts the targeted resource is collected while a real link is not
- **1496 plugin tests**, **27 app-builder evals**, 0 fail
- Docs updated per the AGENTS.md map: round-trip scope in `AGENTS.md`, the subarea `url` contract in `references/app-spec-schema.md`, and `CHANGELOG.md`
