### PR TITLE
Prefer scoped pickers for media and document access

### DIFF
--- a/plugins/mobile-apps/agents/native-app-planner.md
+++ b/plugins/mobile-apps/agents/native-app-planner.md
@@ -182,12 +182,13 @@ Map each shipped module to a user-facing capability slug. Use this known mapping
 | `biometrics` / `local-authentication` | `expo-local-authentication` | `/add-native biometrics` |
 | `clipboard` | `expo-clipboard` | `/add-native clipboard` |
 | `mail-composer` / `email-draft` | `expo-mail-composer` | `/add-native mail-composer` |
-| `media-library` | `expo-media-library` | `/add-native media-library` |
 | `audio` | `expo-audio` | `/add-native audio` |
 | `video` | `expo-video` | `/add-native video` |
 | `sensors` | `expo-sensors` | `/add-native sensors` |
 | `screen-orientation` | `expo-screen-orientation` | `/add-native screen-orientation` |
 | `date-time-picker` | `@react-native-community/datetimepicker` | screen-builder form component rule |
+
+For user-selected photos and videos, plan `image-picker`; for documents and other files, plan `document-picker`. Do not plan broad media-library access when a system picker satisfies the workflow.
 
 Do not propose `native-pdf-viewer` or `pen-input` unless the exact extension package is present in the template allowlist output (`@microsoft/power-apps-native-pdf-viewer` and `@microsoft/power-apps-native-pen-input`). Do not propose `geolocation` unless `@microsoft/power-apps-native-bglocation` is present, and only for continuous/background tracking or durable Dataverse upload — use one-shot `location` (`expo-location`) for a single foreground coordinate read. When proposing `geolocation`, record that its Dataverse target table must already exist and must be verified by `/add-native geolocation` (default entity set `msdyn_locationrecords`, or a custom `tableName` whose `fieldMap` columns exist). Do not propose `pdf-report` unless `expo-print` is present. Do not propose local sharing for generated PDFs unless `expo-sharing` is present. If neither package path is present, drop the PDF capability and add a transparency note.
 

--- a/plugins/mobile-apps/agents/native-app-planner.md
+++ b/plugins/mobile-apps/agents/native-app-planner.md
@@ -170,7 +170,7 @@ Map each shipped module to a user-facing capability slug. Use this known mapping
 |---|---|---|
 | `camera` | `expo-camera` | `/add-native camera` |
 | `image-picker` | `expo-image-picker` | `/add-native image-picker` |
-| `document-picker` | `expo-document-picker` | — |
+| `document-picker` | `expo-document-picker` | `/add-native document-picker` |
 | `pdf-report` | `expo-print` (+ `expo-sharing` when local share is needed and present) | `/add-native pdf-report` |
 | `native-pdf-viewer` | `@microsoft/power-apps-native-pdf-viewer` | `/add-native pdf-viewer` |
 | `pen-input` | `@microsoft/power-apps-native-pen-input` | `/add-native pen-input` |
@@ -188,7 +188,7 @@ Map each shipped module to a user-facing capability slug. Use this known mapping
 | `screen-orientation` | `expo-screen-orientation` | `/add-native screen-orientation` |
 | `date-time-picker` | `@react-native-community/datetimepicker` | screen-builder form component rule |
 
-For user-selected photos and videos, plan `image-picker`; for documents and other files, plan `document-picker`. Do not plan broad media-library access when a system picker satisfies the workflow.
+For custom workflows outside Dataverse File/Image form fields, plan `image-picker` with `/add-native image-picker` for user-selected photos and videos, or `document-picker` with `/add-native document-picker` for documents and other files. For Dataverse-bound File/Image fields, plan host `<FilePicker>` / `<ImagePicker>` controls instead. Do not plan broad media-library access when either scoped picker path satisfies the workflow.
 
 Do not propose `native-pdf-viewer` or `pen-input` unless the exact extension package is present in the template allowlist output (`@microsoft/power-apps-native-pdf-viewer` and `@microsoft/power-apps-native-pen-input`). Do not propose `geolocation` unless `@microsoft/power-apps-native-bglocation` is present, and only for continuous/background tracking or durable Dataverse upload — use one-shot `location` (`expo-location`) for a single foreground coordinate read. When proposing `geolocation`, record that its Dataverse target table must already exist and must be verified by `/add-native geolocation` (default entity set `msdyn_locationrecords`, or a custom `tableName` whose `fieldMap` columns exist). Do not propose `pdf-report` unless `expo-print` is present. Do not propose local sharing for generated PDFs unless `expo-sharing` is present. If neither package path is present, drop the PDF capability and add a transparency note.
 

