### PR TITLE
fix(canvas-apps): recover from stale coauthoring sessions

### DIFF
--- a/plugins/canvas-apps/AGENTS.md
+++ b/plugins/canvas-apps/AGENTS.md
@@ -98,9 +98,15 @@ package, not here — the only recovery lever in this repo is skill instructions
 - **Detection signal:** the literal `Invalid session state` text with a 401. A generic
   401/403 without it stays an authentication problem (`force_account_select`, `login_hint`,
   `auth_flow`) — not an expired session.
-- **Recovery (orchestrator-only, agent instruction):** one `connect` reusing the earlier
-  parameters, then one retry of the failed operation. No loop, no repeated connect/retry, no
-  planner/builder re-dispatch. Builders never call `connect`.
+- **Recovery (orchestrator decides, agent instruction):** one `connect` reusing the earlier
+  parameters, then one retry of the failed operation. If the 401 surfaced inside the
+  planner (it calls discovery tools and compiles `App.pa.yaml` during CREATE, has no
+  `connect` tool, and returns `Session: stale` in its handoff), the orchestrator reconnects
+  once and then either re-compiles the written `App.pa.yaml` itself or re-dispatches that
+  one planner invocation once. At most one
+  `connect` and one retry / re-dispatch per failure — no loop, no repeated connect/retry,
+  no builder re-dispatch, no reconnect from inside a sub-agent. Builders never call
+  `connect`.
 - **Manual fallback if that fails:** reload Studio → reconnect MCP (`/configure-canvas-mcp`
   or `connect`) → re-run `compile_canvas`. Local `.pa.yaml` files are not lost.
 

--- a/plugins/canvas-apps/AGENTS.md
+++ b/plugins/canvas-apps/AGENTS.md
@@ -85,6 +85,28 @@ The `canvas-authoring` MCP server exposes the following tools:
 | `list_data_sources` | Lists all available data sources in the current authoring session |
 | `sync_canvas` | Syncs the current coauthoring session state from the server to a local directory, writing all YAML files |
 
+## Session Lifecycle & Recovery
+
+The MCP server holds one coauthoring session (`connect`), bound to the Studio browser tab.
+Session handling lives in the external `Microsoft.PowerApps.CanvasAuthoring.McpServer`
+package, not here — the only recovery lever in this repo is skill instructions.
+
+- **Observed failure (reported, not a guaranteed lifetime):** after roughly 25–30 minutes a
+  long-lived session goes stale — Studio shows a grey loading screen and
+  `compile_canvas` / `sync_canvas` return `HTTP 401 Unauthorized: Invalid session state` on
+  every call.
+- **Detection signal:** the literal `Invalid session state` text with a 401. A generic
+  401/403 without it stays an authentication problem (`force_account_select`, `login_hint`,
+  `auth_flow`) — not an expired session.
+- **Recovery (orchestrator-only, agent instruction):** one `connect` reusing the earlier
+  parameters, then one retry of the failed operation. No loop, no repeated connect/retry, no
+  planner/builder re-dispatch. Builders never call `connect`.
+- **Manual fallback if that fails:** reload Studio → reconnect MCP (`/configure-canvas-mcp`
+  or `connect`) → re-run `compile_canvas`. Local `.pa.yaml` files are not lost.
+
+Full instructions: `references/ValidationWorkflow.md`, `skills/canvas-app/SKILL.md`
+(Shared Invariant 12), `skills/configure-canvas-mcp/SKILL.md`.
+
 ## Hooks
 
 Both hosts inject a reminder to call `sync_canvas` before acting, so the agent never edits stale

--- a/plugins/canvas-apps/README.md
+++ b/plugins/canvas-apps/README.md
@@ -168,13 +168,14 @@ For more information, see:
 | **Sign-in fails or uses the wrong account** | Retry the connection and choose the correct organizational account. If your host offers connection options, select browser sign-in or provide the account email as a login hint. |
 | **Access is denied or coauthoring is unavailable** | Confirm that your account can edit the app. Ask your Power Platform administrator whether coauthoring is enabled for the app and environment, and whether organizational policies block third-party MCP servers. |
 | **The connection stops working** | The Power Apps Studio session may have expired. Reopen the app, keep its Studio tab open, and run `configure-canvas-mcp` again. |
