### PR TITLE
fix(power-automate): preserve multi-connector solution refs

### DIFF
--- a/plugins/power-automate/.claude-plugin/plugin.json
+++ b/plugins/power-automate/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "power-automate",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "Build, edit, run, and debug Power Automate cloud flows via the FlowAgent MCP server — connection lifecycle, surgical edits, copy across environments, run management, and validated expressions.",
   "author": {
     "name": "Microsoft",

--- a/plugins/power-automate/.plugin/plugin.json
+++ b/plugins/power-automate/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "power-automate",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "Build, edit, run, and debug Power Automate cloud flows via the FlowAgent MCP server — connection lifecycle, surgical edits, copy across environments, run management, and validated expressions.",
   "author": {
     "name": "Microsoft",

--- a/plugins/power-automate/server/mcp.mjs
+++ b/plugins/power-automate/server/mcp.mjs
@@ -50037,6 +50037,7 @@ function applyFlowEdits(definition, operations) {
 }
 
 // packages/core/dist/connection-refs.js
+init_logger();
 function extractConnectorKeysFromDefinition(definition) {
   const keys = /* @__PURE__ */ new Set();
   function scanActions(actions) {
@@ -50071,7 +50072,7 @@ function extractConnectorKeysFromDefinition(definition) {
   }
   return keys;
 }
-async function enrichRefsWithLogicalNames(client, envId, refs, log) {
+async function enrichRefsWithLogicalNames(client, envId, refs, log = (message) => logger.warn(message)) {
   const needsEnrichment = Object.values(refs).some((r) => !r.connectionReferenceLogicalName);
   if (!needsEnrichment)
     return refs;
@@ -66031,9 +66032,12 @@ async function buildUpdateProperties(ctx, envId, flow, input) {
   let refsFromFlow = false;
   let effectiveRefs = input.connectionRefs;
   if (input.definition && !effectiveRefs) {
-    const current = await ctx.getClient().getFlow(envId, flow);
-    effectiveRefs = current.properties?.connectionReferences;
-    refsFromFlow = !!effectiveRefs;
+    try {
+      const current = await ctx.getClient().getFlow(envId, flow);
+      effectiveRefs = current.properties?.connectionReferences;
+      refsFromFlow = !!effectiveRefs;
+    } catch {
+    }
   }
   let enrichedRefs = effectiveRefs;
   if (enrichedRefs && !refsFromFlow) {

--- a/plugins/power-automate/server/mcp.mjs
+++ b/plugins/power-automate/server/mcp.mjs
@@ -50082,10 +50082,10 @@ async function enrichRefsWithLogicalNames(client, envId, refs, log) {
     log?.("Dataverse connection references unavailable; using direct connections");
     return refs;
   }
-  const connectorToLogical = {};
+  const connectorToRefs = {};
   for (const dv of dvRefs) {
     if (dv.connectorid && dv.connectionreferencelogicalname) {
-      connectorToLogical[dv.connectorid] = dv.connectionreferencelogicalname;
+      (connectorToRefs[dv.connectorid] ??= []).push(dv);
     }
   }
   const enriched = { ...refs };
@@ -50094,10 +50094,16 @@ async function enrichRefsWithLogicalNames(client, envId, refs, log) {
     if (ref.connectionReferenceLogicalName)
       continue;
     const connectorId = ref.id ?? `/providers/Microsoft.PowerApps/apis/${key}`;
-    const logicalName = connectorToLogical[connectorId];
+    const candidates = connectorToRefs[connectorId] ?? [];
+    const connectionName = ref.connectionName;
+    const exactMatches = connectionName ? candidates.filter((candidate) => candidate.connectionid === connectionName) : [];
+    const match = exactMatches.length === 1 ? exactMatches[0] : candidates.length === 1 ? candidates[0] : void 0;
+    const logicalName = match?.connectionreferencelogicalname;
     if (logicalName) {
       enriched[key] = { ...ref, connectionReferenceLogicalName: logicalName };
       count++;
+    } else if (candidates.length > 1) {
+      log?.(`Skipped ambiguous connection reference logical name for ${key}; pass connectionReferenceLogicalName explicitly.`);
     }
   }
   if (count > 0) {
@@ -50994,7 +51000,10 @@ var FlowClient = class _FlowClient {
       } catch (connectorErr) {
         logger.debug(`Logic Flows connector transport failed for trigger "${trigger.name}": ${String(connectorErr)}`);
         try {
-          return done("callback", await this.runFlowViaCallback(envId, flowId, body, trigger.name, { withAuth: true }));
+          return done("callback", await this.runFlowViaCallback(envId, flowId, body, trigger.name, {
+            withAuth: true,
+            allowManagementFallback: false
+          }));
         } catch (err) {
           if (isDirectApiInputsRejected(err) || isDirectApiInputsRejected(connectorErr)) {
             throw new DirectApiTriggerInputsError(trigger.name, trigger.kind, connectorErr);
@@ -51079,7 +51088,7 @@ var FlowClient = class _FlowClient {
     try {
       callbackUrl = await this.getTriggerCallbackUrl(envId, flowId, resolvedTrigger);
     } catch (err) {
-      if (err instanceof FlowApiError && /ListCallbackUrlOperationBlocked/i.test(err.message)) {
+      if (err instanceof FlowApiError && /ListCallbackUrlOperationBlocked/i.test(err.message) && opts.allowManagementFallback !== false) {
         logger.warn(`listCallbackUrl blocked for trigger "${resolvedTrigger}" (Button/Request trigger). Falling back to management API with body.`);
         const result = await this.runFlow(envId, flowId, triggerBody, resolvedTrigger);
         return { status: 202, body: result };
@@ -66317,11 +66326,18 @@ async function createMcpServer(authProvider, deps = {}) {
       return safeError(e, enhanceFlowApiError);
     }
   });
-  server2.tool("update_flow", "Update an existing flow's definition or properties. **Refuses by default if the flow lives in a managed Dataverse solution** (returns ManagedSolutionReadOnly). Pass forceManaged: true only if you understand the change will be overwritten on the next solution import \u2014 see docs/recipes/upgrade-managed-flow.md for the right pattern. **Recommended two-phase update**: call preview_update first to obtain a previewToken bound to the exact change, then pass that token back here. update_flow will only apply if the proposal still matches what was previewed (prevents lost writes from concurrent edits). Auto-captures a backup snapshot before applying (last 10 retained per flow, accessible via list_backups). **Use this for**: any change to an existing flow. **Do NOT use for**: creating a new flow (use create_flow) or starting/stopping a flow (use publish_flow / disable_flow).", { env: external_exports.string().optional().describe("Environment ID"), flow: external_exports.string().describe("Flow ID"), definition: jsonRecord.optional().describe("Updated definition JSON"), connectionRefs: jsonRecord.optional().describe("Connection references JSON"), name: external_exports.string().optional().describe("New name"), state: external_exports.enum(["Started", "Stopped"]).optional().describe("State"), forceManaged: external_exports.boolean().optional().describe("Override the managed-solution read-only guard. Default false."), previewToken: external_exports.string().optional().describe("Token issued by preview_update for this exact (env, flow, body) tuple. When supplied, the update only applies if the proposed change still matches what was previewed; mismatched tokens throw PreviewTokenMismatch.") }, { readOnlyHint: false, title: "Update Flow" }, async ({ env, flow, definition, connectionRefs, name: name3, state, forceManaged, previewToken }) => {
+  server2.tool("update_flow", "Update an existing flow's definition or properties. **Refuses by default if the flow lives in a managed Dataverse solution** (returns ManagedSolutionReadOnly). Pass forceManaged: true only if you understand the change will be overwritten on the next solution import \u2014 see docs/recipes/upgrade-managed-flow.md for the right pattern. **Recommended two-phase update**: call preview_update first to obtain a previewToken bound to the exact change, then pass that token back here. update_flow will only apply if the proposal still matches what was previewed (prevents lost writes from concurrent edits). Auto-captures a backup snapshot before applying (last 10 retained per flow, accessible via list_backups). **Use this for**: any change to an existing flow. **Do NOT use for**: creating a new flow (use create_flow) or starting/stopping a flow (use publish_flow / disable_flow).", { env: external_exports.string().optional().describe("Environment ID"), flow: external_exports.string().describe("Flow ID"), definition: jsonRecord.optional().describe("Updated definition JSON"), connectionRefs: jsonRecord.optional().describe("Connection references JSON"), name: external_exports.string().optional().describe("New name"), state: external_exports.enum(["Started", "Stopped"]).optional().describe("State"), forceManaged: external_exports.boolean().optional().describe("Override the managed-solution read-only guard. Default false."), autoResolveConnectionRefs: external_exports.boolean().optional().describe("Auto-resolve missing connection refs for new connectors in the definition. Default true. Set false to skip if auto-merge is causing errors."), previewToken: external_exports.string().optional().describe("Token issued by preview_update for this exact (env, flow, body) tuple. When supplied, the update only applies if the proposed change still matches what was previewed; mismatched tokens throw PreviewTokenMismatch.") }, { readOnlyHint: false, title: "Update Flow" }, async ({ env, flow, definition, connectionRefs, name: name3, state, forceManaged, autoResolveConnectionRefs, previewToken }) => {
     try {
       const envId = ctx.resolveEnv(env);
-      let enrichedRefs = connectionRefs;
-      if (enrichedRefs) {
+      let refsFromFlow = false;
+      let effectiveRefs = connectionRefs;
+      if (definition && !effectiveRefs) {
+        const current = await ctx.getClient().getFlow(envId, flow);
+        effectiveRefs = current.properties?.connectionReferences;
+        refsFromFlow = !!effectiveRefs;
+      }
+      let enrichedRefs = effectiveRefs;
+      if (enrichedRefs && !refsFromFlow) {
         try {
           enrichedRefs = await enrichRefsWithLogicalNames(ctx.getClient(), envId, enrichedRefs);
         } catch {
@@ -66336,7 +66352,7 @@ async function createMcpServer(authProvider, deps = {}) {
         props.displayName = name3;
       if (state)
         props.state = state;
-      const r = await ctx.getClient().updateFlow(envId, flow, { properties: props }, { forceManaged, previewToken });
+      const r = await ctx.getClient().updateFlow(envId, flow, { properties: props }, { forceManaged, autoResolveConnectionRefs, previewToken });
       return safeResult({ name: r.name, displayName: r.properties?.displayName, state: r.properties?.state, lastModifiedTime: r.properties?.lastModifiedTime });
     } catch (e) {
       return safeError(e, enhanceFlowApiError);

--- a/plugins/power-automate/server/mcp.mjs
+++ b/plugins/power-automate/server/mcp.mjs
@@ -66027,6 +66027,32 @@ function enhanceFlowApiError(err) {
 
 Fix: ${hints.join("\n")}` : msg;
 }
+async function buildUpdateProperties(ctx, envId, flow, input) {
+  let refsFromFlow = false;
+  let effectiveRefs = input.connectionRefs;
+  if (input.definition && !effectiveRefs) {
+    const current = await ctx.getClient().getFlow(envId, flow);
+    effectiveRefs = current.properties?.connectionReferences;
+    refsFromFlow = !!effectiveRefs;
+  }
+  let enrichedRefs = effectiveRefs;
+  if (enrichedRefs && !refsFromFlow) {
+    try {
+      enrichedRefs = await enrichRefsWithLogicalNames(ctx.getClient(), envId, enrichedRefs);
+    } catch {
+    }
+  }
+  const props = {};
+  if (input.definition)
+    props.definition = input.definition;
+  if (enrichedRefs)
+    props.connectionReferences = enrichedRefs;
+  if (input.name)
+    props.displayName = input.name;
+  if (input.state)
+    props.state = input.state;
+  return props;
+}
 function inferActionType(opProps) {
   if (!opProps)
     return "OpenApiConnection";
@@ -66329,29 +66355,12 @@ async function createMcpServer(authProvider, deps = {}) {
   server2.tool("update_flow", "Update an existing flow's definition or properties. **Refuses by default if the flow lives in a managed Dataverse solution** (returns ManagedSolutionReadOnly). Pass forceManaged: true only if you understand the change will be overwritten on the next solution import \u2014 see docs/recipes/upgrade-managed-flow.md for the right pattern. **Recommended two-phase update**: call preview_update first to obtain a previewToken bound to the exact change, then pass that token back here. update_flow will only apply if the proposal still matches what was previewed (prevents lost writes from concurrent edits). Auto-captures a backup snapshot before applying (last 10 retained per flow, accessible via list_backups). **Use this for**: any change to an existing flow. **Do NOT use for**: creating a new flow (use create_flow) or starting/stopping a flow (use publish_flow / disable_flow).", { env: external_exports.string().optional().describe("Environment ID"), flow: external_exports.string().describe("Flow ID"), definition: jsonRecord.optional().describe("Updated definition JSON"), connectionRefs: jsonRecord.optional().describe("Connection references JSON"), name: external_exports.string().optional().describe("New name"), state: external_exports.enum(["Started", "Stopped"]).optional().describe("State"), forceManaged: external_exports.boolean().optional().describe("Override the managed-solution read-only guard. Default false."), autoResolveConnectionRefs: external_exports.boolean().optional().describe("Auto-resolve missing connection refs for new connectors in the definition. Default true. Set false to skip if auto-merge is causing errors."), previewToken: external_exports.string().optional().describe("Token issued by preview_update for this exact (env, flow, body) tuple. When supplied, the update only applies if the proposed change still matches what was previewed; mismatched tokens throw PreviewTokenMismatch.") }, { readOnlyHint: false, title: "Update Flow" }, async ({ env, flow, definition, connectionRefs, name: name3, state, forceManaged, autoResolveConnectionRefs, previewToken }) => {
     try {
       const envId = ctx.resolveEnv(env);
-      let refsFromFlow = false;
-      let effectiveRefs = connectionRefs;
-      if (definition && !effectiveRefs) {
-        const current = await ctx.getClient().getFlow(envId, flow);
-        effectiveRefs = current.properties?.connectionReferences;
-        refsFromFlow = !!effectiveRefs;
-      }
-      let enrichedRefs = effectiveRefs;
-      if (enrichedRefs && !refsFromFlow) {
-        try {
-          enrichedRefs = await enrichRefsWithLogicalNames(ctx.getClient(), envId, enrichedRefs);
-        } catch {
-        }
-      }
-      const props = {};
-      if (definition)
-        props.definition = definition;
-      if (enrichedRefs)
-        props.connectionReferences = enrichedRefs;
-      if (name3)
-        props.displayName = name3;
-      if (state)
-        props.state = state;
+      const props = await buildUpdateProperties(ctx, envId, flow, {
+        definition,
+        connectionRefs,
+        name: name3,
+        state
+      });
       const r = await ctx.getClient().updateFlow(envId, flow, { properties: props }, { forceManaged, autoResolveConnectionRefs, previewToken });
       return safeResult({ name: r.name, displayName: r.properties?.displayName, state: r.properties?.state, lastModifiedTime: r.properties?.lastModifiedTime });
     } catch (e) {
@@ -66361,22 +66370,12 @@ async function createMcpServer(authProvider, deps = {}) {
   server2.tool("preview_update", "Read-only: compute a diff between the live flow and the proposed update body, and return a short-lived single-use token. Use the token with update_flow to apply the change only if the proposal still matches what you reviewed. No mutation is performed by this tool.", { env: external_exports.string().optional().describe("Environment ID"), flow: external_exports.string().describe("Flow ID"), definition: jsonRecord.optional().describe("Proposed updated definition JSON"), connectionRefs: jsonRecord.optional().describe("Proposed connection references JSON"), name: external_exports.string().optional().describe("Proposed new name"), state: external_exports.enum(["Started", "Stopped"]).optional().describe("Proposed state") }, { readOnlyHint: true, title: "Preview Update" }, async ({ env, flow, definition, connectionRefs, name: name3, state }) => {
     try {
       const envId = ctx.resolveEnv(env);
-      let enrichedRefs = connectionRefs;
-      if (enrichedRefs) {
-        try {
-          enrichedRefs = await enrichRefsWithLogicalNames(ctx.getClient(), envId, enrichedRefs);
-        } catch {
-        }
-      }
-      const props = {};
-      if (definition)
-        props.definition = definition;
-      if (enrichedRefs)
-        props.connectionReferences = enrichedRefs;
-      if (name3)
-        props.displayName = name3;
-      if (state)
-        props.state = state;
+      const props = await buildUpdateProperties(ctx, envId, flow, {
+        definition,
+        connectionRefs,
+        name: name3,
+        state
+      });
       const result = await ctx.getClient().previewUpdate(envId, flow, { properties: props });
       return safeResult(result);
     } catch (e) {

--- a/plugins/power-automate/server/mcp.mjs
+++ b/plugins/power-automate/server/mcp.mjs
@@ -65654,6 +65654,7 @@ function progress(extra) {
 
 // packages/core/dist/mcp/server.js
 init_backups();
+init_logger();
 
 // packages/core/dist/api/dynamic-resolvers.js
 init_logger();
@@ -66036,7 +66037,8 @@ async function buildUpdateProperties(ctx, envId, flow, input) {
       const current = await ctx.getClient().getFlow(envId, flow);
       effectiveRefs = current.properties?.connectionReferences;
       refsFromFlow = !!effectiveRefs;
-    } catch {
+    } catch (err) {
+      logger.warn(`buildUpdateProperties: could not read current connectionReferences for ${flow} in ${envId} (${err instanceof Error ? err.message : String(err)}). Existing bindings will not be preserved for this definition-only update; pass connectionRefs explicitly to keep them.`);
     }
   }
   let enrichedRefs = effectiveRefs;

--- a/plugins/power-automate/server/mcp.mjs
+++ b/plugins/power-automate/server/mcp.mjs
@@ -50097,13 +50097,13 @@ async function enrichRefsWithLogicalNames(client, envId, refs, log) {
     const candidates = connectorToRefs[connectorId] ?? [];
     const connectionName = ref.connectionName;
     const exactMatches = connectionName ? candidates.filter((candidate) => candidate.connectionid === connectionName) : [];
-    const match = exactMatches.length === 1 ? exactMatches[0] : candidates.length === 1 ? candidates[0] : void 0;
+    const match = exactMatches.length === 1 ? exactMatches[0] : !connectionName && candidates.length === 1 ? candidates[0] : void 0;
     const logicalName = match?.connectionreferencelogicalname;
     if (logicalName) {
       enriched[key] = { ...ref, connectionReferenceLogicalName: logicalName };
       count++;
-    } else if (candidates.length > 1) {
-      log?.(`Skipped ambiguous connection reference logical name for ${key}; pass connectionReferenceLogicalName explicitly.`);
+    } else if (candidates.length > 1 || connectionName) {
+      log?.(`Skipped unmatched or ambiguous connection reference logical name for ${key}; pass connectionReferenceLogicalName explicitly.`);
     }
   }
   if (count > 0) {


### PR DESCRIPTION
## Summary
- Bump the Power Automate plugin to 3.0.5 and synchronize its bundled FlowAgent MCP server.
- Preserve existing multi-connector connection references during definition-only and surgical updates.
- Resolve connection-reference logical names deterministically; ambiguous matches require an explicit logical name.

## Validation
- FlowAgent solution-flow write regression suite: 8 tests passed.
- Live validation created and updated stopped test flows with Dataverse, Content Conversion, Office 365 Outlook, and Teams references. All references persisted across full and surgical updates. No flows were run and no message actions executed.

Supersedes the release intent of stale PR #412. The earlier core behavior landed through #465; this bundle adds the current validated multi-connector safeguards.