--- a/plugins/mobile-apps/skills/add-native/SKILL.md
+++ b/plugins/mobile-apps/skills/add-native/SKILL.md
@@ -148,7 +148,7 @@ Apply the Native capability gate above. This table is a known capability-to-pack
 | `device-info` | `expo-device` / `expo-application` / `expo-cellular` | `src/native/deviceInfo.ts` | Read-only device/app/cellular metadata wrappers |
 | `date-time-picker` | `@react-native-community/datetimepicker` | screen-level component usage | Use directly in form screens per screen-builder rules; no `/add-native` wrapper required |
 
-For user-selected photos and videos, use `expo-image-picker`; for documents and other files, use `expo-document-picker`. These system-picker flows keep access scoped to the items the user selects and avoid broad photo/video library permissions.
+For custom workflows outside Dataverse File/Image form fields, use the `image-picker` capability via `/add-native image-picker` for user-selected photos and videos, or the `document-picker` capability via `/add-native document-picker` for documents and other files. These wrappers use scoped system-picker flows. Dataverse File/Image form fields remain the exception: use host `<FilePicker>` / `<ImagePicker>` controls as described above, not `/add-native` wrappers or raw Expo module imports.
 
 ### PDF / pen routing rules
 

--- a/plugins/mobile-apps/skills/add-native/SKILL.md
+++ b/plugins/mobile-apps/skills/add-native/SKILL.md
@@ -141,13 +141,14 @@ Apply the Native capability gate above. This table is a known capability-to-pack
 | `biometrics`, `local-authentication` | `expo-local-authentication` | `src/native/biometrics.ts` | Use only when the current template package contains `expo-local-authentication` |
 | `clipboard` | `expo-clipboard` | `src/native/clipboard.ts` | Use only when the current template package contains `expo-clipboard` |
 | `mail-composer`, `email-draft` | `expo-mail-composer` | `src/native/mailComposer.ts` | Opens native mail compose when the package is present; connectors still own server-side email sends |
-| `media-library` | `expo-media-library` | `src/native/mediaLibrary.ts` | Use for device media-library access only when package is present |
 | `audio` | `expo-audio` | `src/native/audio.ts` | Use for audio recording/playback only when package is present |
 | `video` | `expo-video` | `src/native/video.ts` | Use for video playback only when package is present |
 | `sensors` | `expo-sensors` | `src/native/sensors.ts` | Use only for sensor APIs exposed by the installed package |
 | `screen-orientation` | `expo-screen-orientation` | `src/native/screenOrientation.ts` | Use only when package is present; do not edit native config |
 | `device-info` | `expo-device` / `expo-application` / `expo-cellular` | `src/native/deviceInfo.ts` | Read-only device/app/cellular metadata wrappers |
 | `date-time-picker` | `@react-native-community/datetimepicker` | screen-level component usage | Use directly in form screens per screen-builder rules; no `/add-native` wrapper required |
+
+For user-selected photos and videos, use `expo-image-picker`; for documents and other files, use `expo-document-picker`. These system-picker flows keep access scoped to the items the user selects and avoid broad photo/video library permissions.
 
 ### PDF / pen routing rules
 

--- a/plugins/mobile-apps/template/package.json
+++ b/plugins/mobile-apps/template/package.json
@@ -56,7 +56,6 @@
     "expo-local-authentication": "55.0.13",
     "expo-location": "55.1.9",
     "expo-mail-composer": "55.0.13",
-    "expo-media-library": "55.0.16",
     "expo-modules-core": "55.0.25",
     "expo-print": "55.0.14",
     "expo-router": "55.0.14",


### PR DESCRIPTION
Related PR: https://microsoft.ghe.com/bic/pa-wrap-tools/pull/254

**Summary**
- Remove `expo-media-library` from the mobile app template.
- Remove media-library capability guidance from native planning.
- Prefer `expo-image-picker` for photos/videos and `expo-document-picker` for files.
- Avoid broad photo/video permissions in accordance with Google Play policy.

**Validation**
- Confirmed no remaining `expo-media-library` references.
- Validated `package.json` and whitespace checks.