+| **Studio goes to a grey loading screen and `compile_canvas` returns `401 Invalid session state`** | A long-lived coauthoring session has been reported to become invalid after roughly 25–30 minutes (an observed pattern, not a guaranteed service limit). The agent attempts one automatic reconnect and retry. If that does not recover it: reload the Power Apps Studio browser tab and let the app finish loading (this creates a fresh authoring session), run `configure-canvas-mcp` again if the tools report no session, then re-run `compile_canvas` to push your local `.pa.yaml` files. Your local files are not lost. |
 
 ### App authoring
 
 | Problem | What to do |
 |---------|------------|
 | **Controls, connectors, or data sources are missing** | Confirm that the MCP server is connected to the intended app and environment. Add required connectors and data sources through the **Data** panel in Power Apps Studio, then ask your agent to list them again. Organizational data policies may restrict what is available. |
-| **Changes are not visible in Power Apps Studio** | Confirm that the original Studio tab is open and signed in, and check whether the agent reported a validation or compilation error. If the Studio session expired, reopen the app and reconnect before retrying. |
+| **Changes are not visible in Power Apps Studio** | Confirm that the original Studio tab is open and signed in, and check whether the agent reported a validation or compilation error. If the Studio session expired (grey loading screen, or `401 Invalid session state` from `compile_canvas`), reload the Studio tab, reconnect, and re-run `compile_canvas` before retrying. |
 
 ## Support
 

--- a/plugins/canvas-apps/agents/canvas-app-planner.md
+++ b/plugins/canvas-apps/agents/canvas-app-planner.md
@@ -308,7 +308,10 @@ write any plan artifact. You are the only agent that knows the collection schema
 this is the cheapest point in the whole workflow to catch a bad field name. Ignore
 diagnostics from screen files — they are not written yet.
 
-Report the resulting `App.pa.yaml` compile status in your handoff.
+Report the resulting `App.pa.yaml` compile status in your handoff. If `compile_canvas`
+returns `HTTP 401 Unauthorized: Invalid session state` instead of diagnostics, stop here —
+it is not a diagnostic you can fix and you have no `connect` tool — and return the handoff
+with `Session: stale` (see "Return the Handoff" and Constraints).
 
 ### EDIT
 
@@ -438,7 +441,16 @@ Shared plan: `[working directory]/canvas-app-shared.md`
 App file: [`[working directory]/App.pa.yaml` for CREATE, "unchanged" for EDIT]
 App compile: [Clean / diagnostics remaining, with detail]
 Functional scenarios: [N total; all assigned to screen briefs / defects]
+Session: stale
 ```
+
+Include the `Session:` line **only** when a `canvas-authoring` MCP call in this run failed
+with `HTTP 401 Unauthorized: Invalid session state` — the literal `Invalid session state`
+text together with a 401. Its only value is `stale`, and it tells the orchestrator the
+coauthoring session expired mid-plan so it can run its one bounded reconnect. Omit the line
+entirely on every other handoff, including one that still has ordinary compile diagnostics.
+A generic `401`/`403` **without** that text is a sign-in failure: describe it in
+`App compile:` or the prose and do **not** write `Session: stale`.
 
 ## Constraints
 
@@ -446,6 +458,11 @@ Functional scenarios: [N total; all assigned to screen briefs / defects]
 - Do not edit existing `.pa.yaml` files in EDIT mode.
 - Call `compile_canvas` only to validate CREATE-mode `App.pa.yaml`. Do not use it to
   chase screen-file diagnostics; the orchestrator owns full-app validation.
+- If any `canvas-authoring` MCP call (discovery or the CREATE-mode `App.pa.yaml` compile)
+  returns `HTTP 401 Unauthorized: Invalid session state` — the literal text with a 401, not
+  a generic `401`/`403` and not a compile diagnostic — stop that step, do not retry it in a
+  loop, and return the handoff immediately with `Session: stale`. You have no `connect`
+  tool; reconnecting and retrying is the orchestrator's decision.
 - Do not edit `[working directory]/_EditorState.pa.yaml`; record ordering work in `## Editor State Changes` for the top-level orchestrator.
 - Do not embed all discovery output in the index or shared plan.
 - Every screen brief must be self-sufficient when read with the shared plan.

