### PR TITLE
Use npm Power Apps CLI in Code Apps issue reports

### DIFF
--- a/plugins/code-apps/.claude-plugin/plugin.json
+++ b/plugins/code-apps/.claude-plugin/plugin.json
@@ -16,7 +16,7 @@
     "vite",
     "dataverse",
     "connectors",
-    "pac-cli",
+    "power-apps-cli",
     "power-platform"
   ]
 }

--- a/plugins/code-apps/.plugin/plugin.json
+++ b/plugins/code-apps/.plugin/plugin.json
@@ -16,7 +16,7 @@
     "vite",
     "dataverse",
     "connectors",
-    "pac-cli",
+    "power-apps-cli",
     "power-platform"
   ]
 }

--- a/plugins/code-apps/AGENTS.md
+++ b/plugins/code-apps/AGENTS.md
@@ -33,7 +33,7 @@ skills/
   create-code-app/
     SKILL.md                      <- Scaffold, init, build, and deploy a new code app
     references/
-      prerequisites-reference.md  <- Node, pac, git requirements
+      prerequisites-reference.md  <- Node, npm-installed Power Apps CLI, git requirements
       troubleshooting.md          <- Common issues and fixes
   deploy/
     SKILL.md                      <- Build and deploy an existing code app

--- a/plugins/code-apps/skills/report-issue/report-issue-workflow.md
+++ b/plugins/code-apps/skills/report-issue/report-issue-workflow.md
@@ -50,12 +50,12 @@ Use `AskUserQuestion` to gather bug details. `AskUserQuestion` supports 1-4 ques
 
 **Call 3** — Environment details:
 
-Use `AskUserQuestion` with a single question: **"We recommend including environment details (OS, Claude Code version, PAC CLI version) to help maintainers reproduce and debug the issue faster. Include them?"** (header: "Environment") — Options: "Yes, auto-collect them" (recommended), "No, skip".
+Use `AskUserQuestion` with a single question: **"We recommend including environment details (OS, Claude Code version, Power Apps CLI version) to help maintainers reproduce and debug the issue faster. Include them?"** (header: "Environment") — Options: "Yes, auto-collect them" (recommended), "No, skip".
 
 - If **yes**: Auto-collect the following by running shell commands:
   - **OS**: Detect the user's OS name and version using an appropriate command for their platform.
   - **Claude Code version**: Run `claude --version`
-  - **PAC CLI version**: Run `pac help` and extract the version from the output
+  - **Power Apps CLI version**: Resolve the locally installed CLI from the code app project root using [cli-binary.md](${PLUGIN_ROOT}/shared/cli-binary.md), then run `$PA --version`. If the CLI is not installed, report that explicitly.
   - Present the collected details to the user.
 - If **no**: Skip environment fields.
 


### PR DESCRIPTION
## Summary
- replace stale PAC CLI references in the Code Apps plugin metadata and contributor guidance
- collect the locally installed `@microsoft/power-apps-cli` version with the resolved `$PA --version` command

## Validation
- `git diff --check`
- verified no `pac` or `pac-cli` references remain under `plugins/code-apps`