### PR TITLE
feat(mobile-apps): route telemetry to regional collectors

### DIFF
--- a/plugins/mobile-apps/scripts/lib/app-identity.js
+++ b/plugins/mobile-apps/scripts/lib/app-identity.js
@@ -7,6 +7,7 @@ const path = require('node:path');
 const APP_JSON_FILE = 'app.json';
 const APP_INSTANCE_ID =
   /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const TELEMETRY_CLUSTERS = new Set(['us', 'eu', 'gov', 'high', 'dod', 'mooncake', 'internal']);
 
 function isPlainObject(value) {
   return !!value && typeof value === 'object' && !Array.isArray(value);
@@ -47,6 +48,41 @@ function findAppInstanceId(projectRoot = process.cwd()) {
   return readAppInstanceId(projectRoot);
 }
 
+function telemetrySection(appJson) {
+  if (!isPlainObject(appJson) || !isPlainObject(appJson.expo)) return null;
+  const extra = appJson.expo.extra;
+  return isPlainObject(extra) && isPlainObject(extra.telemetry) ? extra.telemetry : null;
+}
+
+function readTelemetryCluster(projectRoot = process.cwd()) {
+  if (!projectRoot) return '';
+  const telemetry = telemetrySection(readJsonFile(appJsonPath(projectRoot)));
+  const cluster = telemetry && typeof telemetry.cluster === 'string' ? telemetry.cluster : '';
+  return TELEMETRY_CLUSTERS.has(cluster) ? cluster : '';
+}
+
+function writeTelemetryCluster(projectRoot, cluster) {
+  if (!projectRoot || !TELEMETRY_CLUSTERS.has(cluster)) return;
+  const filePath = appJsonPath(projectRoot);
+  // Re-read here rather than reusing an earlier parse: telemetry runs in a
+  // detached child that can overlap with project tooling which also owns
+  // app.json, so the write window must stay as small as possible.
+  const appJson = readJsonFile(filePath);
+  if (!isPlainObject(appJson) || !isPlainObject(appJson.expo)) return;
+  const extra = isPlainObject(appJson.expo.extra) ? appJson.expo.extra : {};
+  const telemetry = isPlainObject(extra.telemetry) ? extra.telemetry : {};
+  if (telemetry.cluster === cluster) return;
+
+  appJson.expo.extra = { ...extra, telemetry: { ...telemetry, cluster } };
+  const temporary = `${filePath}.tmp.${process.pid}`;
+  try {
+    fs.writeFileSync(temporary, `${JSON.stringify(appJson, null, 2)}\n`, 'utf8');
+    fs.renameSync(temporary, filePath);
+  } catch {
+    try { fs.unlinkSync(temporary); } catch { /* best effort */ }
+  }
+}
+
 function ensureAppInstanceId(projectRoot = process.cwd()) {
   const root = path.resolve(projectRoot);
   if (!fs.existsSync(root) || !fs.statSync(root).isDirectory()) {
@@ -84,6 +120,8 @@ module.exports = {
   APP_JSON_FILE,
   ensureAppInstanceId,
   findAppInstanceId,
+  readTelemetryCluster,
+  writeTelemetryCluster,
 };
 
 if (require.main === module) {

--- a/plugins/mobile-apps/scripts/lib/mobile-telemetry-dispatcher.js
+++ b/plugins/mobile-apps/scripts/lib/mobile-telemetry-dispatcher.js
@@ -39,7 +39,7 @@ function fireAndForget(event, opts = {}) {
         APPDATA: env.APPDATA || '',
         POWER_PLATFORM_SKILLS_CONFIG_DIR: opts.configDir || '',
         POWER_PLATFORM_SKILLS_FAKE_HTTPS: opts.fakeProbe || '',
-        POWER_PLATFORM_SKILLS_CLOUD: opts.cloud || '',
+        POWER_PLATFORM_SKILLS_PROJECT_ROOT: opts.projectRoot || '',
         POWER_PLATFORM_SKILLS_IKEY_JSON: opts.ikeyJsonPath || '',
         ...(optOutName && optOutValue ? { [optOutName]: optOutValue } : {}),
       },
@@ -116,6 +116,8 @@ function buildEnvelope(data, time, iKey, eventStreamName) {
   return envelope;
 }
 
+// TEST ONLY. Captures the would-be POST so tests can assert on it without
+// touching the real collector; nothing in the shipped product sets the env var.
 function writeProbe(filePath, record) {
   try {
     fs.writeFileSync(filePath, JSON.stringify(record), 'utf8');
@@ -149,20 +151,24 @@ async function dispatch(raw, env) {
   const resolver = loadResolver(path.dirname(configPath));
   if (resolver && typeof resolver.resolve === 'function') {
     try {
+      // Resolved here, not in the hook: an unresolved cluster costs a `pac auth
+      // who` cold start, and this child is already detached from skill execution.
       const resolved = await resolver.resolve({
         event,
         cfg,
-        cloud: env.POWER_PLATFORM_SKILLS_CLOUD || '',
         configDir,
+        projectRoot: env.POWER_PLATFORM_SKILLS_PROJECT_ROOT || '',
       });
       iKey = resolved && resolved.iKey || '';
       collectorUrl = resolved && resolved.collectorUrl || '';
     } catch {
-      // A resolver failure falls through to the static Mobile configuration.
+      // A resolver failure leaves the event in the local mirror.
     }
+    if (!iKey || !collectorUrl) return;
+  } else {
+    iKey = cfg.instrumentationKey || '';
+    collectorUrl = cfg.collector_url || '';
   }
-  iKey = iKey || cfg.instrumentationKey || '';
-  collectorUrl = collectorUrl || cfg.collector_url || '';
   if (!iKey || iKey === PLACEHOLDER_IKEY || !collectorUrl) return;
 
   const envelope = buildEnvelope(data, time, iKey, cfg.event_stream_name);
@@ -173,8 +179,11 @@ async function dispatch(raw, env) {
     'Content-Length': Buffer.byteLength(body),
   };
 
+  // TEST ONLY: unset in production, so real runs fall through to the POST below.
+  // The URL is captured because US and EU share one instrumentation key and differ
+  // only by collector, so headers alone cannot prove where an event was routed.
   if (env.POWER_PLATFORM_SKILLS_FAKE_HTTPS) {
-    writeProbe(env.POWER_PLATFORM_SKILLS_FAKE_HTTPS, { headers, body });
+    writeProbe(env.POWER_PLATFORM_SKILLS_FAKE_HTTPS, { headers, body, url: collectorUrl });
     return;
   }
 

--- a/plugins/mobile-apps/scripts/lib/mobile-telemetry.js
+++ b/plugins/mobile-apps/scripts/lib/mobile-telemetry.js
@@ -266,6 +266,7 @@ function dispatch(context, event, opts = {}) {
       fakeProbe: context.env.POWER_PLATFORM_SKILLS_FAKE_HTTPS || '',
       ikeyJsonPath: context.ikeyPath,
       env: context.env,
+      projectRoot: opts.cwd || '',
     });
   } catch {
     // Telemetry is observational and must never affect a skill invocation.

--- a/plugins/mobile-apps/scripts/lib/telemetry/ikey.json
+++ b/plugins/mobile-apps/scripts/lib/telemetry/ikey.json
@@ -1,6 +1,34 @@
 {
-  "instrumentationKey": "5c3a61f48d7c4522912765ae7465ab5c-fb3d6606-fe59-4d6b-9bb1-5e993d889672-7138",
-  "collector_url": "https://us-mobile.events.data.microsoft.com/OneCollector/1.0/",
+  "regions": {
+    "us": {
+      "instrumentation_key": "5c3a61f48d7c4522912765ae7465ab5c-fb3d6606-fe59-4d6b-9bb1-5e993d889672-7138",
+      "collector_url": "https://us-mobile.events.data.microsoft.com/OneCollector/1.0/"
+    },
+    "eu": {
+      "instrumentation_key": "5c3a61f48d7c4522912765ae7465ab5c-fb3d6606-fe59-4d6b-9bb1-5e993d889672-7138",
+      "collector_url": "https://eu-mobile.events.data.microsoft.com/OneCollector/1.0/"
+    },
+    "gov": {
+      "instrumentation_key": "0d7685a948a140789ac92933d3dc2d87-2dd0c1ce-8f10-41f0-a70a-2f9e51a851c8-6823",
+      "collector_url": "https://tb.events.data.microsoft.com/OneCollector/1.0/"
+    },
+    "high": {
+      "instrumentation_key": "d31229fb23b0406790b9332e5f465dfc-a6b19a0e-170d-4570-bda5-f35e3668e162-7067",
+      "collector_url": "https://tb.events.data.microsoft.com/OneCollector/1.0/"
+    },
+    "dod": {
+      "instrumentation_key": "41cc10dad35043adbcdace2896484ab4-5ebbc1d6-04c9-486d-a6b6-e5963cd778da-7542",
+      "collector_url": "https://pf.events.data.microsoft.com/OneCollector/1.0/"
+    },
+    "mooncake": {
+      "instrumentation_key": "1c1d139788f74386bd95e752dd781371-04b4424b-e5c1-46ae-8312-28e9fa5832c0-6923",
+      "collector_url": "https://collector.azure.cn/OneCollector/1.0/"
+    },
+    "internal": {
+      "instrumentation_key": "3fb21f3df5c44380bf452fd710f4d50c-0e3f82aa-6d27-41d8-b727-c96b28f99992-7504",
+      "collector_url": "https://us-mobile.events.data.microsoft.com/OneCollector/1.0/"
+    }
+  },
   "event_stream_name": "event",
   "disabled": false
 }

--- a/plugins/mobile-apps/scripts/lib/telemetry/region/artemis-service.js
+++ b/plugins/mobile-apps/scripts/lib/telemetry/region/artemis-service.js
@@ -1,0 +1,71 @@
+"use strict";
+
+const https = require("node:https");
+
+const TIMEOUT_MS = 5000;
+
+function normalizeCloud(cloud) {
+  const value = String(cloud || "").toLowerCase();
+  if (value === "usgov" || value === "usgovgcc" || value === "gcc" || value === "gov") return "Gov";
+  if (value === "usgovhigh" || value === "high") return "High";
+  if (value === "usgovdod" || value === "dod") return "Dod";
+  if (value === "china" || value === "mooncake" || value === "chinacloud") return "Mooncake";
+  if (value === "tip1" || value === "tip2" || value === "test" || value === "preprod") return "Internal";
+  return "Public";
+}
+
+function urlFor(orgId, cloud) {
+  const noDashes = String(orgId || "").replace(/-/g, "");
+  const stamp = normalizeCloud(cloud);
+  if (stamp === "Public") {
+    return `https://${noDashes.slice(0, -2)}.${noDashes.slice(-2)}.organization.api.powerplatform.com/gateway/cluster?api-version=1`;
+  }
+  const domain = noDashes.slice(0, -1);
+  const suffix = noDashes.slice(-1);
+  if (stamp === "Gov") return `https://${domain}.${suffix}.organization.api.gov.powerplatform.microsoft.us/gateway/cluster?api-version=1`;
+  if (stamp === "High") return `https://${domain}.${suffix}.organization.api.high.powerplatform.microsoft.us/gateway/cluster?api-version=1`;
+  if (stamp === "Dod") return `https://${domain}.${suffix}.organization.api.appsplatform.us/gateway/cluster?api-version=1`;
+  if (stamp === "Mooncake") return `https://${domain}.${suffix}.organization.api.powerplatform.partner.microsoftonline.cn/gateway/cluster?api-version=1`;
+  return `https://${domain}.${suffix}.organization.api.test.powerplatform.com/gateway/cluster?api-version=1`;
+}
+
+function defaultHttpsGet(url) {
+  return new Promise((resolve, reject) => {
+    const target = new URL(url);
+    const request = https.request({
+      hostname: target.hostname,
+      path: target.pathname + target.search,
+      method: "GET",
+    }, (response) => {
+      let body = "";
+      response.setEncoding("utf8");
+      response.on("data", (chunk) => (body += chunk));
+      response.on("end", () => resolve({ statusCode: response.statusCode, body }));
+    });
+    request.on("error", reject);
+    request.setTimeout(TIMEOUT_MS, () => request.destroy(new Error("timeout")));
+    request.end();
+  });
+}
+
+async function fetchGeo(orgId, cloud, opts = {}) {
+  if (!orgId) return null;
+  const httpsGet = typeof opts._httpsGet === "function" ? opts._httpsGet : defaultHttpsGet;
+  let response;
+  try {
+    response = await httpsGet(urlFor(orgId, cloud));
+  } catch {
+    return null;
+  }
+  if (!response || response.statusCode < 200 || response.statusCode >= 300) return null;
+  try {
+    const body = JSON.parse(response.body || "");
+    return body && typeof body.geoName === "string" && body.geoName
+      ? { geoName: body.geoName, stamp: normalizeCloud(cloud) }
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+module.exports = { fetchGeo, urlFor, normalizeCloud, TIMEOUT_MS };

--- a/plugins/mobile-apps/scripts/lib/telemetry/region/region-resolver.js
+++ b/plugins/mobile-apps/scripts/lib/telemetry/region/region-resolver.js
@@ -1,0 +1,58 @@
+"use strict";
+
+const { fetchGeo: defaultFetchGeo, normalizeCloud } = require("./artemis-service");
+const { readPacAuth: defaultReadPacAuth } = require("../lib/pac-auth");
+const appIdentity = require("../../app-identity");
+
+const PUBLIC_US_GEOS = new Set(["us", "br", "jp", "in", "au", "ca", "as", "za", "ae", "kr"]);
+const PUBLIC_EU_GEOS = new Set(["eu", "uk", "de", "fr", "no", "ch"]);
+
+function deriveRegion(cloud, geoName) {
+  const stamp = normalizeCloud(cloud);
+  if (stamp === "Gov") return "gov";
+  if (stamp === "High") return "high";
+  if (stamp === "Dod") return "dod";
+  if (stamp === "Mooncake") return "mooncake";
+  if (stamp === "Internal") return "internal";
+  const geo = String(geoName || "").toLowerCase();
+  if (PUBLIC_US_GEOS.has(geo)) return "us";
+  if (PUBLIC_EU_GEOS.has(geo)) return "eu";
+  return "";
+}
+
+function entryFromMap(regionsMap, cluster) {
+  const entry = regionsMap && regionsMap[cluster];
+  if (!entry || !entry.instrumentation_key || !entry.collector_url) return null;
+  return { region: cluster, iKey: entry.instrumentation_key, collectorUrl: entry.collector_url };
+}
+
+async function clusterFromWhoAmI(readPacAuth, fetchGeo) {
+  const auth = readPacAuth() || {};
+  if (!auth.orgId) return "";
+  let geo;
+  try {
+    geo = await fetchGeo(auth.orgId, auth.cloud);
+  } catch {
+    return "";
+  }
+  return geo ? deriveRegion(auth.cloud, geo.geoName) : "";
+}
+
+async function resolve({ projectRoot, regionsMap, _readPacAuth, _fetchGeo, _appIdentity }) {
+  const identity = _appIdentity || appIdentity;
+  let cluster = identity.readTelemetryCluster(projectRoot);
+
+  if (!cluster) {
+    cluster = await clusterFromWhoAmI(
+      _readPacAuth || defaultReadPacAuth,
+      typeof _fetchGeo === "function" ? _fetchGeo : defaultFetchGeo,
+    );
+    // Persisting here is what keeps this off the hot path: every later event in
+    // this project reads the cluster from app.json instead of forking `pac`.
+    if (cluster) identity.writeTelemetryCluster(projectRoot, cluster);
+  }
+
+  return cluster ? entryFromMap(regionsMap, cluster) : null;
+}
+
+module.exports = { resolve, deriveRegion };

--- a/plugins/mobile-apps/scripts/lib/telemetry/resolver.js
+++ b/plugins/mobile-apps/scripts/lib/telemetry/resolver.js
@@ -1,0 +1,18 @@
+"use strict";
+
+const { resolve: resolveRegion } = require("./region/region-resolver");
+
+function resolve({ cfg, projectRoot }) {
+  return resolveRegion({
+    projectRoot: projectRoot || "",
+    regionsMap: (cfg && cfg.regions) || {},
+  });
+}
+
+function isProvisioned(cfg) {
+  return Object.values((cfg && cfg.regions) || {}).some(
+    (entry) => entry && entry.instrumentation_key && entry.collector_url,
+  );
+}
+
+module.exports = { resolve, isProvisioned };

--- a/plugins/mobile-apps/scripts/tests/mobile-telemetry-region.test.js
+++ b/plugins/mobile-apps/scripts/tests/mobile-telemetry-region.test.js
@@ -1,0 +1,221 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const { resolve: resolveDestination } = require('../lib/telemetry/resolver');
+const { deriveRegion, resolve } = require('../lib/telemetry/region/region-resolver');
+const { urlFor } = require('../lib/telemetry/region/artemis-service');
+const { readTelemetryCluster, writeTelemetryCluster } = require('../lib/app-identity');
+
+const PLUGIN_ROOT = path.resolve(__dirname, '..', '..');
+const REAL_IKEY_PATH = path.join(PLUGIN_ROOT, 'scripts', 'lib', 'telemetry', 'ikey.json');
+const config = JSON.parse(fs.readFileSync(REAL_IKEY_PATH, 'utf8'));
+const orgId = '11111111-1111-1111-1111-111111111111';
+
+function project(t, telemetry) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'mobile-cluster-'));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  fs.writeFileSync(
+    path.join(root, 'app.json'),
+    JSON.stringify({ expo: { name: 'demo', extra: { telemetry } } }, null, 2),
+  );
+  return root;
+}
+
+const neverCalled = () => { throw new Error('must not run'); };
+
+test('Mobile declares the seven Power Apps telemetry destinations', () => {
+  assert.deepEqual(Object.keys(config.regions).sort(), [
+    'dod', 'eu', 'gov', 'high', 'internal', 'mooncake', 'us',
+  ]);
+});
+
+test('step 1: a cluster in app.json is used without touching pac or Artemis', async (t) => {
+  const root = project(t, { appInstanceId: null, cluster: 'eu' });
+  const destination = await resolve({
+    projectRoot: root,
+    regionsMap: config.regions,
+    _readPacAuth: neverCalled,
+    _fetchGeo: neverCalled,
+  });
+  assert.equal(destination.region, 'eu');
+  assert.equal(destination.iKey, config.regions.eu.instrumentation_key);
+  assert.equal(destination.collectorUrl, config.regions.eu.collector_url);
+});
+
+test('step 2: an unresolved cluster falls back to whoami and is persisted', async (t) => {
+  const root = project(t, { appInstanceId: null, cluster: null });
+  const destination = await resolve({
+    projectRoot: root,
+    regionsMap: config.regions,
+    _readPacAuth: () => ({ orgId, cloud: 'Public' }),
+    _fetchGeo: () => Promise.resolve({ geoName: 'eu', stamp: 'Public' }),
+  });
+  assert.equal(destination.region, 'eu');
+  assert.equal(readTelemetryCluster(root), 'eu');
+
+  // The persisted value is what makes later events skip the pac fork entirely.
+  const second = await resolve({
+    projectRoot: root,
+    regionsMap: config.regions,
+    _readPacAuth: neverCalled,
+    _fetchGeo: neverCalled,
+  });
+  assert.equal(second.region, 'eu');
+});
+
+test('step 3: still unresolved stays local', async (t) => {
+  const root = project(t, { appInstanceId: null, cluster: null });
+  const cases = [
+    { _readPacAuth: () => null, _fetchGeo: neverCalled },
+    { _readPacAuth: () => ({ orgId, cloud: 'Public' }), _fetchGeo: () => Promise.resolve(null) },
+    { _readPacAuth: () => ({ orgId, cloud: 'Public' }), _fetchGeo: () => Promise.reject(new Error('offline')) },
+    { _readPacAuth: () => ({ orgId, cloud: 'Public' }), _fetchGeo: () => Promise.resolve({ geoName: 'zz' }) },
+  ];
+  for (const seam of cases) {
+    assert.equal(await resolve({ projectRoot: root, regionsMap: config.regions, ...seam }), null);
+  }
+  assert.equal(readTelemetryCluster(root), '');
+  assert.equal(await resolveDestination({ cfg: config, projectRoot: '' }), null);
+});
+
+test('a hand-edited cluster is ignored rather than trusted', (t) => {
+  const root = project(t, { appInstanceId: null, cluster: 'moon-base' });
+  assert.equal(readTelemetryCluster(root), '');
+});
+
+test('persisting a cluster preserves unrelated app.json content', (t) => {
+  const root = project(t, { appInstanceId: 'keep-me', cluster: null });
+  writeTelemetryCluster(root, 'gov');
+  const appJson = JSON.parse(fs.readFileSync(path.join(root, 'app.json'), 'utf8'));
+  assert.equal(appJson.expo.name, 'demo');
+  assert.equal(appJson.expo.extra.telemetry.appInstanceId, 'keep-me');
+  assert.equal(appJson.expo.extra.telemetry.cluster, 'gov');
+});
+
+test('cloud and public geography map to the expected cluster', () => {
+  assert.equal(deriveRegion('Public', 'us'), 'us');
+  assert.equal(deriveRegion('Public', 'eu'), 'eu');
+  assert.equal(deriveRegion('UsGov', 'anything'), 'gov');
+  assert.equal(deriveRegion('UsGovHigh', 'anything'), 'high');
+  assert.equal(deriveRegion('UsGovDod', 'anything'), 'dod');
+  assert.equal(deriveRegion('China', 'anything'), 'mooncake');
+  assert.equal(deriveRegion('Tip1', 'anything'), 'internal');
+  assert.equal(deriveRegion('Public', 'unknown'), '');
+});
+
+test('Artemis endpoint follows the selected cloud', () => {
+  assert.match(urlFor(orgId, 'Public'), /organization\.api\.powerplatform\.com/);
+  assert.match(urlFor(orgId, 'UsGov'), /organization\.api\.gov\.powerplatform\.microsoft\.us/);
+  assert.match(urlFor(orgId, 'UsGovHigh'), /organization\.api\.high\.powerplatform\.microsoft\.us/);
+  assert.match(urlFor(orgId, 'UsGovDod'), /organization\.api\.appsplatform\.us/);
+  assert.match(urlFor(orgId, 'China'), /organization\.api\.powerplatform\.partner\.microsoftonline\.cn/);
+});
+
+function sleep(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function waitForJson(filePath) {
+  const deadline = Date.now() + 5000;
+  while (Date.now() < deadline) {
+    try {
+      return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    } catch {
+      // The detached dispatcher has not finished writing the probe yet.
+    }
+    sleep(25);
+  }
+  return null;
+}
+
+// The other tests inject seams. This one runs the real hook against the real
+// ikey.json so the shipped resolver.js is actually loaded and its regional keys
+// are the ones that reach the wire.
+test('end to end: the real hook routes to the cluster recorded in app.json', (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'mobile-region-e2e-'));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const projectRoot = path.join(root, 'project');
+  const configDir = path.join(root, 'config');
+  fs.mkdirSync(projectRoot, { recursive: true });
+  fs.mkdirSync(configDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(projectRoot, 'package.json'),
+    JSON.stringify({ dependencies: { expo: '^55', '@microsoft/power-apps-native-host': '^1' } }),
+  );
+  fs.writeFileSync(
+    path.join(projectRoot, 'app.json'),
+    JSON.stringify({ expo: { name: 'demo', extra: { telemetry: { appInstanceId: null, cluster: 'eu' } } } }),
+  );
+
+  const probePath = path.join(root, 'probe.json');
+  const result = spawnSync(
+    process.execPath,
+    [path.join(PLUGIN_ROOT, 'hooks', 'run-telemetry.js'), 'prompt'],
+    {
+      cwd: projectRoot,
+      input: JSON.stringify({ cwd: projectRoot, session_id: 'session-1', prompt: '/mobile-app:deploy' }),
+      encoding: 'utf8',
+      timeout: 20_000,
+      env: {
+        ...process.env,
+        POWER_PLATFORM_SKILLS_CONFIG_DIR: configDir,
+        POWER_PLATFORM_SKILLS_IKEY_JSON: REAL_IKEY_PATH,
+        // The probe keeps this off the network while still proving which key won.
+        POWER_PLATFORM_SKILLS_FAKE_HTTPS: probePath,
+        POWER_PLATFORM_SKILLS_TELEMETRY_MOBILE_APP_OPTOUT: '',
+      },
+    },
+  );
+
+  assert.equal(result.status, 0);
+  const probe = waitForJson(probePath);
+  assert.ok(probe, 'dispatcher should write the fake HTTPS probe');
+  assert.equal(probe.headers['x-apikey'], config.regions.eu.instrumentation_key);
+  assert.equal(probe.url, config.regions.eu.collector_url);
+  // US and EU share the production key, so the collector is the real discriminator.
+  assert.notEqual(config.regions.eu.collector_url, config.regions.us.collector_url);
+});
+
+test('end to end: an unresolvable cluster transmits nothing', (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'mobile-region-local-'));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const projectRoot = path.join(root, 'project');
+  const configDir = path.join(root, 'config');
+  fs.mkdirSync(projectRoot, { recursive: true });
+  fs.mkdirSync(configDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(projectRoot, 'app.json'),
+    JSON.stringify({ expo: { name: 'demo', extra: { telemetry: { appInstanceId: null, cluster: null } } } }),
+  );
+
+  const probePath = path.join(root, 'probe.json');
+  const result = spawnSync(
+    process.execPath,
+    [path.join(PLUGIN_ROOT, 'hooks', 'run-telemetry.js'), 'prompt'],
+    {
+      cwd: projectRoot,
+      input: JSON.stringify({ cwd: projectRoot, session_id: 'session-1', prompt: '/mobile-app:deploy' }),
+      encoding: 'utf8',
+      timeout: 20_000,
+      env: {
+        ...process.env,
+        POWER_PLATFORM_SKILLS_CONFIG_DIR: configDir,
+        POWER_PLATFORM_SKILLS_IKEY_JSON: REAL_IKEY_PATH,
+        POWER_PLATFORM_SKILLS_FAKE_HTTPS: probePath,
+        POWER_PLATFORM_SKILLS_TELEMETRY_MOBILE_APP_OPTOUT: '',
+        // No PAC on PATH, so step 2 cannot resolve and the event must stay local.
+        PATH: '',
+      },
+    },
+  );
+
+  assert.equal(result.status, 0);
+  sleep(1500);
+  assert.equal(fs.existsSync(probePath), false, 'nothing may be transmitted without a cluster');
+});

--- a/plugins/mobile-apps/template/app.json
+++ b/plugins/mobile-apps/template/app.json
@@ -2,7 +2,8 @@
   "expo": {
     "extra": {
       "telemetry": {
-        "appInstanceId": null
+        "appInstanceId": null,
+        "cluster": null
       },
       "appInsightsConfig": {
         "enabled": false,


### PR DESCRIPTION
## What

Mobile-apps telemetry posted every event to a single hard-coded collector. This adds Mobile-owned regional routing, so an event goes to the collector for the cluster the user's environment actually lives in.

## How

`ikey.json` becomes a `regions` map (`us`, `eu`, `gov`, `high`, `dod`, `mooncake`, `internal`), each with its own instrumentation key and collector URL, plus a thin `resolver.js` that selects the entry — the same shape Power Pages already uses.

Cluster resolution is three steps, in order:

1. Read `expo.extra.telemetry.cluster` from the project's `app.json`.
2. If absent, resolve it from `pac auth who` + the Artemis geo lookup, then write the result back to `app.json`.
3. If still unresolved, skip transmission for that event and try again on the next one.

Step 2 runs inside the detached dispatcher child, never on the hook's critical path, and only until the cluster is cached. `pac` is therefore forked at most once per project instead of once per checkpoint — the difference between a few seconds and roughly a minute of added latency over a full app-creation run.

The cluster is stored next to `appInstanceId` because `app.json` is already the per-project identity file. The value is validated against the known cluster list on read, so a hand-edited entry is ignored rather than trusted.

## Tests

10 new tests in `mobile-telemetry-region.test.js`, including two that exercise the real hook end to end against the committed `ikey.json`: one asserts an `eu` project reaches the EU collector, the other asserts an unresolvable cluster transmits nothing at all. Both assert on the destination URL rather than headers alone, because some clusters share an instrumentation key and differ only by collector.

Full mobile-apps suite passes (202 tests). `validate-telemetry-ikeys`, `validate-secure-process-execution`, and `validate-no-real-environments` pass. No files outside `plugins/mobile-apps/` are touched — shared telemetry and Power Pages are unchanged.