--- a/plugins/canvas-apps/agents/canvas-app-planner.md
+++ b/plugins/canvas-apps/agents/canvas-app-planner.md
@@ -441,7 +441,7 @@ Shared plan: `[working directory]/canvas-app-shared.md`
 App file: [`[working directory]/App.pa.yaml` for CREATE, "unchanged" for EDIT]
 App compile: [Clean / diagnostics remaining, with detail]
 Functional scenarios: [N total; all assigned to screen briefs / defects]
-Session: stale
+Session: stale (ONLY when a `canvas-authoring` MCP call failed with `HTTP 401 Unauthorized: Invalid session state`)
 ```
 
 Include the `Session:` line **only** when a `canvas-authoring` MCP call in this run failed

--- a/plugins/canvas-apps/references/ValidationWorkflow.md
+++ b/plugins/canvas-apps/references/ValidationWorkflow.md
@@ -41,6 +41,46 @@ the navigation to satisfy an intermediate compile breaks the finished app.
 
 Call `compile_canvas`.
 
+### Recovering from an expired coauthoring session
+
+Run this check **before** normal diagnostic/YAML troubleshooting. A long-lived Studio tab
+has been reported to lose its coauthoring session after roughly 25–30 minutes (observed
+behavior, not a guaranteed lifetime); when that happens `compile_canvas` (and `sync_canvas`)
+return, and keep returning on every retry:
+
+```
+HTTP 401 Unauthorized: Invalid session state
+```
+
+This is **not** a compile diagnostic and **not** a generic authentication failure:
+
+- It is the literal `Invalid session state` text together with a 401. A generic `401` or
+  `403` **without** that text is a sign-in problem — do not reconnect for it; surface it
+  as-is. Do not treat every authentication failure as an expired session.
+- The convergence budget and liveness rules below do **not** apply — a stale session never
+  "converges" by editing YAML.
+
+Recovery is an agent orchestration step, **orchestrator-only**, and bounded:
+
+1. On the known `Invalid session state` condition, treat the session as invalid.
+2. Call `connect` **once**, reusing the `environment_id`, `app_id`,
+   `environment_category`, and any `login_hint` / `auth_flow` / `tenant_id` from the last
+   successful `connect` in this conversation. If those parameters are not available, skip to
+   step 4.
+3. Re-run the failed operation **once**. On success, continue the workflow normally, but
+   tell the user their Studio tab may still show the grey loading screen and should be
+   reloaded so its view resyncs.
+4. If the reconnect fails, the parameters are unknown, or the single retry still returns
+   `Invalid session state`, **stop**. Give the user the manual recovery steps from
+   `skills/configure-canvas-mcp/SKILL.md` → "Manual recovery": reload the Power Apps Studio
+   tab (fresh `authoringsession`) → reconnect the MCP (`/configure-canvas-mcp` or `connect`)
+   → re-run `compile_canvas` to push the local `.pa.yaml` files. No local `.pa.yaml` work is
+   lost.
+
+Exactly one `connect` and exactly one retry per stale-session failure. No retry loop, no
+planner/builder re-dispatch, no spawned agent. Builders and sub-agents never call `connect`
+for recovery — a builder that hits the error reports it upward for the orchestrator to
+handle once.
 
 If compilation fails, fix diagnostics in this order:
 

--- a/plugins/canvas-apps/references/ValidationWorkflow.md
+++ b/plugins/canvas-apps/references/ValidationWorkflow.md
@@ -58,9 +58,15 @@ This is **not** a compile diagnostic and **not** a generic authentication failur
   `403` **without** that text is a sign-in problem — do not reconnect for it; surface it
   as-is. Do not treat every authentication failure as an expired session.
 - The convergence budget and liveness rules below do **not** apply — a stale session never
-  "converges" by editing YAML.
+  "converges" by editing YAML. This recovery is a separate, bounded path; it does not
+  consume the compile-and-fix, liveness, or functional-retry budgets.
 
-Recovery is an agent orchestration step, **orchestrator-only**, and bounded:
+Recovery is an agent orchestration step. **Only the orchestrator ever calls `connect`.**
+The planner and builders have no `connect` tool, never reconnect, and never start this
+recovery; a sub-agent that hits the error reports it upward and the orchestrator handles it
+once. The shape depends on which component's tool call failed.
+
+#### A. The orchestrator's own `compile_canvas` / `sync_canvas` call failed
 
 1. On the known `Invalid session state` condition, treat the session as invalid.
 2. Call `connect` **once**, reusing the `environment_id`, `app_id`,
@@ -71,16 +77,51 @@ Recovery is an agent orchestration step, **orchestrator-only**, and bounded:
    tell the user their Studio tab may still show the grey loading screen and should be
    reloaded so its view resyncs.
 4. If the reconnect fails, the parameters are unknown, or the single retry still returns
-   `Invalid session state`, **stop**. Give the user the manual recovery steps from
-   `skills/configure-canvas-mcp/SKILL.md` → "Manual recovery": reload the Power Apps Studio
-   tab (fresh `authoringsession`) → reconnect the MCP (`/configure-canvas-mcp` or `connect`)
-   → re-run `compile_canvas` to push the local `.pa.yaml` files. No local `.pa.yaml` work is
-   lost.
+   `Invalid session state`, **stop** and give the manual recovery steps (below).
 
-Exactly one `connect` and exactly one retry per stale-session failure. No retry loop, no
-planner/builder re-dispatch, no spawned agent. Builders and sub-agents never call `connect`
-for recovery — a builder that hits the error reports it upward for the orchestrator to
-handle once.
+#### B. The failure happened inside the planner
+
+The planner is a spawned agent (`canvas-app-planner`, invoked with `Task`). During CREATE
+it calls MCP discovery tools and then compiles `[working directory]/App.pa.yaml` itself
+(`canvas-app-planner.md` → "Write App YAML", `compile_canvas`); during EDIT it may still
+call discovery tools. It has **no `connect` tool**, so it cannot recover a stale session —
+it stops the failing step and returns its handoff with a **`Session: stale`** line (and
+describes the failure in `App compile:` / prose). The planner emits `Session: stale` **only**
+for `HTTP 401 Unauthorized: Invalid session state`; a generic `401`/`403` is a sign-in
+problem it reports without that line, and you do **not** reconnect for it.
+
+When the planner's handoff contains `Session: stale`:
+
+1. Call `connect` **once**, with the parameters from the last successful `connect` in this
+   conversation. If they are unavailable, **stop** and give the manual recovery steps.
+2. Complete the planner's failed operation **once** — exactly one of these, never both:
+   - **Compile only, `App.pa.yaml` already written:** re-run `compile_canvas` on
+     `[working directory]/App.pa.yaml` yourself. No re-dispatch — the file is on disk and
+     the orchestrator owns full-app compilation anyway.
+   - **Discovery incomplete, or plan artifacts missing / partial:** re-dispatch the **same**
+     planner invocation once (same mode, working directory, and approved plan). This single
+     re-dispatch is permitted **only** for this known stale-session case — it is not a
+     regeneration for compile diagnostics.
+3. The re-dispatched planner runs under its normal bounded rules and still cannot
+   `connect`. If it again returns `Session: stale` (or the recompile still returns
+   `Invalid session state`) — **stop** and give the manual recovery steps. No second
+   reconnect, no second re-dispatch.
+
+#### Manual recovery steps
+
+Give the user the steps from `skills/configure-canvas-mcp/SKILL.md` → "Manual recovery":
+reload the Power Apps Studio tab (fresh `authoringsession`) → reconnect the MCP
+(`/configure-canvas-mcp` or `connect`) → re-run `compile_canvas` to push the local
+`.pa.yaml` files. No local `.pa.yaml` work is lost.
+
+#### The hard bound
+
+Per stale-session failure: **at most one `connect`, and at most one retry — one operation
+re-run *or* one planner re-dispatch, never both, never twice.** Never
+`connect` → re-dispatch → `connect` → re-dispatch. A stale session that survives one
+reconnect is a manual-recovery case, not a second automatic attempt. No builder
+re-dispatch, no general-purpose "fix it" agent, and no reconnect initiated from inside any
+sub-agent.
 
 If compilation fails, fix diagnostics in this order:
 
@@ -205,6 +246,11 @@ diagnostic history, and a fresh agent would have to rediscover all of it.
 - The only sanctioned re-delegation is back to `canvas-app-planner` when a builder
   returned `Status: Blocked` because its brief was genuinely missing a definition or an
   assignment field — never for a diagnostic on a file that already exists.
+- A stale coauthoring session inside the planner's own discovery or CREATE-mode
+  `App.pa.yaml` compile is the one other case: see "Recovering from an expired coauthoring
+  session" → B. That is a single, bounded re-dispatch to recover the session — not a
+  regeneration for compile diagnostics — and it neither resets nor consumes the convergence
+  budget.
 - Modify `[working directory]/_EditorState.pa.yaml` when a diagnostic identifies it or when the requested
   screen or component-definition order requires correction. Preserve valid names and
   repair only the affected order entries.

--- a/plugins/canvas-apps/skills/canvas-app/SKILL.md
+++ b/plugins/canvas-apps/skills/canvas-app/SKILL.md
@@ -50,6 +50,14 @@ Do not load both workflow documents.
 
 CREATE and complex EDIT workflows return here after the planner finishes.
 
+If the planner's handoff contains `Session: stale`, its CREATE-mode discovery or
+`App.pa.yaml` compile hit the known expired coauthoring session (`401 Invalid session
+state`). Do **not** run the checks below or re-invoke the planner for defects yet: follow
+`${PLUGIN_ROOT}/references/ValidationWorkflow.md` → "Recovering from an expired coauthoring
+session" → B — one `connect`, then either recompile the existing `App.pa.yaml` once or
+re-dispatch the same planner invocation once (never both, no second `connect`). A second
+`Session: stale` or `Invalid session state` stops recovery and goes to the manual fallback.
+
 1. Read `[working directory]/canvas-app-plan.md` returned by the planner.
 2. Verify its `## Requirement Coverage` table maps every concrete requested noun and
    interaction to a visible affordance. Any approximation must be explicit and must not
