### PR TITLE
fix(model-apps): keep a hand-pinned languageCode across a download (#456)

### DIFF
--- a/plugins/model-apps/CHANGELOG.md
+++ b/plugins/model-apps/CHANGELOG.md
@@ -54,6 +54,15 @@ smoke-eval assertion that could never pass live.
   GitHub Copilot CLI or Claude Code host when a newer version is available.
 
 ### Fixed
+- **A hand-pinned `languageCode` is no longer lost on download**
+  ([#456](https://github.com/microsoft/power-platform-skills/issues/456)). Download
+  still never reads the LCID from Dataverse — copying the source org's language into a
+  portable spec is how it starts failing in an org that lacks that language — but a value
+  the author wrote is now carried over from the previous `app-spec.json` at that path.
+  Losing it was quiet and costly: the next build resolved the org default, so newly
+  created columns got one language while the ones from the pinned build kept another,
+  with no error anywhere.
+
 - **A sitemap subarea that targets a custom web resource now round-trips**
   ([#430](https://github.com/microsoft/power-platform-skills/issues/430)).
   The Site Map Designer writes `$webresource:<name>` into a URL subarea; the http(s)

--- a/plugins/model-apps/references/app-spec-schema.md
+++ b/plugins/model-apps/references/app-spec-schema.md
@@ -85,10 +85,13 @@ sample data (incl. multi-parent junction links + status reasons), and publish.
   Must be a positive integer LCID up to 65535 — `1031`, not `"de-DE"` and not `true`. An invalid
   value is rejected by validation, and a caller that bypasses validation gets a warning naming the
   discarded value rather than a silent fall-through.
-  **Not emitted by `download-model-app.js`**, and that is deliberate: an LCID copied out of the
-  source org would be re-applied verbatim when the spec is rebuilt somewhere else, which is exactly
-  how a spec starts failing in an org that lacks that language. Leaving it absent lets every target
-  org resolve its own base language. If you pinned one by hand, re-add it after a download.
+  **Emitted by `download-model-app.js` only if you pinned it yourself.** It is deliberately never
+  read from Dataverse: an LCID copied out of the source org would be re-applied verbatim when the
+  spec is rebuilt somewhere else, which is exactly how a spec starts failing in an org that lacks
+  that language. Leaving it absent lets every target org resolve its own base language. But a value
+  **you** wrote is carried across a download from the previous `app-spec.json` at that path, so a
+  pin is not silently lost — losing it would leave newly created columns in the org default while
+  the existing ones keep the pinned language, with no error anywhere.
 
 ## entities[]
 ```jsonc

--- a/plugins/model-apps/scripts/download-model-app.js
+++ b/plugins/model-apps/scripts/download-model-app.js
@@ -17,7 +17,7 @@ const { parseManifestBase64, manifestResourceName, reconcilePageIds } = require(
 const { reverseResolveNavIds } = require('./lib/pageref-resolver.js');
 const { fetchSitemap, sitemapGenPages } = require('./lib/sitemap-pages.js');
 const { isRestrictedSolution } = require('./lib/system-solutions.js');
-const { isPlatformIconRef, webResourceNameFromRef, validateAppSpec } = require('./lib/app-spec.js');
+const { isPlatformIconRef, webResourceNameFromRef, validateAppSpec, normalizeLanguageCode } = require('./lib/app-spec.js');
 
 // webresourcetype (int) -> app-spec web-resource type.
 const WR_TYPE = { 1: 'html', 2: 'css', 3: 'js', 4: 'xml', 5: 'png', 6: 'jpg', 7: 'gif', 8: 'xap', 9: 'xsl', 10: 'ico', 11: 'svg', 12: 'resx' };
@@ -809,12 +809,42 @@ async function main() {
     return;
   }
   const specPath = path.join(outDir, 'app-spec.json');
+  preserveAuthoredLanguageCode(spec, specPath);
   fs.writeFileSync(specPath, JSON.stringify(spec, null, 2));
   emitResult(true, { ok: true, spec: specPath, pages: pages.length, entities: entities.length, webResources: webResources.length, droppedSubareas });
+}
+
+// Carry an AUTHOR-PINNED `languageCode` across a download, and only from the spec already on disk.
+//
+// Download deliberately does not read `languageCode` from Dataverse. An LCID copied out of the source
+// org would be re-applied verbatim when the spec is rebuilt somewhere else, which is exactly how a
+// spec starts failing in an org that has not provisioned that language (#447) — leaving it absent lets
+// every target org resolve its own base language, which is the right default.
+//
+// But silently dropping a value the author WROTE is its own bug, and a quiet one: the next build
+// resolves the org default, so newly created columns get one language while the ones from the pinned
+// build keep another. A mixed-language app, no error anywhere. So the value is restored from the
+// previous spec at this path — the author's own file — and never synthesized from the environment.
+//
+// Best-effort by design: a missing, unreadable or malformed previous spec just means there is nothing
+// to preserve. Failing the download over it would be worse than the wart this fixes.
+// Exported for tests.
+function preserveAuthoredLanguageCode(spec, specPath, deps = {}) {
+  const readFileSync = deps.readFileSync || fs.readFileSync;
+  const existsSync = deps.existsSync || fs.existsSync;
+  if (!spec || spec.languageCode !== undefined) return spec;
+  try {
+    if (!existsSync(specPath)) return spec;
+    const prior = JSON.parse(readFileSync(specPath, 'utf8'));
+    // Only a value that would itself pass validation is worth restoring; carrying a broken one
+    // forward would fail the next build for a reason the operator did not cause on this run.
+    if (prior && normalizeLanguageCode(prior.languageCode) !== null) spec.languageCode = prior.languageCode;
+  } catch { /* no previous spec, or not parseable — nothing to preserve */ }
+  return spec;
 }
 
 if (require.main === module) {
   main().catch((err) => emitResult(false, err));
 }
 
-module.exports = { resolveAppId, collectSitemap, appComponentEntities, parseDownloadedPages, assignPageKeys, missingDownloads, entityFromMetadata, iconWebResources, readDashboards, droppedSubareaCount, recoverAppSolution, runDownload };
+module.exports = { resolveAppId, collectSitemap, appComponentEntities, parseDownloadedPages, assignPageKeys, missingDownloads, entityFromMetadata, iconWebResources, readDashboards, droppedSubareaCount, recoverAppSolution, runDownload, preserveAuthoredLanguageCode };

--- a/plugins/model-apps/scripts/tests/download-model-app.test.js
+++ b/plugins/model-apps/scripts/tests/download-model-app.test.js
@@ -4,7 +4,7 @@ const assert = require('node:assert');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
-const { resolveAppId, collectSitemap, parseDownloadedPages, entityFromMetadata, iconWebResources, readDashboards, droppedSubareaCount } = require('../download-model-app.js');
+const { resolveAppId, collectSitemap, parseDownloadedPages, entityFromMetadata, iconWebResources, readDashboards, droppedSubareaCount, preserveAuthoredLanguageCode } = require('../download-model-app.js');
 
 test('resolveAppId returns a guid as-is, else resolves by uniquename', async () => {
   const guid = '11111111-2222-3333-4444-555555555555';
@@ -810,4 +810,49 @@ test('a FOREIGN-prefix nav web resource is left as a bare reference, not re-decl
   } };
   const { webResources } = await iconWebResources(sdk, [], [], 'crba3', true, ['isv_page.html']);
   assert.strictEqual(webResources.length, 0, 'a foreign-prefix nav resource must not be re-declared');
+});
+
+// #456: download does NOT read languageCode from Dataverse, and that is deliberate — an LCID copied
+// out of the source org would be re-applied verbatim when the spec is rebuilt elsewhere, which is how
+// a spec starts failing in an org that lacks that language (#447). But dropping a value the AUTHOR
+// wrote is its own bug, and a silent one: the next build resolves the org default, so new columns get
+// one language while the pinned ones keep another. Mixed-language app, no error.
+test('a hand-pinned languageCode survives a download (#456)', () => {
+  const spec = { app: { name: 'A' }, entities: [] };
+  const prior = JSON.stringify({ app: { name: 'A' }, languageCode: 1031 });
+  const deps = { existsSync: () => true, readFileSync: () => prior };
+  preserveAuthoredLanguageCode(spec, 'app-spec.json', deps);
+  assert.strictEqual(spec.languageCode, 1031, 'the author-pinned LCID is restored');
+});
+
+test('preserving never invents a languageCode where the author had none', () => {
+  const spec = { app: { name: 'A' }, entities: [] };
+  const deps = { existsSync: () => true, readFileSync: () => JSON.stringify({ app: { name: 'A' } }) };
+  preserveAuthoredLanguageCode(spec, 'app-spec.json', deps);
+  assert.strictEqual(spec.languageCode, undefined, 'no previous value means the field stays absent');
+
+  // A first-ever download has no previous spec at all.
+  const fresh = { app: { name: 'A' }, entities: [] };
+  preserveAuthoredLanguageCode(fresh, 'app-spec.json', { existsSync: () => false, readFileSync: () => { throw new Error('nope'); } });
+  assert.strictEqual(fresh.languageCode, undefined);
+});
+
+test('a downloaded languageCode is never overwritten by the previous file', () => {
+  // Defensive: if a future download ever DOES emit one, the live value wins over the stale file.
+  const spec = { app: { name: 'A' }, languageCode: 1036 };
+  const deps = { existsSync: () => true, readFileSync: () => JSON.stringify({ languageCode: 1031 }) };
+  preserveAuthoredLanguageCode(spec, 'app-spec.json', deps);
+  assert.strictEqual(spec.languageCode, 1036);
+});
+
+test('a corrupt or invalid previous spec is ignored rather than failing the download', () => {
+  for (const prior of ['{ not json', JSON.stringify({ languageCode: 'de-DE' }), JSON.stringify({ languageCode: true }), JSON.stringify({ languageCode: 0 }), JSON.stringify({ languageCode: 99999 })]) {
+    const spec = { app: { name: 'A' } };
+    preserveAuthoredLanguageCode(spec, 'app-spec.json', { existsSync: () => true, readFileSync: () => prior });
+    assert.strictEqual(spec.languageCode, undefined, 'must not carry forward ' + prior.slice(0, 30));
+  }
+  // A read that throws must not escape either.
+  const spec = { app: { name: 'A' } };
+  assert.doesNotThrow(() => preserveAuthoredLanguageCode(spec, 'x', { existsSync: () => true, readFileSync: () => { throw new Error('EACCES'); } }));
+  assert.strictEqual(spec.languageCode, undefined);
 });


### PR DESCRIPTION
Fixes item 2 of #456 — a hand-pinned `languageCode` was silently lost on download.

## The bug

Download deliberately does **not** read `languageCode` from Dataverse, and this PR keeps that: an LCID copied out of the source org would be re-applied verbatim when the spec is rebuilt somewhere else, which is exactly how a spec starts failing in an org that has not provisioned that language (#447). Leaving it absent lets every target org resolve its own base language.

But silently dropping a value the *author* wrote is its own bug, and a quiet one. The next build resolves the org default, so columns created from then on get one language while the ones from the pinned build keep another — **a mixed-language app with no error anywhere** to explain it.

## The fix

`preserveAuthoredLanguageCode` restores the value from the **previous `app-spec.json` at the output path** — the author's own file — and never synthesizes it from the environment. That keeps the portability property (a spec carries no org-specific LCID unless someone chose one) while making a deliberate pin survive a round trip.

Best-effort by design: a missing, unreadable or malformed previous spec simply means there is nothing to preserve, and an invalid value is not carried forward — failing the next build for something the operator did not do on this run would be worse than the wart being fixed.

## Why it was deferred, and why the obvious fix is wrong

This was left out of the original #447 work with the reasoning recorded on #456. The obvious fix — have download emit the org's LCID like any other discovered value — is **actively harmful**: it makes every downloaded spec org-specific and reintroduces #447 the moment that spec is built anywhere else.

## Verification

Tests +4, **red-green verified** (removing the restore turns the pin test red):

| case | behaviour |
|---|---|
| author pinned `1031` | restored |
| author pinned nothing | stays absent — never invented |
| first-ever download (no previous spec) | stays absent |
| a live value already present | wins over the stale file |
| corrupt JSON / `"de-DE"` / `true` / `0` / `99999` / read throws | ignored, download still succeeds |

**1523 plugin + 159 eval tests pass; 7 validators green.**

Docs updated: `references/app-spec-schema.md` previously told the reader to "re-add it after a download", which is no longer necessary.

## Note

Branched from `main`, so it is independent of #458 and either can merge first.