@@ -98,7 +106,8 @@ CREATE and complex EDIT workflows return here after the planner finishes.
 8. Confirm the planner reported a clean `compile_canvas` for `[working directory]/App.pa.yaml`. If it
    did not, compile now and resolve every `App`-level diagnostic before dispatching.
    For EDIT mode, compile after applying the before-builder app changes and resolve
-   App-level diagnostics before dispatching.
+   App-level diagnostics before dispatching. A `Session: stale` handoff is not an ordinary
+   unclean compile — handle it via the stale-session step above before this check.
 9. Invoke `canvas-screen-builder` once per dispatch row, in waves of
    **at most three**. Fire the wave's invocations together in one message, wait for that
    wave to return, then dispatch the next.
@@ -247,17 +256,28 @@ After all builders finish:
 11. Do not report completion until the workspace compiles clean and the functional
     conformance gate passes, or remaining compile and functional defects are explicitly
     reported.
-12. **Expired coauthoring session recovery is an orchestrator-only agent instruction,
-    bounded to one attempt.** A long-lived Studio tab has been reported to lose its
-    coauthoring session after roughly 25–30 minutes (observed, not a guaranteed lifetime);
-    `sync_canvas` / `compile_canvas` then return `HTTP 401 Unauthorized: Invalid session
-    state` on every call. Only on that specific error — the `Invalid session state` text
-    with a 401, not a generic `401`/`403`, which stays a sign-in problem — and only the
-    orchestrator: call `connect` **once** with the parameters from the last successful
-    `connect` in this conversation, then retry the failed operation **once**. Do not loop,
-    do not repeatedly `connect`/retry, do not re-dispatch the planner or a builder. If the
-    one reconnect + one retry still fails, or the parameters are unknown, stop and give the
-    user the manual recovery steps from
+12. **Expired coauthoring session recovery is orchestrator-decided and bounded to one
+    attempt.** A long-lived Studio tab has been reported to lose its coauthoring session
+    after roughly 25–30 minutes (observed, not a guaranteed lifetime); `sync_canvas` /
+    `compile_canvas` then return `HTTP 401 Unauthorized: Invalid session state` on every
+    call. Act only on that specific error — the `Invalid session state` text with a 401,
+    not a generic `401`/`403`, which stays a sign-in problem — and **only the orchestrator
+    ever calls `connect`**.
+    - **Orchestrator's own call failed:** `connect` **once** with the parameters from the
+      last successful `connect` in this conversation, then retry the failed operation
+      **once**.
+    - **Failure came back inside the planner** (CREATE-mode discovery or the planner's own
+      `App.pa.yaml` compile — the planner is a spawned agent with no `connect` tool and
+      returns `Session: stale` in its handoff): `connect` **once**, then complete that
+      operation **once** — either re-run `compile_canvas` on the already-written
+      `App.pa.yaml` yourself, or, if the planner's discovery or plan artifacts are
+      incomplete, re-dispatch the **same** planner invocation once. This one re-dispatch is
+      permitted only for this known stale-session case.
+    At most one `connect` and one retry-or-re-dispatch per stale-session failure — never
+    both, never twice, no loop, no builder re-dispatch, no reconnect from inside a
+    sub-agent. This recovery does not consume the compile-convergence, liveness, or
+    functional-retry budgets. If it still fails, or the parameters are unknown, stop and
+    give the user the manual recovery steps from
     `${PLUGIN_ROOT}/references/ValidationWorkflow.md` (reload Studio → reconnect MCP →
     re-run `compile_canvas`). Builders never call `connect`; a builder that hits the error
     reports it upward for the orchestrator to handle once.

--- a/plugins/canvas-apps/skills/canvas-app/SKILL.md
+++ b/plugins/canvas-apps/skills/canvas-app/SKILL.md
@@ -4,7 +4,7 @@ version: 3.0.1
 description: Creates or edits a Power Apps Canvas App through the Canvas Authoring MCP coauthoring session. Handles new app generation, direct targeted edits, complex multi-screen changes, responsive layout, per-screen self-QA, and compile-error convergence. Trigger on requests to create, build, generate, modify, update, change, fix, or edit a Canvas App or .pa.yaml files.
 author: Microsoft Corporation
 user-invocable: true
-allowed-tools: Read, Write, Edit, Bash, AskUserQuestion, Task, TaskCreate, TaskUpdate, TaskList, EnterPlanMode, ExitPlanMode, mcp__canvas-authoring__sync_canvas, mcp__canvas-authoring__compile_canvas, mcp__canvas-authoring__describe_control
+allowed-tools: Read, Write, Edit, Bash, AskUserQuestion, Task, TaskCreate, TaskUpdate, TaskList, EnterPlanMode, ExitPlanMode, mcp__canvas-authoring__connect, mcp__canvas-authoring__sync_canvas, mcp__canvas-authoring__compile_canvas, mcp__canvas-authoring__describe_control
 ---
 
 # Create or Edit a Canvas App
@@ -24,6 +24,12 @@ Canvas Authoring tools operate on a local directory containing the app YAML.
    create it with `Bash`, and resolve its absolute path.
 4. Call `sync_canvas` with that absolute working directory before reading or editing app
    files. Do not proceed if sync fails.
+
+If `sync_canvas` (or any later `compile_canvas`) fails with
+`HTTP 401 Unauthorized: Invalid session state`, the coauthoring session has expired — see
+**Shared Invariant 12** and `${PLUGIN_ROOT}/references/ValidationWorkflow.md` →
+"Recovering from an expired coauthoring session". Attempt the single bounded recovery there
+before treating the run as failed.
 
 Always use absolute paths for app files. Never edit `_EditorState.pa.yaml`; Studio owns it.
 
@@ -241,3 +247,17 @@ After all builders finish:
 11. Do not report completion until the workspace compiles clean and the functional
     conformance gate passes, or remaining compile and functional defects are explicitly
     reported.
+12. **Expired coauthoring session recovery is an orchestrator-only agent instruction,
+    bounded to one attempt.** A long-lived Studio tab has been reported to lose its
+    coauthoring session after roughly 25–30 minutes (observed, not a guaranteed lifetime);
+    `sync_canvas` / `compile_canvas` then return `HTTP 401 Unauthorized: Invalid session
+    state` on every call. Only on that specific error — the `Invalid session state` text
+    with a 401, not a generic `401`/`403`, which stays a sign-in problem — and only the
+    orchestrator: call `connect` **once** with the parameters from the last successful
+    `connect` in this conversation, then retry the failed operation **once**. Do not loop,
+    do not repeatedly `connect`/retry, do not re-dispatch the planner or a builder. If the
+    one reconnect + one retry still fails, or the parameters are unknown, stop and give the
+    user the manual recovery steps from
+    `${PLUGIN_ROOT}/references/ValidationWorkflow.md` (reload Studio → reconnect MCP →
+    re-run `compile_canvas`). Builders never call `connect`; a builder that hits the error
+    reports it upward for the orchestrator to handle once.

--- a/plugins/canvas-apps/skills/configure-canvas-mcp/SKILL.md
+++ b/plugins/canvas-apps/skills/configure-canvas-mcp/SKILL.md
@@ -144,6 +144,15 @@ Do this at most once per failed operation. Do not repeatedly `connect` and retry
 reconnect or the single retry still returns `Invalid session state`, stop and give the
 manual recovery steps below.
 
+If the failure surfaced **inside the `canvas-app-planner` agent** — it calls discovery
+tools and compiles `App.pa.yaml` during CREATE, and has no `connect` tool of its own — the
+planner returns `Session: stale` in its handoff and the **orchestrator** does the
+same single `connect`, then completes that operation once: re-running `compile_canvas` on
+the already-written `App.pa.yaml` itself, or re-dispatching the same planner invocation
+exactly once if the planner's discovery or plan output is incomplete. Still one `connect`
+and one retry / re-dispatch in total, then manual recovery. Builders and sub-agents never
+call `connect` themselves.
+
 ### Manual recovery
 
 `connect` re-establishes the MCP server's authoring session, but it **cannot refresh the

--- a/plugins/canvas-apps/skills/configure-canvas-mcp/SKILL.md
+++ b/plugins/canvas-apps/skills/configure-canvas-mcp/SKILL.md
@@ -105,3 +105,63 @@ Tell the user:
 > You can now use Canvas App skills like `/canvas-app` to create or edit your app.
 >
 > To verify the setup, try: "List available Canvas App controls" — this should invoke `list_controls`.
+
+## Recover an expired coauthoring session
+
+A long-lived coauthoring session has been **reported** to become invalid after roughly
+**25–30 minutes** of a Studio tab being left open. Treat this as observed/reported
+behavior, **not a guaranteed session lifetime** — the exact timing varies.
+
+What the user sees when it happens:
+
+- The Power Apps Studio tab goes to a **grey / blank loading screen** and does not recover
+  on its own. Evidence from the reported network trace indicates that the realtime SignalR
+  channel (`/api/signalr/diagnosticshub`) can become unavailable and that subsequent
+  `negotiate` requests may return `410 Gone`. That gateway behavior is outside this
+  repository — this skill cannot repair it.
+- `compile_canvas` (and `sync_canvas`) from the Canvas Authoring MCP start returning
+  **`HTTP 401 Unauthorized: Invalid session state`**, and keep failing the same way on
+  every retry.
+
+Recognize this as a **stale coauthoring/authoring session, not a sign-in failure**, by the
+exact `Invalid session state` text together with the 401. A plain `401`/`403` **without**
+that text is an authentication problem — handle it as in step 3 (`force_account_select`,
+`login_hint`, `auth_flow`) and do **not** treat it as an expired session.
+
+### Automatic recovery attempt
+
+This is an agent orchestration instruction, not a programmatic mechanism. When
+`compile_canvas` / `sync_canvas` fail with `Invalid session state`, the `canvas-app` skill
+makes **one** bounded recovery attempt:
+
+1. Treat the current session as invalid.
+2. Call `connect` **once**, reusing the `environment_id`, `app_id`,
+   `environment_category`, and any `login_hint` / `auth_flow` / `tenant_id` from the last
+   successful `connect` in this conversation.
+3. Retry the failed operation **once**.
+
+Do this at most once per failed operation. Do not repeatedly `connect` and retry. If the
+reconnect or the single retry still returns `Invalid session state`, stop and give the
+manual recovery steps below.
+
+### Manual recovery
+
+`connect` re-establishes the MCP server's authoring session, but it **cannot refresh the
+Studio browser tab or its `authoringsession`** — only a reload does that, and Studio's grey
+screen is not guaranteed to clear without one. If the automatic attempt did not restore
+compilation, or Studio is still on the grey screen, tell the user:
+
+> The Power Apps coauthoring session has expired (this has been reported after roughly
+> 25–30 minutes). To recover:
+>
+> 1. **Reload the Power Apps Studio tab** and wait for the app to finish loading — this
+>    creates a fresh `authoringsession`.
+> 2. Reconnect the Canvas Authoring MCP: run `/configure-canvas-mcp` again (or ask me to
+>    `connect`).
+> 3. Re-run `compile_canvas` to push your local `.pa.yaml` files again.
+>
+> Your local `.pa.yaml` files are not lost — they stay on disk and re-compile once the
+> session is fresh.
+
+If the user reloads Studio, re-run this skill's step 3 (`connect`) with the same parameters
+before retrying `compile_canvas`.


### PR DESCRIPTION
## Related Issue

Fixes #8362
Fixes the Canvas Apps agent workflow when a long-lived coauthoring session becomes invalid.

After roughly 25–30 minutes, a Canvas coauthoring session may lose its realtime SignalR connection. Power Apps Studio can become stuck on the grey loading screen, while Canvas Authoring MCP operations such as compile_canvas and sync_canvas may start returning:

401 Unauthorized: Invalid session state

Previously, the Canvas Apps skills did not distinguish this stale-session failure from ordinary authentication or YAML/compile errors. As a result, the agent could continue troubleshooting or retrying the operation without recovering the authoring session, requiring the user to manually reconnect.

What changed

* Added explicit stale-session detection guidance for 401 Invalid session state.
* Added bounded recovery instructions:
* attempt one mcp__canvas-authoring__connect;
   retry the failed operation once;
  stop rather than entering a reconnect/retry loop if recovery fails.
* Restricted session recovery to the orchestrator; builders and sub-agents must not call connect for recovery.
* Added guidance to distinguish stale-session errors from generic 401/403 authentication failures.
* Documented the observed ~25–30 minute session behavior without treating it as a guaranteed service lifetime.
* Added a clear manual recovery path when automatic recovery cannot restore the session:
    1. Reload the Power Apps Studio tab to create a fresh authoring session.
    2. Reconnect the Canvas Authoring MCP.
    3. Re-run compile_canvas to push the local .pa.yaml files again.
* Updated Canvas Apps troubleshooting and plugin guidance accordingly.

Why this belongs in this repository

The Canvas Authoring MCP server and Power Apps SignalR/authoring gateway are external to this repository, so the underlying 410/SignalR failure cannot be repaired here.

This change instead improves the agent-level recovery behavior available to the Canvas Apps skills: when the external MCP reports a known stale-session condition, the agent makes one bounded reconnect attempt and one retry before providing an actionable fallback.

Validation

The following repository checks pass:

* node scripts/validate-skill-descriptions.js
* node scripts/validate-keyword-case.js
* node scripts/validate-legacy-compatibility.js
* node scripts/validate-plugin-names.js
* node scripts/validate-secure-process-execution.js
* node scripts/validate-no-real-environments.js
* node scripts/validate-telemetry-ikeys.js
* node --test scripts/tests/*.test.js

All validator tests pass with 63 passed, 0 failed.

No new runtime dependencies, MCP server changes, or CI workflows are introduced