### PR TITLE
[Pages] Add bidirectional design and localization integrity safeguards

### DIFF
--- a/plugins/power-pages/AGENTS.md
+++ b/plugins/power-pages/AGENTS.md
@@ -18,6 +18,7 @@ Read `PLUGIN_DEVELOPMENT_GUIDE.md` for UX and reliability standards when creatin
 - **Azure CLI `--allow-no-subscriptions`** — this flag is only valid on `az login`. Other `az` subcommands (`az account get-access-token`, `az account show`, etc.) reject it as an unrecognized argument and exit 2, so do NOT add it to anything other than `az login`. When the user is not logged in to the Azure CLI, suggest plain `az login` first; only suggest `az login --allow-no-subscriptions` as a fallback if they don't have any associated Azure subscription, since that variant lets subscription-less accounts sign in and still mint AAD-scoped Dataverse/Power Platform tokens via subsequent `az account get-access-token` calls. Reuse the shared `getAuthToken` helper in `scripts/lib/validation-helpers.js` instead of shelling out to `az` directly.
 - **Reference docs** shared across skills live in `references/` — reference via `${PLUGIN_ROOT}/references/` paths, don't duplicate.
 - **Bidirectional by default** — All generated sites must follow `references/bidirectional-design.md`: resolve direction from the locale's writing script, prefer CSS logical properties, isolate mixed-direction content, use script-capable font profiles, and classify directional assets instead of mirroring everything. Intentional physical CSS requires an adjacent `/* bidi-physical: <specific reason>; verify=ltr,rtl */` directive. Run `scripts/audit-bidirectional-readiness.js` for deterministic readiness findings.
+- **Preserve site integrity after creation** — Any skill or agent that changes visible SPA source must follow `references/site-modification-integrity.md`: synchronize new semantic keys across configured locale resources, preserve unavailable-locale boundaries, use direction-neutral UI, and design for text expansion. The centralized hook runs `scripts/validate-site-integrity.js` after source-mutating skills, and deployment runs it again as the backstop for manual edits.
 - **Templates** use `__PLACEHOLDER__` tokens (e.g., `__SITE_NAME__`) replaced during scaffolding. The `gitignore` file is stored without the dot prefix and renamed to `.gitignore` during scaffolding.
 - **Hooks** are defined centrally in `hooks/hooks.json`, using `PostToolUse` with matcher `Skill` so validation runs when a tracked Power Pages skill completes.
 - **ALM split-decision thresholds** are intentionally tighter than the platform hard caps. `scripts/lib/alm-thresholds.js` recommends a split at 75 MB / 4000 components (vs platform caps of 95 MB / 6000), reserving ~20 MB / ~2000-component growth headroom in each split child. Override per-project via `.alm-config.json` if you have a justified reason to push closer to the caps.
@@ -41,6 +42,7 @@ agents/
 scripts/
   generate-uuid.js             ← Shared UUID v4 generator (used by multiple skills)
   audit-bidirectional-readiness.js ← Audits generated source for deterministic bidirectional blockers and review findings
+  validate-site-integrity.js ← Shared post-modification/deployment localization and bidirectional integrity check
   validate-i18n-package.js      ← Validates npm localization package compatibility, stability, maintenance, mode, docs, and license
   check-activation-status.js   ← Checks if site is already activated (used by deploy-site, activate-site)
   poll-async-operation.js      ← Polls Dataverse asyncoperations until terminal state (used by export-solution, import-solution)
@@ -50,6 +52,7 @@ references/                    ← Shared reference docs used by multiple skills
   odata-common.md              ← Auth headers, token refresh, error handling, retry patterns
   bcp47-subtags.json           ← Bundled IANA Language Subtag Registry snapshot
   bidirectional-design.md      ← Shared LTR/RTL design, typography, content, component, coordinator, and testing standard
+  site-modification-integrity.md ← Shared lifecycle contract for localized, direction-safe, expansion-safe site edits
   i18n-frameworks.md           ← Framework localization modes, packages, resources, selector behavior, and manifest schema
   dataverse-prerequisites.md   ← PAC CLI check, Azure CLI token, API access verification
   framework-conventions.md     ← Framework detection, paths, route discovery

--- a/plugins/power-pages/AGENTS.md
+++ b/plugins/power-pages/AGENTS.md
@@ -17,6 +17,7 @@ Read `PLUGIN_DEVELOPMENT_GUIDE.md` for UX and reliability standards when creatin
 - **Dataverse-backed validation** must stay opt-in for local runs only. Do not require live Dataverse connectivity in CI workflows or default test runs; gate it behind explicit local flags such as `--validate-dataverse-relationships`.
 - **Azure CLI `--allow-no-subscriptions`** — this flag is only valid on `az login`. Other `az` subcommands (`az account get-access-token`, `az account show`, etc.) reject it as an unrecognized argument and exit 2, so do NOT add it to anything other than `az login`. When the user is not logged in to the Azure CLI, suggest plain `az login` first; only suggest `az login --allow-no-subscriptions` as a fallback if they don't have any associated Azure subscription, since that variant lets subscription-less accounts sign in and still mint AAD-scoped Dataverse/Power Platform tokens via subsequent `az account get-access-token` calls. Reuse the shared `getAuthToken` helper in `scripts/lib/validation-helpers.js` instead of shelling out to `az` directly.
 - **Reference docs** shared across skills live in `references/` — reference via `${PLUGIN_ROOT}/references/` paths, don't duplicate.
+- **Bidirectional by default** — All generated sites must follow `references/bidirectional-design.md`: resolve direction from the locale's writing script, prefer CSS logical properties, isolate mixed-direction content, use script-capable font profiles, and classify directional assets instead of mirroring everything. Intentional physical CSS requires an adjacent `/* bidi-physical: <specific reason>; verify=ltr,rtl */` directive. Run `scripts/audit-bidirectional-readiness.js` for deterministic readiness findings.
 - **Templates** use `__PLACEHOLDER__` tokens (e.g., `__SITE_NAME__`) replaced during scaffolding. The `gitignore` file is stored without the dot prefix and renamed to `.gitignore` during scaffolding.
 - **Hooks** are defined centrally in `hooks/hooks.json`, using `PostToolUse` with matcher `Skill` so validation runs when a tracked Power Pages skill completes.
 - **ALM split-decision thresholds** are intentionally tighter than the platform hard caps. `scripts/lib/alm-thresholds.js` recommends a split at 75 MB / 4000 components (vs platform caps of 95 MB / 6000), reserving ~20 MB / ~2000-component growth headroom in each split child. Override per-project via `.alm-config.json` if you have a justified reason to push closer to the caps.
@@ -39,6 +40,7 @@ agents/
   ai-webapi-settings-architect.md ← Agent: proposes Summarization/* site settings (read-only)
 scripts/
   generate-uuid.js             ← Shared UUID v4 generator (used by multiple skills)
+  audit-bidirectional-readiness.js ← Audits generated source for deterministic bidirectional blockers and review findings
   validate-i18n-package.js      ← Validates npm localization package compatibility, stability, maintenance, mode, docs, and license
   check-activation-status.js   ← Checks if site is already activated (used by deploy-site, activate-site)
   poll-async-operation.js      ← Polls Dataverse asyncoperations until terminal state (used by export-solution, import-solution)
@@ -47,6 +49,7 @@ scripts/
 references/                    ← Shared reference docs used by multiple skills
   odata-common.md              ← Auth headers, token refresh, error handling, retry patterns
   bcp47-subtags.json           ← Bundled IANA Language Subtag Registry snapshot
+  bidirectional-design.md      ← Shared LTR/RTL design, typography, content, component, coordinator, and testing standard
   i18n-frameworks.md           ← Framework localization modes, packages, resources, selector behavior, and manifest schema
   dataverse-prerequisites.md   ← PAC CLI check, Azure CLI token, API access verification
   framework-conventions.md     ← Framework detection, paths, route discovery
@@ -59,7 +62,7 @@ skills/
     SKILL.md                   ← Skill definition with frontmatter (model, allowed-tools)
     assets/{react,vue,angular,astro}/  ← Framework templates with __PLACEHOLDER__ tokens
     references/design-aesthetics.md  ← Design principles, font/color/motion guidance for inline design step
-    scripts/validate-site.js   ← Node script validating generated sites
+    scripts/validate-site.js   ← Validates generated sites, root locale direction, and deterministic bidirectional blockers
   deploy-site/
     SKILL.md                   ← Deployment skill definition
   setup-datamodel/
@@ -74,7 +77,7 @@ skills/
     scripts/validate-seo.js    ← Node script validating SEO assets (robots.txt, sitemap.xml, meta tags)
   add-localization/
     SKILL.md                   ← SPA localization workflow for React, Vue, Angular, and Astro
-    scripts/validate-localization.js ← Validates manifest, locales, resources, tokens, selector, lang, and dir
+    scripts/validate-localization.js ← Validates manifest, resources, selectors, lang/dir, opposite-direction readiness, and runtime coordinators
   activate-site/
     SKILL.md                   ← Site activation/provisioning skill definition
     scripts/activate-site.js   ← Activates a site via PP API + polls status

--- a/plugins/power-pages/README.md
+++ b/plugins/power-pages/README.md
@@ -401,6 +401,8 @@ Power Pages code-site SPAs.
   switching; runtime React, Vue, and Angular sites use a locale coordinator
 - Keeps an unsafe new locale unavailable for later remediation, or records
   explicit approval for usable non-blocking limitations
+- Revalidates localization resources, bidirectional source rules, and text-expansion risks after
+  later UI-modifying skills and again before deployment
 - Localizes only the SPA UI; it does not enable Dataverse environment languages
 
 #### `/add-seo`

--- a/plugins/power-pages/README.md
+++ b/plugins/power-pages/README.md
@@ -49,6 +49,8 @@ The plugin provides 35 skills that cover the full lifecycle of a Power Pages sit
 Scaffolds a complete code site from a framework template, applies your design direction (fonts, colors, layout), builds out pages and components, and provides a live preview in the browser throughout development.
 
 - Choose from React, Vue, Angular, or Astro
+- Direction-neutral layouts work with LTR and RTL writing systems from the start
+- Script-aware fonts, locale-aware formatting, and mixed-direction content safety
 - Real images from Unsplash (no placeholders)
 - Live browser preview during development
 - Git commits at each milestone
@@ -391,7 +393,14 @@ Power Pages code-site SPAs.
   for Angular, and built-in static locale routes for Astro
 - Generates translations with the agent or creates blank values for manual
   completion
-- Adds an accessible language selector with fallback and RTL handling
+- Resolves direction from each locale's writing script, including languages
+  written in multiple scripts
+- Audits the first opposite-direction locale and remediates blocking layout,
+  component, asset, mixed-content, and font issues
+- Adds an accessible language selector with fallback and safe runtime LTR/RTL
+  switching; runtime React, Vue, and Angular sites use a locale coordinator
+- Keeps an unsafe new locale unavailable for later remediation, or records
+  explicit approval for usable non-blocking limitations
 - Localizes only the SPA UI; it does not enable Dataverse environment languages
 
 #### `/add-seo`
@@ -533,6 +542,7 @@ Several skills now ask about solution identity, orphan components, and pre-expor
 - [PAC CLI Reference](https://learn.microsoft.com/power-platform/developer/cli/reference/pages)
 - [Power Pages REST API](https://learn.microsoft.com/rest/api/power-platform/powerpages/websites)
 - [Dataverse Web API](https://learn.microsoft.com/power-apps/developer/data-platform/webapi/overview)
+- [Bidirectional design standard](references/bidirectional-design.md)
 - [ALM prompts — user guide](references/alm-prompts.md)
 
 ## Testing validator scripts

--- a/plugins/power-pages/agents/ai-webapi-integration.md
+++ b/plugins/power-pages/agents/ai-webapi-integration.md
@@ -40,6 +40,11 @@ wire into UI, no duplicate helpers). The Microsoft-shipped support-case Copilot 
 configuration of Data Summarization (specific entity set, `$select`/`$expand`, and prompt
 identifier), not a third endpoint.
 
+Before changing any page or component, read
+`${PLUGIN_ROOT}/references/site-modification-integrity.md`. Localize summary labels, loading,
+empty, error, citation, and remediation states across every configured locale, and keep the
+resulting UI bidirectional and safe for text expansion.
+
 ## Reference docs
 
 Read these first — they have the authoritative API shapes, headers, request bodies, and error

--- a/plugins/power-pages/agents/webapi-integration.md
+++ b/plugins/power-pages/agents/webapi-integration.md
@@ -27,6 +27,11 @@ tools:
 
 You are a Power Pages Web API integration specialist. Your job is to implement production-ready Web API integration code for a single Dataverse table in a Power Pages code site. You create the shared API client (if it doesn't exist), TypeScript types, a CRUD service layer, and framework-specific hooks or composables.
 
+Before changing any page or component, read
+`${PLUGIN_ROOT}/references/site-modification-integrity.md`. If a localization manifest exists,
+localize every new visible state and synchronize all configured resources; every UI change must
+also remain bidirectional and safe for text expansion.
+
 ## Workflow
 
 1. **Analyze Site** — Detect the framework, find existing API patterns, locate the source directory

--- a/plugins/power-pages/hooks/run-skill-posttool-validation.js
+++ b/plugins/power-pages/hooks/run-skill-posttool-validation.js
@@ -6,7 +6,9 @@ const { spawnSync } = require('child_process');
 const {
   getTrackedSkillFromToolInput,
   getValidatorScript,
+  getBlockingSpawnStatus,
   isAlmPlanSkill,
+  modifiesVisibleSource,
 } = require('../scripts/lib/powerpages-hook-utils');
 const { planDataPath } = require('../scripts/lib/alm-paths');
 
@@ -51,8 +53,36 @@ process.stdin.on('end', () => {
       });
       if (result.stdout) process.stdout.write(result.stdout);
       if (result.stderr) process.stderr.write(result.stderr);
-      validatorStatus = result.status ?? 0;
+      validatorStatus = getBlockingSpawnStatus(result);
+      if (result.error || result.signal) {
+        process.stderr.write(
+          `[power-pages] Skill validator did not complete: ` +
+          `${result.error?.message || `signal ${result.signal}`}.\n`
+        );
+      }
       debug(`[power-pages hook] Validator exited with code ${validatorStatus}\n`);
+    }
+
+    // A skill-specific validator knows its own artifacts, but cannot enforce
+    // cross-cutting localization and direction invariants. Run the shared pass
+    // only after that validator succeeds so its error remains the primary result.
+    if (validatorStatus === 0 && modifiesVisibleSource(skillName)) {
+      const integrityPath = path.join(__dirname, '..', 'scripts', 'validate-site-integrity.js');
+      const integrity = spawnSync(
+        process.execPath,
+        [integrityPath, '--projectRoot', cwd],
+        { encoding: 'utf8', cwd }
+      );
+      if (integrity.stdout) process.stdout.write(integrity.stdout);
+      if (integrity.stderr) process.stderr.write(integrity.stderr);
+      validatorStatus = getBlockingSpawnStatus(integrity);
+      if (integrity.error || integrity.signal) {
+        process.stderr.write(
+          `[power-pages] Site integrity validator did not complete: ` +
+          `${integrity.error?.message || `signal ${integrity.signal}`}.\n`
+        );
+      }
+      debug(`[power-pages hook] Site integrity exited with code ${validatorStatus}\n`);
     }
 
     // ALM plan reconcile backstop (auto-heal). The refresh-alm-plan-data.js calls

--- a/plugins/power-pages/references/bidirectional-design.md
+++ b/plugins/power-pages/references/bidirectional-design.md
@@ -1,0 +1,185 @@
+# Bidirectional Design Standard
+
+Use this standard for every Power Pages code site, including sites that start
+with only one LTR or RTL language. Bidirectional readiness is a design
+foundation, not a retrofit performed only after an opposite-direction locale is
+added.
+
+## Locale, script, and direction
+
+- Canonicalize locale tags as BCP-47.
+- Resolve direction from the locale's explicit or likely writing script. Do not
+  maintain a language-only RTL allowlist.
+- Set both `lang` and `dir` on the root `<html>` element. `lang` controls
+  linguistic behavior; `dir` controls base text and layout direction.
+- For a single-language site, the root document is the persisted source of
+  truth. Do not create localization infrastructure until localization is added.
+
+References:
+
+- https://www.w3.org/International/articles/language-tags/
+- https://www.w3.org/TR/css-writing-modes-3/#text-direction
+- https://www.unicode.org/reports/tr35/
+
+## Direction-neutral layout
+
+Use logical CSS whenever placement follows reading direction:
+
+| Physical declaration | Logical declaration |
+|---|---|
+| `margin-left/right` | `margin-inline-start/end` |
+| `padding-left/right` | `padding-inline-start/end` |
+| `left/right` | `inset-inline-start/end` |
+| `border-left/right` | `border-inline-start/end` |
+| physical corner radii | `border-start/end-start/end-radius` |
+| `text-align: left/right` | `text-align: start/end` |
+| `width` for flow-relative sizing | `inline-size` |
+
+Keep meaningful reading and focus sequence in DOM order. Do not simulate RTL
+with reversed arrays, `row-reverse`, or `order`. A flex row already follows its
+inherited inline direction.
+
+Some geometry is intentionally physical: centering, maps, media timelines,
+fixed lighting and shadows, charts with a fixed domain axis, or a product
+requirement that keeps a control in one physical corner. Keep such behavior
+only after verifying both directions and add an adjacent directive:
+
+```css
+/* bidi-physical: Map controls remain at physical right by product requirement; verify=ltr,rtl */
+right: 1rem;
+```
+
+The directive applies only to the immediately following declaration. It must
+contain a specific reason and `verify=ltr,rtl`; file-wide suppression is not
+allowed.
+
+Transforms, animation coordinates, gradients, shadows, clipping, canvas, SVG,
+charts, horizontal scrolling, and third-party positioning do not become
+logical automatically. Review their semantic direction component by component.
+
+Reference: https://www.w3.org/TR/css-logical-1/
+
+## Mixed-direction content
+
+Classify inserted content at its rendering boundary:
+
+- Translated UI content inherits the active document direction.
+- Unknown or user-authored content such as names, comments, titles, and search
+  queries uses `<bdi>` or `dir="auto"`.
+- Machine-oriented values such as URLs, email addresses, source code, file
+  paths, GUIDs, and Latin identifiers use an isolated explicit direction,
+  normally `dir="ltr"`.
+- Never reverse strings. Format numbers, dates, currency, percentages, and
+  relative time with `Intl` APIs for the active locale.
+
+Use `dir="auto"` on free-form multilingual inputs. Use the `dirname` form
+attribute when the submitted value's detected direction must be preserved.
+
+References:
+
+- https://www.w3.org/International/questions/qa-html-dir
+- https://www.w3.org/International/articles/inline-bidi-markup/
+- https://www.unicode.org/reports/tr9/
+
+## Typography and content flexibility
+
+- Select fonts for the scripts used by configured locales, including shaping,
+  glyph coverage, weights, combining marks, and punctuation.
+- Reuse one font profile across languages when it supports their scripts well.
+  Add script-specific profiles only when necessary, with locale-specific
+  overrides for genuine typographic differences such as Urdu Nasta'liq.
+- Preserve the site's visual character across script profiles.
+- Do not rely on capitalization, Latin-style italics, or letter spacing for
+  hierarchy. Avoid arbitrary letter spacing on cursive scripts.
+- Avoid fixed-height text containers. Allow navigation, buttons, validation,
+  cards, and headings to wrap and accommodate translated text expansion.
+- For runtime localization, prepare a required target-script font before
+  committing the visible locale switch when late loading would cause a
+  significant layout shift.
+
+References:
+
+- https://www.w3.org/International/articles/typography/fontstyles.en.html
+- https://www.w3.org/TR/alreq/
+
+## Components, icons, and assets
+
+Give every direction-sensitive component an explicit contract:
+
+- Navigation, drawers, tabs, pagination, breadcrumbs, forms, calendars,
+  date-pickers, carousels, timelines, charts, drag/drop, and gestures must be
+  reviewed in both directions.
+- Mirror icons whose meaning follows inline progression, such as previous/next
+  and breadcrumb chevrons.
+- Keep logos, maps, photographs, status marks, clocks, and media controls
+  unchanged unless their specific semantics require otherwise.
+- Classify images and illustrations as unchanged, mirrored, or replaced with a
+  localized asset. Never mirror embedded text or trademarks.
+- Decide whether table and chart order is linguistic or domain-fixed. Do not
+  mirror chronological, scientific, or geographic meaning automatically.
+- Native controls and scrollbars should inherit direction; custom horizontal
+  scrolling must use semantic start/end operations rather than raw assumptions
+  about `scrollLeft`.
+
+Reference: https://learn.microsoft.com/en-us/globalization/fonts-layout/mirroring
+
+## Localization modes and scoped coordination
+
+- Single-language sites use static root `lang`/`dir` and do not receive a
+  locale coordinator.
+- Angular static localization and Astro built-in localization use
+  locale-specific outputs/routes and do not receive a runtime coordinator.
+- React, Vue, and runtime Angular use one locale coordinator as the authority
+  for active locale, messages, canonical `lang`, resolved `dir`, script font
+  profile, metadata, fallback, and persistence.
+- A runtime switch prepares resources first and then commits locale-dependent
+  state together. Stale requests cannot overwrite a newer selection.
+- Add direction-change notifications only for components that cache physical
+  geometry, such as charts, carousels, virtualized lists, grids, and overlays.
+
+## First opposite-direction locale
+
+When a locale set first changes from LTR-only or RTL-only to mixed direction,
+run the bidirectional-readiness audit before implementation approval. Include
+safe remediation, intentional physical exceptions, typography, assets,
+mixed-content boundaries, and complex component behavior in the plan.
+
+Use a tiered disposition:
+
+- Build/runtime failures, incorrect `lang`/`dir`, unreadable text, unreachable
+  critical controls, and serious accessibility failures keep the new locale
+  unavailable to end users until fixed.
+- Usable limitations may proceed only after the maker reviews the exact impact
+  and explicitly approves enabling the locale with documented limitations.
+- The maker may preserve localization work while keeping the locale
+  unavailable for later remediation.
+
+Unavailable locale resources may remain on disk, but one managed
+`localeAvailability` module must export an `isLocaleAvailable` predicate that
+excludes those locales. Selectors, browser detection and switching,
+alternate-language metadata, and production static output must all apply it.
+The manifest is a record of that state, not the mechanism that enforces it.
+While hard bidirectional blockers remain, every configured locale opposite to
+the default locale's direction stays unavailable.
+
+Do not describe a technically broken or inaccessible locale as successfully
+enabled.
+
+## Verification
+
+- Audit every generated or modified site, not only the first RTL locale.
+- Test every representative route in LTR and RTL at desktop and narrow/mobile
+  viewports.
+- For runtime modes, test LTR -> RTL -> LTR and RTL -> LTR -> RTL without
+  reload, stale requests, route loss, form-state loss, or focus loss.
+- Verify calendars, gestures, overlays, charts, mixed-direction fixtures,
+  script fonts, localized formatting, console output, and accessibility.
+- Use expanded pseudo-LTR and pseudo-RTL content during site creation so future
+  localization defects are found before real translations exist.
+- Scan source and identifiers for unexpected Unicode bidi controls. Normal
+  translated prose may legitimately contain controls; source-code exceptions
+  require deliberate review.
+
+High-visibility marketing, onboarding, legal, and brand content should receive
+native-speaker or regional review before publication. Technical
+bidirectionality does not replace cultural localization.

--- a/plugins/power-pages/references/i18n-frameworks.md
+++ b/plugins/power-pages/references/i18n-frameworks.md
@@ -80,13 +80,33 @@ Store only the canonical locale string in `localStorage` under a
 site-specific key. This is browser-local preference data; do not write it to
 Dataverse or associate it with the signed-in user.
 
-When the visitor changes language:
+Generate one locale coordinator for runtime-localized sites. Single-language
+sites and static localization modes do not receive this infrastructure. The
+coordinator is the only owner of active locale changes.
 
-- Change the localization library's active locale without reloading.
-- Persist the canonical locale.
-- Set `document.documentElement.lang`.
-- Set `document.documentElement.dir` to `rtl` or `ltr`.
-- Fall back to the default locale for missing values.
+Required coordinator paths:
+
+- React/Vue: `src/i18n/localeCoordinator.ts`
+- Angular runtime: follow the existing i18n service directory, otherwise
+  `src/app/i18n/locale-coordinator.service.ts`
+
+The coordinator must expose a public `switchLocale` operation and:
+
+1. Canonicalize and validate the requested supported locale.
+2. Prepare messages and any required target-script font before visible change.
+3. Cancel or invalidate stale switch requests.
+4. Activate the localization library locale without reloading.
+5. Set `document.documentElement.lang` and `.dir` from the same resolved locale.
+6. Apply the locale/script font profile and localized metadata when configured.
+7. Persist the canonical locale only after a successful commit.
+8. Fall back to the default locale for invalid saved values and missing messages.
+
+Add direction-change subscriptions only when components cache physical
+geometry, such as charts, carousels, virtualized lists, grids, or overlays.
+Ordinary components using logical CSS need no subscription.
+
+The language selector calls the coordinator; it must not independently mutate
+the localization library, `lang`, `dir`, or persistence.
 
 ## Static locale behavior
 
@@ -190,6 +210,11 @@ Write `.powerpages-localization.json` after implementation using this shape:
   },
   "generatedFiles": ["src/components/LanguageSelector.tsx"],
   "managedFiles": ["src/i18n/index.ts", "src/main.tsx"],
+  "unavailableLocales": [],
+  "bidirectionalReadiness": {
+    "status": "ready",
+    "findings": []
+  },
   "adoptedExistingConfiguration": false,
   "lastOperation": "create",
   "updatedAt": "2026-07-30T00:00:00.000Z"
@@ -215,6 +240,25 @@ Use the project's declared `astro` dependency or devDependency value for
 to its source/target XLF file. Keep paths repository-relative. Set
 `translationMethod` to `"agent"` or `"blank"` so validation can distinguish
 intentional empty targets from broken translations.
+
+`unavailableLocales` is optional and contains configured locale tags that have
+resources on disk for development/remediation but must not be selectable,
+auto-detected, advertised, or deployed as production static output. The
+implementation must expose one managed `localeAvailability` module with an
+`isLocaleAvailable` predicate that rejects the unavailable set. Every selector,
+switch/detection path, alternate-language metadata generator, and static output
+configuration must apply that predicate; recording the array in the manifest
+does not disable a locale by itself. During `pending-remediation`, all
+configured locales opposite to the default locale's direction must remain
+unavailable.
+`bidirectionalReadiness` is optional for same-direction locale sets and required
+when the configured set contains both LTR and RTL:
+
+- `ready` — no unresolved compatibility findings.
+- `approved-with-limitations` — the experience remains functional, readable,
+  accurate, and accessible; the maker explicitly accepted documented limits.
+- `pending-remediation` — hard compatibility work remains; affected locales
+  belong in `unavailableLocales` and managed availability logic.
 
 Schema version 1 includes `packageVerification`:
 

--- a/plugins/power-pages/references/i18n-frameworks.md
+++ b/plugins/power-pages/references/i18n-frameworks.md
@@ -260,6 +260,11 @@ when the configured set contains both LTR and RTL:
 - `pending-remediation` — hard compatibility work remains; affected locales
   belong in `unavailableLocales` and managed availability logic.
 
+Each pending finding must preserve the exact scanner result with `file`, `line`, `rule`, and
+`message`.
+Only those recorded physical-layout blockers are deferred by lifecycle validation; newly
+introduced findings, invisible bidi controls, and invalid exception directives still block.
+
 Schema version 1 includes `packageVerification`:
 
 - Known recommendations use `status: "verified"` and

--- a/plugins/power-pages/references/site-modification-integrity.md
+++ b/plugins/power-pages/references/site-modification-integrity.md
@@ -1,0 +1,66 @@
+# Site Modification Integrity
+
+Apply this contract whenever a skill, agent, or manual change adds or changes visible SPA
+content after site creation. It keeps localization and bidirectional behavior as lifecycle
+properties rather than one-time scaffolding tasks.
+
+## Before editing
+
+1. Locate the code-site root by finding `powerpages.config.json`.
+2. Read `.powerpages-localization.json` when it exists. Do not create localization infrastructure
+   merely because a site is single-language.
+3. Read `references/bidirectional-design.md`. Preserve the site's established framework,
+   component patterns, design system, and localization package.
+
+## Visible content
+
+When a localization manifest exists:
+
+- Put every new user-visible string behind a stable semantic translation key. This includes page
+  copy, navigation, buttons, headings, form labels, placeholders, validation messages, loading,
+  empty and error states, dialog text, image alternatives, accessible names, document titles, and
+  visible metadata.
+- Add each key to every configured locale resource. Preserve existing keys and translations.
+- Follow `translationMethod`: generate a translation for `agent`; add an empty target value for
+  `blank`. Never copy source-language prose into a target locale as if it were translated.
+- Preserve interpolation variables, markup placeholders, and protected tokens exactly.
+- For static localization, update the localized route/page output required by the framework.
+- Do not expose a locale listed in `unavailableLocales` through selectors, auto-detection,
+  alternate links, navigation, or generated production routes.
+
+When no localization manifest exists, keep visible strings organized so `/add-localization` can
+extract them later, but do not introduce an i18n dependency or manifest.
+
+## Direction and layout
+
+- Use logical CSS properties and direction-neutral component APIs. An intentional physical
+  declaration needs the adjacent exception documented by `bidirectional-design.md`.
+- Keep DOM, reading, focus, and visual order aligned. Do not use CSS reversal to simulate RTL.
+- Isolate user-generated or externally sourced mixed-direction values using semantic `dir`
+  handling, normally `dir="auto"` at the smallest useful boundary.
+- Use the active locale for `Intl` formatting and the locale coordinator for runtime language,
+  direction, font-profile, and geometry-change updates.
+- Classify new directional images or icons as unchanged, mirrored, or replaced. Do not mirror
+  text, trademarks, media controls, or universally directional symbols.
+
+## Content expansion
+
+Design text containers to wrap and grow:
+
+- Avoid fixed width or height on containers that hold translated text.
+- Allow labels, buttons, navigation, cards, tables, dialogs, and form errors to reflow.
+- Prefer flexible min/max constraints and test long strings, narrow viewports, zoom, and both
+  directions. Truncation is acceptable only when the full value remains accessible.
+
+## Completion
+
+Run the normal skill validator, then:
+
+```bash
+node "${PLUGIN_ROOT}/scripts/validate-site-integrity.js" --projectRoot "<PROJECT_ROOT>"
+```
+
+Deterministic localization or bidirectional errors block completion. Review findings such as
+fixed text geometry, visual reordering, transforms, gradients, and clipping must be inspected in
+both directions and with expanded content; they do not fail the command by themselves. Deployment
+runs the same validator as a final backstop for changes made outside a skill.

--- a/plugins/power-pages/scripts/audit-bidirectional-readiness.js
+++ b/plugins/power-pages/scripts/audit-bidirectional-readiness.js
@@ -15,7 +15,9 @@ function parseArgs(argv) {
 function main() {
   const args = parseArgs(process.argv.slice(2));
   const projectRoot = path.resolve(args.projectRoot || process.cwd());
-  process.stdout.write(`${JSON.stringify(auditBidirectionalReadiness(projectRoot), null, 2)}\n`);
+  const result = auditBidirectionalReadiness(projectRoot);
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  if (result.summary.error > 0) process.exitCode = 1;
 }
 
 if (require.main === module) main();

--- a/plugins/power-pages/scripts/audit-bidirectional-readiness.js
+++ b/plugins/power-pages/scripts/audit-bidirectional-readiness.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+'use strict';
+
+const path = require('path');
+const { auditBidirectionalReadiness } = require('./lib/bidirectional-readiness');
+
+function parseArgs(argv) {
+  const args = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    if (argv[index] === '--projectRoot') args.projectRoot = argv[index + 1];
+  }
+  return args;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const projectRoot = path.resolve(args.projectRoot || process.cwd());
+  process.stdout.write(`${JSON.stringify(auditBidirectionalReadiness(projectRoot), null, 2)}\n`);
+}
+
+if (require.main === module) main();
+
+module.exports = { parseArgs };

--- a/plugins/power-pages/scripts/audit-bidirectional-readiness.js
+++ b/plugins/power-pages/scripts/audit-bidirectional-readiness.js
@@ -3,14 +3,14 @@
 
 const path = require('path');
 const { auditBidirectionalReadiness } = require('./lib/bidirectional-readiness');
+const {
+  parseOptionalProjectRootArgs,
+} = require('./lib/cli-arguments');
 
-function parseArgs(argv) {
-  const args = {};
-  for (let index = 0; index < argv.length; index += 1) {
-    if (argv[index] === '--projectRoot') args.projectRoot = argv[index + 1];
-  }
-  return args;
-}
+const USAGE =
+  'Usage: audit-bidirectional-readiness.js [--projectRoot <path>]';
+
+const parseArgs = (argv) => parseOptionalProjectRootArgs(argv, USAGE);
 
 function main() {
   const args = parseArgs(process.argv.slice(2));
@@ -20,6 +20,13 @@ function main() {
   if (result.summary.error > 0) process.exitCode = 1;
 }
 
-if (require.main === module) main();
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 2;
+  }
+}
 
 module.exports = { parseArgs };

--- a/plugins/power-pages/scripts/lib/bidirectional-readiness.js
+++ b/plugins/power-pages/scripts/lib/bidirectional-readiness.js
@@ -1,0 +1,245 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const SOURCE_EXTENSIONS = new Set([
+  '.css', '.scss', '.less', '.js', '.jsx', '.ts', '.tsx', '.vue', '.astro', '.html',
+]);
+const SKIPPED_DIRECTORIES = new Set([
+  '.git', 'dist', 'build', 'node_modules', '.output', 'coverage',
+]);
+const PHYSICAL_DIRECTIVE_RE =
+  /bidi-physical:\s*(\S(?:.*\S)?)\s*;\s*verify=ltr,rtl\s*(?:\*\/)?\s*$/i;
+const BLOCKING_PROPERTY_RE =
+  /(?:^|[;{,"'])\s*['"]?(?:(?:margin|padding|border)-(?:left|right)(?:-(?:color|style|width))?|border-(?:top|bottom)-(?:left|right)-radius)['"]?\s*:/gi;
+const BLOCKING_STYLE_OBJECT_PROPERTY_RE =
+  /(?:^|[,{])\s*['"]?(?:(?:margin|padding|border)(?:Left|Right)(?:Color|Style|Width)?|border(?:Top|Bottom)(?:Left|Right)Radius)['"]?\s*:/g;
+const BLOCKING_ALIGNMENT_RE =
+  /(?:^|[;{,"'])\s*['"]?(?:text-align|textAlign|float|clear)['"]?\s*:\s*['"]?(?:left|right)['"]?\s*(?:[;,!}]|$)/gi;
+const REVIEW_PROPERTY_RE = /(?:^|[;{,"'])\s*['"]?(?:left|right)['"]?\s*:/gi;
+const VISUAL_ORDER_RE =
+  /\b(?:flex-direction\s*:\s*(?:row|column)-reverse|order\s*:\s*-?\d+)/i;
+const GEOMETRY_RE =
+  /\b(?:translateX|transform-origin|linear-gradient\s*\([^)]*(?:left|right)|clip-path|mask(?:-image)?\s*:)/i;
+const FIXED_TEXT_SIZE_RE =
+  /^\s*(?:height|width|inline-size|block-size)\s*:\s*\d+(?:\.\d+)?(?:px|rem|em)\s*;/i;
+const BIDI_CONTROL_RE = /[\u061c\u200e\u200f\u202a-\u202e\u2066-\u2069]/u;
+
+function collectSourceFiles(projectRoot) {
+  const roots = ['src', 'public'].map((name) => path.join(projectRoot, name));
+  for (const entry of ['index.html']) {
+    const candidate = path.join(projectRoot, entry);
+    if (fs.existsSync(candidate)) roots.push(candidate);
+  }
+  const files = [];
+  for (const root of roots) walk(root, files);
+  return files;
+}
+
+function walk(target, files) {
+  if (!fs.existsSync(target)) return;
+  const stat = fs.statSync(target);
+  if (stat.isFile()) {
+    if (SOURCE_EXTENSIONS.has(path.extname(target).toLowerCase())) files.push(target);
+    return;
+  }
+  for (const entry of fs.readdirSync(target, { withFileTypes: true })) {
+    if (entry.isDirectory() && SKIPPED_DIRECTORIES.has(entry.name)) continue;
+    walk(path.join(target, entry.name), files);
+  }
+}
+
+function auditBidirectionalReadiness(projectRoot) {
+  const findings = [];
+  for (const filePath of collectSourceFiles(projectRoot)) {
+    const relativePath = path.relative(projectRoot, filePath).replaceAll('\\', '/');
+    const lines = fs.readFileSync(filePath, 'utf8').split(/\r?\n/);
+    let pendingDirective = null;
+
+    for (let index = 0; index < lines.length; index += 1) {
+      const line = lines[index];
+      const trimmed = line.trim();
+      const directiveMatch = trimmed.match(PHYSICAL_DIRECTIVE_RE);
+      if (directiveMatch) {
+        const reason = directiveMatch[1].trim();
+        if (reason.length < 12 || /^(?:needed|intentional|required|exception)$/i.test(reason)) {
+          findings.push(finding(
+            relativePath,
+            index + 1,
+            'invalid-physical-exception',
+            'error',
+            'A bidi-physical directive requires a specific reason of at least 12 characters.'
+          ));
+          continue;
+        }
+        pendingDirective = {
+          line: index + 1,
+          reason,
+        };
+        continue;
+      }
+      if (/bidi-physical:/i.test(trimmed)) {
+        findings.push(finding(
+          relativePath,
+          index + 1,
+          'invalid-physical-exception',
+          'error',
+          'Use "bidi-physical: <specific reason>; verify=ltr,rtl" immediately before one declaration.'
+        ));
+        continue;
+      }
+
+      if (!trimmed || trimmed.startsWith('//') ||
+          (trimmed.startsWith('/*') && trimmed.endsWith('*/'))) {
+        if (pendingDirective && !trimmed) {
+          findings.push(finding(
+            relativePath,
+            pendingDirective.line,
+            'unused-physical-exception',
+            'error',
+            'A bidi-physical directive must be adjacent to the declaration it exempts.'
+          ));
+          pendingDirective = null;
+        }
+        if (BIDI_CONTROL_RE.test(line)) {
+          findings.push(unexpectedBidiControl(relativePath, index + 1));
+        }
+        continue;
+      }
+
+      const physicalMatches = collectPhysicalMatches(line);
+      if (pendingDirective) {
+        if (physicalMatches.length > 0) {
+          // An exception is deliberately declaration-scoped. Minified CSS can
+          // contain several declarations on one line, so consume exactly one
+          // in source order instead of allowing it to hide the entire line or
+          // a later, more severe declaration.
+          physicalMatches.shift();
+          pendingDirective = null;
+        } else {
+          findings.push(finding(
+            relativePath,
+            pendingDirective.line,
+            'unused-physical-exception',
+            'error',
+            'A bidi-physical directive may exempt only the immediately following physical declaration.'
+          ));
+          pendingDirective = null;
+        }
+      }
+      for (const physicalMatch of physicalMatches) {
+        if (physicalMatch.severity === 'error') {
+          findings.push(finding(
+            relativePath,
+            index + 1,
+            'directional-physical-css',
+            'error',
+            `Use a logical CSS property, or add an adjacent validated bidi-physical exception: ${trimmed}`
+          ));
+        } else {
+          findings.push(finding(
+            relativePath,
+            index + 1,
+            'physical-inset-review',
+            'review',
+            `Confirm whether this is intentionally physical or should use an inline inset: ${trimmed}`
+          ));
+        }
+      }
+
+      if (VISUAL_ORDER_RE.test(line)) {
+        findings.push(finding(
+          relativePath,
+          index + 1,
+          'visual-order-review',
+          'review',
+          'Confirm visual reversal does not diverge from DOM reading and focus order.'
+        ));
+      }
+      if (GEOMETRY_RE.test(line)) {
+        findings.push(finding(
+          relativePath,
+          index + 1,
+          'directional-geometry-review',
+          'review',
+          'Review this physical geometry, animation, gradient, clipping, or mask in both directions.'
+        ));
+      }
+      if (FIXED_TEXT_SIZE_RE.test(line)) {
+        findings.push(finding(
+          relativePath,
+          index + 1,
+          'fixed-content-size-review',
+          'review',
+          'Confirm translatable content can expand and wrap without clipping.'
+        ));
+      }
+      if (BIDI_CONTROL_RE.test(line)) {
+        findings.push(unexpectedBidiControl(relativePath, index + 1));
+      }
+    }
+
+    if (pendingDirective) {
+      findings.push(finding(
+        relativePath,
+        pendingDirective.line,
+        'unused-physical-exception',
+        'error',
+        'A bidi-physical directive must be followed by a physical declaration.'
+      ));
+    }
+  }
+
+  return {
+    projectRoot,
+    summary: summarizeFindings(findings),
+    findings,
+  };
+}
+
+function finding(file, line, rule, severity, message) {
+  return { file, line, rule, severity, message };
+}
+
+function collectPhysicalMatches(value) {
+  const matches = [];
+  for (const pattern of [
+    BLOCKING_PROPERTY_RE,
+    BLOCKING_STYLE_OBJECT_PROPERTY_RE,
+    BLOCKING_ALIGNMENT_RE,
+  ]) {
+    for (const match of value.matchAll(pattern)) {
+      matches.push({ index: match.index, severity: 'error' });
+    }
+  }
+  for (const match of value.matchAll(REVIEW_PROPERTY_RE)) {
+    matches.push({ index: match.index, severity: 'review' });
+  }
+  return matches.sort((left, right) => left.index - right.index);
+}
+
+function unexpectedBidiControl(file, line) {
+  return finding(
+    file,
+    line,
+    'unexpected-bidi-control',
+    'error',
+    'Source contains an invisible Unicode bidi control. Prefer semantic HTML isolation or document a reviewed source-code need.'
+  );
+}
+
+function summarizeFindings(findings) {
+  return findings.reduce(
+    (summary, current) => {
+      summary[current.severity] += 1;
+      return summary;
+    },
+    { error: 0, review: 0 }
+  );
+}
+
+module.exports = {
+  auditBidirectionalReadiness,
+  collectSourceFiles,
+};

--- a/plugins/power-pages/scripts/lib/bidirectional-readiness.js
+++ b/plugins/power-pages/scripts/lib/bidirectional-readiness.js
@@ -56,12 +56,12 @@ function auditBidirectionalReadiness(projectRoot) {
     const relativePath = path.relative(projectRoot, filePath).replaceAll('\\', '/');
     const lines = fs.readFileSync(filePath, 'utf8').split(/\r?\n/);
     let pendingDirective = null;
-    let commentState = { blockEnd: null };
+    let commentState = { blockEnd: null, quote: null };
 
     for (let index = 0; index < lines.length; index += 1) {
       const line = lines[index];
       const trimmed = line.trim();
-      const directiveMatch = commentState.blockEnd
+      const directiveMatch = commentState.blockEnd || commentState.quote
         ? null
         : trimmed.match(PHYSICAL_DIRECTIVE_RE);
       if (directiveMatch) {
@@ -82,7 +82,7 @@ function auditBidirectionalReadiness(projectRoot) {
         };
         continue;
       }
-      if (!commentState.blockEnd && /bidi-physical:/i.test(trimmed)) {
+      if (!commentState.blockEnd && !commentState.quote && /bidi-physical:/i.test(trimmed)) {
         findings.push(finding(
           relativePath,
           index + 1,
@@ -206,10 +206,22 @@ function auditBidirectionalReadiness(projectRoot) {
   };
 }
 
+function isInsideUnquotedUrl(value, index) {
+  const prefix = value.slice(0, index);
+
+  // Preserve comment-looking sequences anywhere in an unquoted URL token, for example:
+  //   background: url(https://cdn.example.com/a//b/*/image.png)
+  //   <img src=//cdn.example.com/image.png>
+  // Restrict bare schemes to common URL protocols so `retry: // comment` remains a comment.
+  return /\burl\(\s*[^)]*$/i.test(prefix) ||
+    /\b(?:action|background|cite|data|formaction|href|manifest|poster|src|srcset)\s*=\s*[^\s"'`<>]*$/i.test(prefix) ||
+    /\b(?:https?|ftp|wss?|file):[^\s"'`<>]*$/i.test(prefix);
+}
+
 function stripSourceComments(value, initialState) {
   const state = { ...initialState };
   let result = '';
-  let quote = null;
+  let quote = state.quote || null;
   let escaped = false;
 
   for (let index = 0; index < value.length; index += 1) {
@@ -242,18 +254,21 @@ function stripSourceComments(value, initialState) {
       result += character;
       continue;
     }
+    // JavaScript permits a line comment immediately after a token (`value// comment`).
+    // Quoted strings are handled above; URL-like unquoted forms need a separate guard.
     const startsLineComment =
-      value.startsWith('//', index) &&
-      (index === 0 || /[\s;{}]/.test(value[index - 1]));
+      value.startsWith('//', index) && !isInsideUnquotedUrl(value, index);
     if (startsLineComment) {
       result += ' '.repeat(value.length - index);
       break;
     }
-    const blockEnd = value.startsWith('<!--', index)
-      ? '-->'
-      : value.startsWith('/*', index)
-        ? '*/'
-        : null;
+    const blockEnd = isInsideUnquotedUrl(value, index)
+      ? null
+      : value.startsWith('<!--', index)
+        ? '-->'
+        : value.startsWith('/*', index)
+          ? '*/'
+          : null;
     if (blockEnd) {
       state.blockEnd = blockEnd;
       result += ' '.repeat(blockEnd === '-->' ? 4 : 2);
@@ -263,6 +278,9 @@ function stripSourceComments(value, initialState) {
     result += character;
   }
 
+  // Backticks routinely span lines in JavaScript, and quoted HTML attributes may also
+  // be multiline. Carry quote state so comment-looking text inside them stays source.
+  state.quote = quote;
   return { value: result, state };
 }
 

--- a/plugins/power-pages/scripts/lib/bidirectional-readiness.js
+++ b/plugins/power-pages/scripts/lib/bidirectional-readiness.js
@@ -56,11 +56,14 @@ function auditBidirectionalReadiness(projectRoot) {
     const relativePath = path.relative(projectRoot, filePath).replaceAll('\\', '/');
     const lines = fs.readFileSync(filePath, 'utf8').split(/\r?\n/);
     let pendingDirective = null;
+    let commentState = { blockEnd: null };
 
     for (let index = 0; index < lines.length; index += 1) {
       const line = lines[index];
       const trimmed = line.trim();
-      const directiveMatch = trimmed.match(PHYSICAL_DIRECTIVE_RE);
+      const directiveMatch = commentState.blockEnd
+        ? null
+        : trimmed.match(PHYSICAL_DIRECTIVE_RE);
       if (directiveMatch) {
         const reason = directiveMatch[1].trim();
         if (reason.length < 12 || /^(?:needed|intentional|required|exception)$/i.test(reason)) {
@@ -79,7 +82,7 @@ function auditBidirectionalReadiness(projectRoot) {
         };
         continue;
       }
-      if (/bidi-physical:/i.test(trimmed)) {
+      if (!commentState.blockEnd && /bidi-physical:/i.test(trimmed)) {
         findings.push(finding(
           relativePath,
           index + 1,
@@ -90,8 +93,13 @@ function auditBidirectionalReadiness(projectRoot) {
         continue;
       }
 
-      if (!trimmed || trimmed.startsWith('//') ||
-          (trimmed.startsWith('/*') && trimmed.endsWith('*/'))) {
+      // Preserve string literals while removing code comments so documented
+      // physical-property examples cannot become blocking audit findings.
+      const stripped = stripSourceComments(line, commentState);
+      const scanLine = stripped.value;
+      const scanTrimmed = scanLine.trim();
+      commentState = stripped.state;
+      if (!scanTrimmed) {
         if (pendingDirective && !trimmed) {
           findings.push(finding(
             relativePath,
@@ -108,7 +116,7 @@ function auditBidirectionalReadiness(projectRoot) {
         continue;
       }
 
-      const physicalMatches = collectPhysicalMatches(line);
+      const physicalMatches = collectPhysicalMatches(scanLine);
       if (pendingDirective) {
         if (physicalMatches.length > 0) {
           // An exception is deliberately declaration-scoped. Minified CSS can
@@ -135,7 +143,7 @@ function auditBidirectionalReadiness(projectRoot) {
             index + 1,
             'directional-physical-css',
             'error',
-            `Use a logical CSS property, or add an adjacent validated bidi-physical exception: ${trimmed}`
+            `Use a logical CSS property, or add an adjacent validated bidi-physical exception: ${scanTrimmed}`
           ));
         } else {
           findings.push(finding(
@@ -148,7 +156,7 @@ function auditBidirectionalReadiness(projectRoot) {
         }
       }
 
-      if (VISUAL_ORDER_RE.test(line)) {
+      if (VISUAL_ORDER_RE.test(scanLine)) {
         findings.push(finding(
           relativePath,
           index + 1,
@@ -157,7 +165,7 @@ function auditBidirectionalReadiness(projectRoot) {
           'Confirm visual reversal does not diverge from DOM reading and focus order.'
         ));
       }
-      if (GEOMETRY_RE.test(line)) {
+      if (GEOMETRY_RE.test(scanLine)) {
         findings.push(finding(
           relativePath,
           index + 1,
@@ -166,7 +174,7 @@ function auditBidirectionalReadiness(projectRoot) {
           'Review this physical geometry, animation, gradient, clipping, or mask in both directions.'
         ));
       }
-      if (FIXED_TEXT_SIZE_RE.test(line)) {
+      if (FIXED_TEXT_SIZE_RE.test(scanLine)) {
         findings.push(finding(
           relativePath,
           index + 1,
@@ -196,6 +204,66 @@ function auditBidirectionalReadiness(projectRoot) {
     summary: summarizeFindings(findings),
     findings,
   };
+}
+
+function stripSourceComments(value, initialState) {
+  const state = { ...initialState };
+  let result = '';
+  let quote = null;
+  let escaped = false;
+
+  for (let index = 0; index < value.length; index += 1) {
+    if (state.blockEnd) {
+      const end = value.indexOf(state.blockEnd, index);
+      if (end < 0) {
+        result += ' '.repeat(value.length - index);
+        break;
+      }
+      result += ' '.repeat(end + state.blockEnd.length - index);
+      index = end + state.blockEnd.length - 1;
+      state.blockEnd = null;
+      continue;
+    }
+
+    const character = value[index];
+    if (quote) {
+      result += character;
+      if (escaped) {
+        escaped = false;
+      } else if (character === '\\') {
+        escaped = true;
+      } else if (character === quote) {
+        quote = null;
+      }
+      continue;
+    }
+    if (character === '"' || character === "'" || character === '`') {
+      quote = character;
+      result += character;
+      continue;
+    }
+    const startsLineComment =
+      value.startsWith('//', index) &&
+      (index === 0 || /[\s;{}]/.test(value[index - 1]));
+    if (startsLineComment) {
+      result += ' '.repeat(value.length - index);
+      break;
+    }
+    const blockEnd = value.startsWith('<!--', index)
+      ? '-->'
+      : value.startsWith('/*', index)
+        ? '*/'
+        : null;
+    if (blockEnd) {
+      state.blockEnd = blockEnd;
+      result += ' '.repeat(blockEnd === '-->' ? 4 : 2);
+      index += blockEnd === '-->' ? 3 : 1;
+      continue;
+    }
+    result += character;
+  }
+
+  return { value: result, state };
 }
 
 function finding(file, line, rule, severity, message) {

--- a/plugins/power-pages/scripts/lib/cli-arguments.js
+++ b/plugins/power-pages/scripts/lib/cli-arguments.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const path = require('path');
+
+function parseOptionalProjectRootArgs(argv, usage) {
+  const parsed = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg !== '--projectRoot') {
+      throw new Error(`Unknown or misplaced argument "${arg}".\n${usage}`);
+    }
+    if (parsed.projectRoot) {
+      throw new Error(
+        `Argument "${arg}" may be specified only once.\n${usage}`
+      );
+    }
+    const value = argv[index + 1];
+    if (typeof value !== 'string' || !value.trim() ||
+        value.startsWith('--')) {
+      throw new Error(`Argument "${arg}" requires a value.\n${usage}`);
+    }
+    parsed.projectRoot = path.resolve(value);
+    index += 1;
+  }
+  return parsed;
+}
+
+module.exports = {
+  parseOptionalProjectRootArgs,
+};

--- a/plugins/power-pages/scripts/lib/localization-config.js
+++ b/plugins/power-pages/scripts/lib/localization-config.js
@@ -61,6 +61,19 @@ const DEFAULT_SOURCE_SCAN_LIMITS = Object.freeze({
   maxFileBytes: 1024 * 1024,
   maxTotalBytes: 10 * 1024 * 1024,
 });
+// Direction belongs to a writing script, not permanently to a language. The
+// runtime's ICU/CLDR data supplies likely scripts through Intl.Locale#maximize.
+// CLDR ScriptMetadata field 6 identifies every script containing RTL letters;
+// keep this list complete because Intl.Locale#textInfo can report language-level
+// direction even when an explicit script requests the opposite direction.
+// See: https://github.com/unicode-org/cldr/blob/main/common/properties/scriptMetadata.txt
+const RTL_SCRIPTS = Object.freeze(new Set([
+  'Adlm', 'Arab', 'Aran', 'Armi', 'Avst', 'Chrs', 'Cprt', 'Elym', 'Gara',
+  'Hatr', 'Hebr', 'Hung', 'Khar', 'Lydi', 'Mand', 'Mani', 'Mend', 'Merc',
+  'Mero', 'Narb', 'Nbat', 'Nkoo', 'Orkh', 'Ougr', 'Palm', 'Phli', 'Phlp',
+  'Phnx', 'Prti', 'Rohg', 'Samr', 'Sarb', 'Sidt', 'Sogd', 'Sogo', 'Syrc',
+  'Syre', 'Syrj', 'Syrn', 'Thaa', 'Yezi',
+]));
 
 let cachedRegistry;
 
@@ -99,6 +112,13 @@ function validateLocalizationManifestShape(manifest) {
         manifest[field].some((value) => typeof value !== 'string' || !value.trim())) {
       errors.push(`Manifest ${field} must be an array of non-empty strings.`);
     }
+  }
+  if (manifest.unavailableLocales !== undefined &&
+      (!Array.isArray(manifest.unavailableLocales) ||
+       manifest.unavailableLocales.some(
+         (value) => typeof value !== 'string' || !value.trim()
+       ))) {
+    errors.push('Manifest unavailableLocales must be an array of non-empty strings.');
   }
   if (!manifest.resourcePaths || typeof manifest.resourcePaths !== 'object' ||
       Array.isArray(manifest.resourcePaths) ||
@@ -177,6 +197,31 @@ function validateLocalizationManifestShape(manifest) {
         errors.push('Manifest initializationEvidence.marker must be a non-empty string.');
       } else if (evidence.marker.length > 200) {
         errors.push('Manifest initializationEvidence.marker must not exceed 200 characters.');
+      }
+    }
+  }
+  if (manifest.bidirectionalReadiness !== undefined) {
+    const readiness = manifest.bidirectionalReadiness;
+    if (!readiness || typeof readiness !== 'object' || Array.isArray(readiness)) {
+      errors.push('Manifest bidirectionalReadiness must be an object.');
+    } else {
+      if (!['ready', 'approved-with-limitations', 'pending-remediation'].includes(
+        readiness.status
+      )) {
+        errors.push(
+          'Manifest bidirectionalReadiness.status must be "ready", ' +
+          '"approved-with-limitations", or "pending-remediation".'
+        );
+      }
+      if (readiness.findings !== undefined && !Array.isArray(readiness.findings)) {
+        errors.push('Manifest bidirectionalReadiness.findings must be an array.');
+      }
+      if (readiness.status === 'pending-remediation' &&
+          (!Array.isArray(manifest.unavailableLocales) ||
+           manifest.unavailableLocales.length === 0)) {
+        errors.push(
+          'Pending bidirectional remediation requires at least one unavailable locale.'
+        );
       }
     }
   }
@@ -447,7 +492,7 @@ function validateLocales(input, options = {}) {
   };
 }
 
-function getLocaleDirection(locale) {
+function getLocaleMetadata(locale) {
   let canonical;
   let parsed;
   try {
@@ -456,16 +501,67 @@ function getLocaleDirection(locale) {
   } catch {
     // Private-use-only tags such as x-contoso are valid BCP-47 identifiers but
     // do not carry script metadata from which a direction can be derived.
-    return 'ltr';
+    return {
+      locale,
+      language: null,
+      script: null,
+      region: null,
+      direction: 'ltr',
+      directionSource: 'private-use-default',
+    };
   }
 
-  // Node exposes Unicode text direction through Intl.Locale.textInfo. Keep the
-  // language fallback for older Node releases that do not implement it.
-  const intlDirection = parsed.textInfo?.direction;
-  if (intlDirection === 'rtl' || intlDirection === 'ltr') return intlDirection;
+  const maximized = parsed.maximize();
+  const script = parsed.script || maximized.script || null;
+  if (script && RTL_SCRIPTS.has(script)) {
+    return {
+      locale: canonical,
+      language: parsed.language,
+      script,
+      region: parsed.region || maximized.region || null,
+      direction: 'rtl',
+      directionSource: parsed.script ? 'explicit-script' : 'likely-script',
+    };
+  }
+  if (script) {
+    return {
+      locale: canonical,
+      language: parsed.language,
+      script,
+      region: parsed.region || maximized.region || null,
+      direction: 'ltr',
+      directionSource: parsed.script ? 'explicit-script' : 'likely-script',
+    };
+  }
 
-  const rtlLanguages = new Set(['ar', 'dv', 'fa', 'he', 'ku', 'ps', 'sd', 'ug', 'ur', 'yi']);
-  return rtlLanguages.has(parsed.language.toLowerCase()) ? 'rtl' : 'ltr';
+  const textInfo = typeof parsed.getTextInfo === 'function'
+    ? parsed.getTextInfo()
+    : parsed.textInfo;
+  const direction = ['rtl', 'ltr'].includes(textInfo?.direction)
+    ? textInfo.direction
+    : 'ltr';
+  return {
+    locale: canonical,
+    language: parsed.language,
+    script: null,
+    region: parsed.region || null,
+    direction,
+    directionSource: textInfo?.direction ? 'intl-text-info' : 'unknown-default',
+  };
+}
+
+function getLocaleDirection(locale) {
+  return getLocaleMetadata(locale).direction;
+}
+
+function classifyLocaleDirections(locales) {
+  const entries = locales.map((locale) => getLocaleMetadata(locale));
+  const directions = [...new Set(entries.map((entry) => entry.direction))].sort();
+  return {
+    classification: directions.length > 1 ? 'mixed' : `${directions[0] || 'ltr'}-only`,
+    directions,
+    locales: entries,
+  };
 }
 
 function resolveLocale(input) {
@@ -479,10 +575,15 @@ function resolveLocale(input) {
   }
 
   const [locale] = validation.locales;
+  const metadata = getLocaleMetadata(locale);
   return {
     ...validation,
     locale,
-    direction: getLocaleDirection(locale),
+    language: metadata.language,
+    script: metadata.script,
+    region: metadata.region,
+    direction: metadata.direction,
+    directionSource: metadata.directionSource,
   };
 }
 
@@ -1177,11 +1278,13 @@ module.exports = {
   MANIFEST_NAME,
   KNOWN_PACKAGES,
   hasLocaleNavigationSignal,
+  classifyLocaleDirections,
   detectFramework,
   detectLocalization,
   detectSiteLanguage,
   detectSiteLanguageForFramework,
   getLocaleDirection,
+  getLocaleMetadata,
   inspectProject,
   loadRegistry,
   resolveLocale,

--- a/plugins/power-pages/scripts/lib/powerpages-hook-utils.js
+++ b/plugins/power-pages/scripts/lib/powerpages-hook-utils.js
@@ -122,6 +122,20 @@ const ALM_PLAN_SKILLS = new Set([
   'force-link-environment',
 ]);
 
+// These workflows can add or change visible SPA source. Their skill-specific
+// validator still runs first; the shared integrity pass then catches localization
+// resource drift and bidirectional regressions across skill boundaries.
+const VISIBLE_SOURCE_SKILLS = new Set([
+  'create-site',
+  'add-localization',
+  'setup-auth',
+  'integrate-webapi',
+  'add-ai-webapi',
+  'add-cloud-flow',
+  'add-server-logic',
+  'add-seo',
+]);
+
 /**
  * True when `value` (a raw skill name, `/skill`, or `power-pages:skill`) resolves
  * to an ALM plan skill. Normalizes via `detectTrackedSkill`, so it also confirms
@@ -136,11 +150,24 @@ function isAlmPlanSkill(value) {
   return name != null && ALM_PLAN_SKILLS.has(name);
 }
 
+function modifiesVisibleSource(value) {
+  const name = detectTrackedSkill(value);
+  return name != null && VISIBLE_SOURCE_SKILLS.has(name);
+}
+
+function getBlockingSpawnStatus(result) {
+  if (!result || result.error || result.signal || result.status == null) return 2;
+  return result.status === 0 ? 0 : 2;
+}
+
 module.exports = {
   TRACKED_SKILLS,
   ALM_PLAN_SKILLS,
+  VISIBLE_SOURCE_SKILLS,
   detectTrackedSkill,
   getTrackedSkillFromToolInput,
   getValidatorScript,
+  getBlockingSpawnStatus,
   isAlmPlanSkill,
+  modifiesVisibleSource,
 };

--- a/plugins/power-pages/scripts/lib/site-integrity.js
+++ b/plugins/power-pages/scripts/lib/site-integrity.js
@@ -1,0 +1,119 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const {
+  classifyLocaleDirections,
+  getLocaleDirection,
+  MANIFEST_NAME,
+} = require('./localization-config');
+const {
+  auditBidirectionalReadiness,
+} = require('./bidirectional-readiness');
+const {
+  validateLocalization,
+} = require('../../skills/add-localization/scripts/validate-localization');
+
+function validateSiteIntegrity(projectRoot) {
+  const configPath = path.join(projectRoot, 'powerpages.config.json');
+  if (!fs.existsSync(configPath)) {
+    return {
+      projectRoot,
+      skipped: true,
+      reason: 'Not a Power Pages code site.',
+      errors: [],
+      reviewFindings: [],
+    };
+  }
+
+  const localizationErrors = validateLocalization(projectRoot);
+  const bidiAudit = auditBidirectionalReadiness(projectRoot);
+  const manifest = readJson(path.join(projectRoot, MANIFEST_NAME));
+  const directionSet = Array.isArray(manifest?.locales)
+    ? classifyLocaleDirections(manifest.locales)
+    : null;
+  const unavailableLocales = new Set(manifest?.unavailableLocales || []);
+  const defaultDirection = manifest?.defaultLocale
+    ? getLocaleDirection(manifest.defaultLocale)
+    : null;
+  const oppositeLocales = Array.isArray(manifest?.locales) && defaultDirection
+    ? manifest.locales.filter((locale) => getLocaleDirection(locale) !== defaultDirection)
+    : [];
+  const remediationPending =
+    manifest?.bidirectionalReadiness?.status === 'pending-remediation' &&
+    directionSet?.classification === 'mixed' &&
+    oppositeLocales.length > 0 &&
+    oppositeLocales.every((locale) => unavailableLocales.has(locale)) &&
+    localizationErrors.length === 0;
+  const recordedFindings = remediationPending
+    ? manifest.bidirectionalReadiness.findings || []
+    : [];
+  const {
+    blocking: blockingBidiFindings,
+    deferred,
+  } = partitionDeferredFindings(
+    bidiAudit.findings.filter((finding) => finding.severity === 'error'),
+    recordedFindings
+  );
+  const deferredFindings = deferred.map((finding) => ({
+    ...finding,
+    severity: 'review',
+    message: `Deferred while opposite-direction locales are unavailable: ${finding.message}`,
+  }));
+
+  return {
+    projectRoot,
+    skipped: false,
+    errors: [...localizationErrors, ...blockingBidiFindings.map(formatBidiFinding)],
+    reviewFindings: [
+      ...bidiAudit.findings.filter((finding) => finding.severity === 'review'),
+      ...deferredFindings,
+    ],
+  };
+}
+
+function partitionDeferredFindings(findings, recordedFindings) {
+  const remainingRecords = [...recordedFindings];
+  const blocking = [];
+  const deferred = [];
+  for (const finding of findings) {
+    // Only a concrete layout blocker may be carried as pending work. Match the
+    // complete scanner identity and consume it once, so changing or adding a
+    // declaration on the same line is still a new blocking defect.
+    const recordIndex = finding.rule === 'directional-physical-css'
+      ? remainingRecords.findIndex((recorded) =>
+        recorded &&
+        recorded.rule === finding.rule &&
+        recorded.file === finding.file &&
+        recorded.line === finding.line &&
+        recorded.message === finding.message
+      )
+      : -1;
+    if (recordIndex === -1) {
+      blocking.push(finding);
+      continue;
+    }
+    remainingRecords.splice(recordIndex, 1);
+    deferred.push(finding);
+  }
+  return { blocking, deferred };
+}
+
+function readJson(filePath) {
+  if (!fs.existsSync(filePath)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function formatBidiFinding(finding) {
+  return `Bidirectional readiness ${finding.file}:${finding.line} ` +
+    `[${finding.rule}]: ${finding.message}`;
+}
+
+module.exports = {
+  partitionDeferredFindings,
+  validateSiteIntegrity,
+};

--- a/plugins/power-pages/scripts/tests/bidirectional-readiness.test.js
+++ b/plugins/power-pages/scripts/tests/bidirectional-readiness.test.js
@@ -1,0 +1,132 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { auditBidirectionalReadiness } = require('../lib/bidirectional-readiness');
+const { createTempProject, writeProjectFile } = require('./test-utils');
+
+test('accepts logical directional CSS', (t) => {
+  const projectRoot = createTempProject(t);
+  writeProjectFile(projectRoot, 'src/theme.css', `
+    .callout {
+      margin-inline-start: 1rem;
+      padding-inline-end: 2rem;
+      border-inline-start: 0.25rem solid;
+      text-align: start;
+    }
+  `);
+
+  const result = auditBidirectionalReadiness(projectRoot);
+  assert.equal(result.summary.error, 0, JSON.stringify(result.findings));
+});
+
+test('blocks unexplained direction-sensitive physical CSS', (t) => {
+  const projectRoot = createTempProject(t);
+  writeProjectFile(projectRoot, 'src/theme.css', `
+    .callout {
+      margin-left: 1rem;
+      border-right: 0.25rem solid;
+      text-align: left;
+    }
+  `);
+
+  const result = auditBidirectionalReadiness(projectRoot);
+  assert.equal(result.summary.error, 3);
+  assert.ok(result.findings.every((item) => item.rule === 'directional-physical-css'));
+});
+
+test('blocks physical framework style-object properties', (t) => {
+  const projectRoot = createTempProject(t);
+  writeProjectFile(
+    projectRoot,
+    'src/Card.tsx',
+    `const padding = { "paddingLeft": '1rem' };
+     const alignment = { textAlign: 'left' };
+     const quoted = { 'margin-right': '1rem' };
+     const template = '<div style="padding-left: 1rem"></div>';`
+  );
+
+  const result = auditBidirectionalReadiness(projectRoot);
+  assert.equal(result.summary.error, 4);
+  assert.ok(result.findings.every((item) => item.rule === 'directional-physical-css'));
+});
+
+test('accepts an adjacent validated physical exception', (t) => {
+  const projectRoot = createTempProject(t);
+  writeProjectFile(projectRoot, 'src/map.css', `
+    .map-controls {
+      /* bidi-physical: Map controls follow provider placement; verify=ltr,rtl */
+      right: 1rem;
+    }
+  `);
+
+  const result = auditBidirectionalReadiness(projectRoot);
+  assert.equal(result.summary.error, 0, JSON.stringify(result.findings));
+  assert.equal(result.findings.length, 0);
+});
+
+test('allows one declaration per physical exception', (t) => {
+  const projectRoot = createTempProject(t);
+  writeProjectFile(projectRoot, 'src/map.css', `
+    /* bidi-physical: Map controls follow provider placement; verify=ltr,rtl */
+    .map-controls { margin-left: 1rem; padding-right: 1rem; }
+  `);
+
+  const result = auditBidirectionalReadiness(projectRoot);
+  assert.equal(result.summary.error, 1);
+  assert.equal(result.findings[0].rule, 'directional-physical-css');
+});
+
+test('applies a physical exception to the first declaration in source order', (t) => {
+  const projectRoot = createTempProject(t);
+  writeProjectFile(projectRoot, 'src/map.css', `
+    /* bidi-physical: Pin remains on the provider-defined physical edge; verify=ltr,rtl */
+    .map-controls { left: 0; margin-left: 1rem; }
+  `);
+
+  const result = auditBidirectionalReadiness(projectRoot);
+  assert.equal(result.summary.error, 1);
+  assert.equal(result.summary.review, 0);
+  assert.equal(result.findings[0].rule, 'directional-physical-css');
+});
+
+test('rejects unused or non-adjacent physical exceptions', (t) => {
+  const projectRoot = createTempProject(t);
+  writeProjectFile(projectRoot, 'src/map.css', `
+    /* bidi-physical: Map controls follow provider placement; verify=ltr,rtl */
+
+    .map-controls {
+      right: 1rem;
+    }
+  `);
+
+  const result = auditBidirectionalReadiness(projectRoot);
+  assert.equal(result.summary.error, 1);
+  assert.equal(result.findings[0].rule, 'unused-physical-exception');
+});
+
+test('reports physical geometry and visual reordering for review', (t) => {
+  const projectRoot = createTempProject(t);
+  writeProjectFile(projectRoot, 'src/carousel.css', `
+    .track {
+      flex-direction: row-reverse;
+      transform: translateX(-100%);
+    }
+  `);
+
+  const result = auditBidirectionalReadiness(projectRoot);
+  assert.equal(result.summary.error, 0);
+  assert.deepEqual(
+    new Set(result.findings.map((item) => item.rule)),
+    new Set(['visual-order-review', 'directional-geometry-review'])
+  );
+});
+
+test('blocks invisible bidi controls in source', (t) => {
+  const projectRoot = createTempProject(t);
+  writeProjectFile(projectRoot, 'src/example.ts', "const route = '/safe\u202Egnp';\n");
+
+  const result = auditBidirectionalReadiness(projectRoot);
+  assert.equal(result.summary.error, 1);
+  assert.equal(result.findings[0].rule, 'unexpected-bidi-control');
+});

--- a/plugins/power-pages/scripts/tests/bidirectional-readiness.test.js
+++ b/plugins/power-pages/scripts/tests/bidirectional-readiness.test.js
@@ -2,8 +2,12 @@
 
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const { spawnSync } = require('child_process');
+const path = require('path');
 const { auditBidirectionalReadiness } = require('../lib/bidirectional-readiness');
 const { createTempProject, writeProjectFile } = require('./test-utils');
+
+const AUDIT_PATH = path.join(__dirname, '..', 'audit-bidirectional-readiness.js');
 
 test('accepts logical directional CSS', (t) => {
   const projectRoot = createTempProject(t);
@@ -129,4 +133,35 @@ test('blocks invisible bidi controls in source', (t) => {
   const result = auditBidirectionalReadiness(projectRoot);
   assert.equal(result.summary.error, 1);
   assert.equal(result.findings[0].rule, 'unexpected-bidi-control');
+});
+
+test('ignores physical-property examples inside multiline comments', (t) => {
+  const projectRoot = createTempProject(t);
+  writeProjectFile(projectRoot, 'src/theme.css', `
+    /*
+     * Avoid physical properties such as:
+     * margin-left: 1rem;
+     * text-align: right;
+     */
+    .card {
+      margin-inline-start: 1rem;
+    }
+  `);
+
+  const result = auditBidirectionalReadiness(projectRoot);
+  assert.equal(result.summary.error, 0, JSON.stringify(result.findings));
+});
+
+test('audit CLI exits nonzero when blocking findings exist', (t) => {
+  const projectRoot = createTempProject(t);
+  writeProjectFile(projectRoot, 'src/theme.css', '.card { margin-left: 1rem; }');
+
+  const result = spawnSync(
+    process.execPath,
+    [AUDIT_PATH, '--projectRoot', projectRoot],
+    { encoding: 'utf8' }
+  );
+
+  assert.equal(result.status, 1);
+  assert.equal(JSON.parse(result.stdout).summary.error, 1);
 });

--- a/plugins/power-pages/scripts/tests/bidirectional-readiness.test.js
+++ b/plugins/power-pages/scripts/tests/bidirectional-readiness.test.js
@@ -152,6 +152,50 @@ test('ignores physical-property examples inside multiline comments', (t) => {
   assert.equal(result.summary.error, 0, JSON.stringify(result.findings));
 });
 
+test('ignores line-comment findings without requiring whitespace before the comment', (t) => {
+  const projectRoot = createTempProject(t);
+  writeProjectFile(projectRoot, 'src/example.ts', `
+    const count = 1// margin-left: 1rem;
+    const ready = true// direction: 'ltr';
+    const step = 2// track.scrollLeft += 100;
+    retry: // padding-right: 1rem;
+  `);
+
+  const result = auditBidirectionalReadiness(projectRoot);
+  assert.equal(result.summary.error, 0, JSON.stringify(result.findings));
+  assert.equal(result.summary.review, 0, JSON.stringify(result.findings));
+});
+
+test('preserves URL double slashes without hiding later findings', (t) => {
+  const projectRoot = createTempProject(t);
+  writeProjectFile(projectRoot, 'src/theme.css', `
+    .cdn { background: url(//cdn.example.com/a//b/image.png); margin-left: 1rem; }
+    .remote { background: url(https://example.com/a//b/*/image.png); padding-right: 1rem; }
+  `);
+  writeProjectFile(
+    projectRoot,
+    'index.html',
+    '<p>https://example.com/a//b</p><img src=//cdn.example.com/image.png><div style="margin-left: 1rem"></div>'
+  );
+
+  const result = auditBidirectionalReadiness(projectRoot);
+  assert.equal(result.summary.error, 3, JSON.stringify(result.findings));
+});
+
+test('carries quote state across lines so literal comment markers cannot hide code', (t) => {
+  const projectRoot = createTempProject(t);
+  writeProjectFile(projectRoot, 'src/example.ts', `
+    const marker = \`
+      /*
+    \`;
+    const styles = { marginLeft: '1rem' };
+  `);
+
+  const result = auditBidirectionalReadiness(projectRoot);
+  assert.equal(result.summary.error, 1, JSON.stringify(result.findings));
+  assert.equal(result.findings[0].rule, 'directional-physical-css');
+});
+
 test('audit CLI exits nonzero when blocking findings exist', (t) => {
   const projectRoot = createTempProject(t);
   writeProjectFile(projectRoot, 'src/theme.css', '.card { margin-left: 1rem; }');

--- a/plugins/power-pages/scripts/tests/bidirectional-readiness.test.js
+++ b/plugins/power-pages/scripts/tests/bidirectional-readiness.test.js
@@ -5,9 +5,50 @@ const assert = require('node:assert/strict');
 const { spawnSync } = require('child_process');
 const path = require('path');
 const { auditBidirectionalReadiness } = require('../lib/bidirectional-readiness');
+const {
+  parseArgs,
+} = require('../audit-bidirectional-readiness');
 const { createTempProject, writeProjectFile } = require('./test-utils');
 
 const AUDIT_PATH = path.join(__dirname, '..', 'audit-bidirectional-readiness.js');
+
+test('parses an optional project root without consuming other options', () => {
+  assert.deepEqual(parseArgs([]), {});
+  assert.equal(parseArgs(['--projectRoot', '.']).projectRoot, path.resolve('.'));
+  assert.throws(
+    () => parseArgs(['--projectRoot']),
+    /"--projectRoot" requires a value/
+  );
+  assert.throws(
+    () => parseArgs(['--projectRoot', '--unexpected']),
+    /"--projectRoot" requires a value/
+  );
+  assert.throws(
+    () => parseArgs(['--projectRoot', '']),
+    /"--projectRoot" requires a value/
+  );
+  assert.throws(
+    () => parseArgs(['--projectRoot', '.', '--projectRoot', '..']),
+    /"--projectRoot" may be specified only once/
+  );
+  assert.throws(
+    () => parseArgs(['--unexpected']),
+    /Unknown or misplaced argument "--unexpected"/
+  );
+});
+
+test('CLI reports malformed project-root usage without auditing another path', () => {
+  const result = spawnSync(
+    process.execPath,
+    [AUDIT_PATH, '--projectRoot', '--unexpected'],
+    { encoding: 'utf8' }
+  );
+
+  assert.equal(result.status, 2);
+  assert.equal(result.stdout, '');
+  assert.match(result.stderr, /"--projectRoot" requires a value/);
+  assert.match(result.stderr, /Usage: audit-bidirectional-readiness/);
+});
 
 test('accepts logical directional CSS', (t) => {
   const projectRoot = createTempProject(t);

--- a/plugins/power-pages/scripts/tests/localization-config.test.js
+++ b/plugins/power-pages/scripts/tests/localization-config.test.js
@@ -8,6 +8,7 @@ const path = require('path');
 
 const {
   LOCALIZATION_CAPABILITIES,
+  classifyLocaleDirections,
   detectFramework,
   detectLocalization,
   detectSiteLanguage,
@@ -155,9 +156,93 @@ test('canonicalizes, visibly deduplicates, and validates registry subtags', () =
 test('resolves a single locale and its writing direction', () => {
   const spanish = resolveLocale('es-es');
   assert.equal(spanish.locale, 'es-ES');
+  assert.equal(spanish.script, 'Latn');
   assert.equal(spanish.direction, 'ltr');
   assert.equal(getLocaleDirection('ar-SA'), 'rtl');
   assert.equal(getLocaleDirection('x-contoso'), 'ltr');
+});
+
+test('resolves direction from explicit or likely writing script', () => {
+  const cases = [
+    ['ar-SA', 'Arab', 'rtl'],
+    ['az-Latn', 'Latn', 'ltr'],
+    ['az-Arab', 'Arab', 'rtl'],
+    ['ku-Latn', 'Latn', 'ltr'],
+    ['ku-Arab', 'Arab', 'rtl'],
+    ['pa-Guru', 'Guru', 'ltr'],
+    ['pa-Arab', 'Arab', 'rtl'],
+    ['sd-Deva', 'Deva', 'ltr'],
+    ['sd-Arab', 'Arab', 'rtl'],
+    ['ar-Latn', 'Latn', 'ltr'],
+    ['wo-Gara', 'Gara', 'rtl'],
+    ['phn-Phnx', 'Phnx', 'rtl'],
+  ];
+
+  for (const [locale, script, direction] of cases) {
+    const result = resolveLocale(locale);
+    assert.equal(result.valid, true, locale);
+    assert.equal(result.script, script, locale);
+    assert.equal(result.direction, direction, locale);
+  }
+});
+
+test('classifies locale sets by their resolved directions', () => {
+  assert.equal(
+    classifyLocaleDirections(['en-US', 'fr-FR']).classification,
+    'ltr-only'
+  );
+  assert.equal(
+    classifyLocaleDirections(['ar-SA', 'he-IL']).classification,
+    'rtl-only'
+  );
+  assert.equal(
+    classifyLocaleDirections(['en-US', 'ar-SA']).classification,
+    'mixed'
+  );
+});
+
+test('validates bidirectional readiness and unavailable locale manifest fields', () => {
+  const manifest = {
+    schemaVersion: 1,
+    framework: 'react',
+    mode: 'runtime',
+    packageName: 'i18next',
+    packageVersion: '25.0.0',
+    defaultLocale: 'en-US',
+    locales: ['en-US', 'ar-SA'],
+    translationMethod: 'agent',
+    lastOperation: 'add',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    generatedFiles: [],
+    managedFiles: [],
+    resourcePaths: {},
+    adoptedExistingConfiguration: false,
+    packageVerification: {
+      status: 'verified',
+      source: 'known-capability',
+    },
+    unavailableLocales: ['ar-SA'],
+    bidirectionalReadiness: {
+      status: 'pending-remediation',
+      findings: [],
+    },
+  };
+
+  assert.deepEqual(validateLocalizationManifestShape(manifest), []);
+  assert.match(
+    validateLocalizationManifestShape({
+      ...manifest,
+      unavailableLocales: undefined,
+    }).join('\n'),
+    /Pending bidirectional remediation requires at least one unavailable locale/
+  );
+  assert.match(
+    validateLocalizationManifestShape({
+      ...manifest,
+      bidirectionalReadiness: { status: 'unknown', findings: [] },
+    }).join('\n'),
+    /bidirectionalReadiness\.status must be/
+  );
 });
 
 test('detects the persisted single-site language from document attributes', (t) => {

--- a/plugins/power-pages/scripts/tests/powerpages-hook-utils.test.js
+++ b/plugins/power-pages/scripts/tests/powerpages-hook-utils.test.js
@@ -6,10 +6,13 @@ const path = require('path');
 const {
   TRACKED_SKILLS,
   ALM_PLAN_SKILLS,
+  VISIBLE_SOURCE_SKILLS,
   detectTrackedSkill,
   getTrackedSkillFromToolInput,
   getValidatorScript,
+  getBlockingSpawnStatus,
   isAlmPlanSkill,
+  modifiesVisibleSource,
 } = require('../lib/powerpages-hook-utils');
 
 const SKILLS_DIR = path.join(__dirname, '..', '..', 'skills');
@@ -173,4 +176,37 @@ test('ALM_PLAN_SKILLS members are all real tracked skills', () => {
   for (const name of ALM_PLAN_SKILLS) {
     assert.ok(TRACKED_SKILLS[name], `ALM_PLAN_SKILLS member "${name}" must be a tracked skill (have a SKILL.md)`);
   }
+});
+
+test('modifiesVisibleSource identifies workflows that can change SPA UI', () => {
+  for (const skillName of [
+    'create-site',
+    'add-localization',
+    'setup-auth',
+    'integrate-webapi',
+    'add-ai-webapi',
+    'add-cloud-flow',
+    'add-server-logic',
+    'add-seo',
+  ]) {
+    assert.equal(modifiesVisibleSource(`/power-pages:${skillName}`), true);
+  }
+  assert.equal(modifiesVisibleSource('setup-datamodel'), false);
+  assert.equal(modifiesVisibleSource('deploy-site'), false);
+  assert.equal(modifiesVisibleSource('missing-skill'), false);
+});
+
+test('VISIBLE_SOURCE_SKILLS members are all real tracked skills', () => {
+  for (const name of VISIBLE_SOURCE_SKILLS) {
+    assert.ok(TRACKED_SKILLS[name], `VISIBLE_SOURCE_SKILLS member "${name}" must be tracked`);
+  }
+});
+
+test('getBlockingSpawnStatus fails closed for incomplete child processes', () => {
+  assert.equal(getBlockingSpawnStatus({ status: 0, error: undefined, signal: null }), 0);
+  assert.equal(getBlockingSpawnStatus({ status: 2, error: undefined, signal: null }), 2);
+  assert.equal(getBlockingSpawnStatus({ status: 1, error: undefined, signal: null }), 2);
+  assert.equal(getBlockingSpawnStatus({ status: null, error: new Error('ENOBUFS'), signal: 'SIGTERM' }), 2);
+  assert.equal(getBlockingSpawnStatus({ status: null, error: undefined, signal: 'SIGTERM' }), 2);
+  assert.equal(getBlockingSpawnStatus(null), 2);
 });

--- a/plugins/power-pages/scripts/tests/run-skill-posttool-validation.test.js
+++ b/plugins/power-pages/scripts/tests/run-skill-posttool-validation.test.js
@@ -186,6 +186,7 @@ test('reconcile backstop is exit-code-neutral: a blocking validator status is un
   writeJson(path.join(withPlan, 'docs', '.alm-plan-data.json'), {
     SITE_NAME: 'T', steps: [{ name: 'Deploy via pipeline to Staging', status: 'pending' }],
   });
+
   backdatePlan(withPlan);
   const resWith = runHook(withPlan, 'deploy-pipeline');
 
@@ -198,4 +199,31 @@ test('reconcile backstop is exit-code-neutral: a blocking validator status is un
   assert.equal(resWithout.status, 2, 'blocking validator must surface exit 2 with no plan');
   assert.equal(resWith.status, resWithout.status,
     'the reconcile backstop must not change the validator-determined exit code');
+});
+
+test('hook blocks a source-mutating skill when shared site integrity fails', (t) => {
+  const root = makeProject(t);
+  writeJson(path.join(root, 'powerpages.config.json'), {});
+  fs.mkdirSync(path.join(root, 'src'), { recursive: true });
+  fs.writeFileSync(path.join(root, 'src', 'bad.css'), '.bad { margin-left: 1rem; }', 'utf8');
+
+  // add-localization approves an otherwise unlocalized code site, allowing the
+  // shared cross-cutting validator to own this failure.
+  const res = runHook(root, 'add-localization');
+
+  assert.equal(res.status, 2);
+  assert.match(res.stderr, /site integrity validation failed/i);
+  assert.match(res.stderr, /directional-physical-css/i);
+});
+
+test('hook does not run site integrity for a non-source-mutating skill', (t) => {
+  const root = makeProject(t);
+  writeJson(path.join(root, 'powerpages.config.json'), {});
+  fs.mkdirSync(path.join(root, 'src'), { recursive: true });
+  fs.writeFileSync(path.join(root, 'src', 'bad.css'), '.bad { margin-left: 1rem; }', 'utf8');
+
+  const res = runHook(root, 'test-site');
+
+  assert.equal(res.status, 0);
+  assert.doesNotMatch(res.stderr, /site integrity validation failed/i);
 });

--- a/plugins/power-pages/scripts/tests/site-integrity.test.js
+++ b/plugins/power-pages/scripts/tests/site-integrity.test.js
@@ -1,0 +1,294 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+const { spawnSync } = require('child_process');
+const {
+  validateSiteIntegrity,
+} = require('../lib/site-integrity');
+const {
+  createTempProject,
+  writeProjectFile,
+} = require('./test-utils');
+
+const CLI_PATH = path.join(__dirname, '..', 'validate-site-integrity.js');
+
+test('skips declarative Power Pages projects', (t) => {
+  const projectRoot = createTempProject(t);
+  const result = validateSiteIntegrity(projectRoot);
+
+  assert.equal(result.skipped, true);
+  assert.deepEqual(result.errors, []);
+});
+
+test('blocks deterministic bidirectional regressions without requiring localization', (t) => {
+  const projectRoot = createTempProject(t);
+  writeProjectFile(projectRoot, 'powerpages.config.json', '{}');
+  writeProjectFile(projectRoot, 'src/Card.css', '.card { margin-left: 1rem; }');
+
+  const result = validateSiteIntegrity(projectRoot);
+
+  assert.equal(result.skipped, false);
+  assert.equal(result.errors.length, 1);
+  assert.match(result.errors[0], /directional-physical-css/);
+});
+
+test('reports content expansion findings without blocking', (t) => {
+  const projectRoot = createTempProject(t);
+  writeProjectFile(projectRoot, 'powerpages.config.json', '{}');
+  writeProjectFile(projectRoot, 'src/Button.css', '.label {\n  width: 8rem;\n}');
+
+  const result = validateSiteIntegrity(projectRoot);
+
+  assert.deepEqual(result.errors, []);
+  assert.equal(result.reviewFindings.length, 1);
+  assert.equal(result.reviewFindings[0].rule, 'fixed-content-size-review');
+});
+
+test('includes localization resource failures when a manifest exists', (t) => {
+  const projectRoot = createTempProject(t);
+  writeProjectFile(projectRoot, 'powerpages.config.json', '{}');
+  writeProjectFile(projectRoot, '.powerpages-localization.json', '{ invalid json');
+
+  const result = validateSiteIntegrity(projectRoot);
+
+  assert.ok(result.errors.some((error) => /not valid JSON/.test(error)));
+});
+
+test('defers known bidi blockers while opposite-direction locales remain unavailable', (t) => {
+  const projectRoot = createTempProject(t);
+  const availabilityPath = 'src/i18n/localeAvailability.ts';
+  writeProjectFile(projectRoot, 'powerpages.config.json', '{}');
+  writeProjectFile(projectRoot, 'package.json', JSON.stringify({
+    dependencies: {
+      react: '^19.0.0',
+      'react-dom': '^19.0.0',
+      i18next: '^25.0.0',
+      'react-i18next': '^16.0.0',
+    },
+  }));
+  writeProjectFile(projectRoot, 'src/i18n/locales/en-US.json', '{"title":"Home"}');
+  writeProjectFile(projectRoot, 'src/i18n/locales/ar-SA.json', '{"title":"الرئيسية"}');
+  writeProjectFile(
+    projectRoot,
+    'src/i18n/index.ts',
+    "import i18next from 'i18next'; i18next.init({ fallbackLng: 'en-US' });\n" +
+    "import { isLocaleAvailable } from './localeAvailability';\n" +
+    "export const selectorLocales = ['en-US', 'ar-SA'].filter(isLocaleAvailable);"
+  );
+  writeProjectFile(projectRoot, availabilityPath, `
+    const unavailableLocales = new Set(['ar-SA']);
+    export const isLocaleAvailable = (locale: string) => !unavailableLocales.has(locale);
+  `);
+  writeProjectFile(projectRoot, 'src/components/LanguageSelector.tsx', `
+    import { isLocaleAvailable } from '../i18n/localeAvailability';
+    export function LanguageSelector() {
+      document.documentElement.lang = 'en-US';
+      document.documentElement.dir = 'ltr';
+      return ['en-US', 'ar-SA'].filter(isLocaleAvailable).map((locale) => locale);
+    }
+  `);
+  writeProjectFile(projectRoot, 'src/theme.css', '.card { margin-left: 1rem; }');
+  writeProjectFile(projectRoot, '.powerpages-localization.json', JSON.stringify({
+    schemaVersion: 1,
+    framework: 'react',
+    mode: 'runtime',
+    packageName: 'react-i18next',
+    packageVersion: '^16.0.0',
+    packageVerification: { status: 'verified', source: 'known-capability' },
+    locales: ['en-US', 'ar-SA'],
+    defaultLocale: 'en-US',
+    translationMethod: 'agent',
+    resourcePaths: {
+      'en-US': 'src/i18n/locales/en-US.json',
+      'ar-SA': 'src/i18n/locales/ar-SA.json',
+    },
+    generatedFiles: ['src/components/LanguageSelector.tsx'],
+    managedFiles: ['src/i18n/index.ts', availabilityPath],
+    unavailableLocales: ['ar-SA'],
+    bidirectionalReadiness: {
+      status: 'pending-remediation',
+      findings: [{
+        file: 'src/theme.css',
+        line: 1,
+        rule: 'directional-physical-css',
+        message: 'Use a logical CSS property, or add an adjacent validated bidi-physical exception: .card { margin-left: 1rem; }',
+      }],
+    },
+    adoptedExistingConfiguration: false,
+    lastOperation: 'extend',
+    updatedAt: '2026-07-30T00:00:00.000Z',
+  }));
+
+  const result = validateSiteIntegrity(projectRoot);
+
+  assert.deepEqual(result.errors, []);
+  assert.ok(result.reviewFindings.some((finding) =>
+    finding.rule === 'directional-physical-css' &&
+    /Deferred while opposite-direction locales are unavailable/.test(finding.message)
+  ));
+});
+
+test('pending remediation still blocks newly introduced bidi defects', (t) => {
+  const projectRoot = createTempProject(t);
+  const availabilityPath = 'src/i18n/localeAvailability.ts';
+  writeProjectFile(projectRoot, 'powerpages.config.json', '{}');
+  writeProjectFile(projectRoot, 'package.json', JSON.stringify({
+    dependencies: {
+      react: '^19.0.0',
+      'react-dom': '^19.0.0',
+      i18next: '^25.0.0',
+      'react-i18next': '^16.0.0',
+    },
+  }));
+  writeProjectFile(projectRoot, 'src/i18n/locales/en-US.json', '{"title":"Home"}');
+  writeProjectFile(projectRoot, 'src/i18n/locales/ar-SA.json', '{"title":"الرئيسية"}');
+  writeProjectFile(
+    projectRoot,
+    'src/i18n/index.ts',
+    "import i18next from 'i18next'; i18next.init({ fallbackLng: 'en-US' });\n" +
+    "import { isLocaleAvailable } from './localeAvailability';\n" +
+    "export const selectorLocales = ['en-US', 'ar-SA'].filter(isLocaleAvailable);"
+  );
+  writeProjectFile(projectRoot, availabilityPath, `
+    const unavailableLocales = new Set(['ar-SA']);
+    export const isLocaleAvailable = (locale: string) => !unavailableLocales.has(locale);
+  `);
+  writeProjectFile(projectRoot, 'src/components/LanguageSelector.tsx', `
+    import { isLocaleAvailable } from '../i18n/localeAvailability';
+    export function LanguageSelector() {
+      document.documentElement.lang = 'en-US';
+      document.documentElement.dir = 'ltr';
+      return ['en-US', 'ar-SA'].filter(isLocaleAvailable).map((locale) => locale);
+    }
+  `);
+  writeProjectFile(
+    projectRoot,
+    'src/theme.css',
+    '.known { margin-left: 1rem; }\n.new { padding-right: 1rem; }'
+  );
+  writeProjectFile(projectRoot, '.powerpages-localization.json', JSON.stringify({
+    schemaVersion: 1,
+    framework: 'react',
+    mode: 'runtime',
+    packageName: 'react-i18next',
+    packageVersion: '^16.0.0',
+    packageVerification: { status: 'verified', source: 'known-capability' },
+    locales: ['en-US', 'ar-SA'],
+    defaultLocale: 'en-US',
+    translationMethod: 'agent',
+    resourcePaths: {
+      'en-US': 'src/i18n/locales/en-US.json',
+      'ar-SA': 'src/i18n/locales/ar-SA.json',
+    },
+    generatedFiles: ['src/components/LanguageSelector.tsx'],
+    managedFiles: ['src/i18n/index.ts', availabilityPath],
+    unavailableLocales: ['ar-SA'],
+    bidirectionalReadiness: {
+      status: 'pending-remediation',
+      findings: [{
+        file: 'src/theme.css',
+        line: 1,
+        rule: 'directional-physical-css',
+        message: 'Use a logical CSS property, or add an adjacent validated bidi-physical exception: .known { margin-left: 1rem; }',
+      }],
+    },
+    adoptedExistingConfiguration: false,
+    lastOperation: 'extend',
+    updatedAt: '2026-07-30T00:00:00.000Z',
+  }));
+
+  const result = validateSiteIntegrity(projectRoot);
+
+  assert.equal(result.errors.length, 1);
+  assert.match(result.errors[0], /src\/theme\.css:2/);
+  assert.equal(result.reviewFindings.length, 1);
+});
+
+test('one recorded finding cannot defer a second same-line declaration', (t) => {
+  const projectRoot = createTempProject(t);
+  const availabilityPath = 'src/i18n/localeAvailability.ts';
+  writeProjectFile(projectRoot, 'powerpages.config.json', '{}');
+  writeProjectFile(projectRoot, 'package.json', JSON.stringify({
+    dependencies: {
+      react: '^19.0.0',
+      'react-dom': '^19.0.0',
+      i18next: '^25.0.0',
+      'react-i18next': '^16.0.0',
+    },
+  }));
+  writeProjectFile(projectRoot, 'src/i18n/locales/en-US.json', '{"title":"Home"}');
+  writeProjectFile(projectRoot, 'src/i18n/locales/ar-SA.json', '{"title":"الرئيسية"}');
+  writeProjectFile(
+    projectRoot,
+    'src/i18n/index.ts',
+    "import i18next from 'i18next'; i18next.init({ fallbackLng: 'en-US' });\n" +
+    "import { isLocaleAvailable } from './localeAvailability';\n" +
+    "export const selectorLocales = ['en-US', 'ar-SA'].filter(isLocaleAvailable);"
+  );
+  writeProjectFile(projectRoot, availabilityPath, `
+    const unavailableLocales = new Set(['ar-SA']);
+    export const isLocaleAvailable = (locale: string) => !unavailableLocales.has(locale);
+  `);
+  writeProjectFile(projectRoot, 'src/components/LanguageSelector.tsx', `
+    import { isLocaleAvailable } from '../i18n/localeAvailability';
+    export function LanguageSelector() {
+      document.documentElement.lang = 'en-US';
+      document.documentElement.dir = 'ltr';
+      return ['en-US', 'ar-SA'].filter(isLocaleAvailable).map((locale) => locale);
+    }
+  `);
+  const cssLine = '.known { margin-left: 1rem; padding-right: 1rem; }';
+  writeProjectFile(projectRoot, 'src/theme.css', cssLine);
+  writeProjectFile(projectRoot, '.powerpages-localization.json', JSON.stringify({
+    schemaVersion: 1,
+    framework: 'react',
+    mode: 'runtime',
+    packageName: 'react-i18next',
+    packageVersion: '^16.0.0',
+    packageVerification: { status: 'verified', source: 'known-capability' },
+    locales: ['en-US', 'ar-SA'],
+    defaultLocale: 'en-US',
+    translationMethod: 'agent',
+    resourcePaths: {
+      'en-US': 'src/i18n/locales/en-US.json',
+      'ar-SA': 'src/i18n/locales/ar-SA.json',
+    },
+    generatedFiles: ['src/components/LanguageSelector.tsx'],
+    managedFiles: ['src/i18n/index.ts', availabilityPath],
+    unavailableLocales: ['ar-SA'],
+    bidirectionalReadiness: {
+      status: 'pending-remediation',
+      findings: [{
+        file: 'src/theme.css',
+        line: 1,
+        rule: 'directional-physical-css',
+        message: `Use a logical CSS property, or add an adjacent validated bidi-physical exception: ${cssLine}`,
+      }],
+    },
+    adoptedExistingConfiguration: false,
+    lastOperation: 'extend',
+    updatedAt: '2026-07-30T00:00:00.000Z',
+  }));
+
+  const result = validateSiteIntegrity(projectRoot);
+
+  assert.equal(result.errors.length, 1);
+  assert.equal(result.reviewFindings.length, 1);
+});
+
+test('CLI exits 2 for blocking integrity errors', (t) => {
+  const projectRoot = createTempProject(t);
+  writeProjectFile(projectRoot, 'powerpages.config.json', '{}');
+  writeProjectFile(projectRoot, 'src/Card.css', '.card { padding-right: 1rem; }');
+
+  const result = spawnSync(
+    process.execPath,
+    [CLI_PATH, '--projectRoot', projectRoot],
+    { encoding: 'utf8' }
+  );
+
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /site integrity validation failed/i);
+});

--- a/plugins/power-pages/scripts/tests/site-integrity.test.js
+++ b/plugins/power-pages/scripts/tests/site-integrity.test.js
@@ -8,11 +8,52 @@ const {
   validateSiteIntegrity,
 } = require('../lib/site-integrity');
 const {
+  parseArgs,
+} = require('../validate-site-integrity');
+const {
   createTempProject,
   writeProjectFile,
 } = require('./test-utils');
 
 const CLI_PATH = path.join(__dirname, '..', 'validate-site-integrity.js');
+
+test('parses an optional project root without consuming other options', () => {
+  assert.deepEqual(parseArgs([]), {});
+  assert.equal(parseArgs(['--projectRoot', '.']).projectRoot, path.resolve('.'));
+  assert.throws(
+    () => parseArgs(['--projectRoot']),
+    /"--projectRoot" requires a value/
+  );
+  assert.throws(
+    () => parseArgs(['--projectRoot', '--unexpected']),
+    /"--projectRoot" requires a value/
+  );
+  assert.throws(
+    () => parseArgs(['--projectRoot', '']),
+    /"--projectRoot" requires a value/
+  );
+  assert.throws(
+    () => parseArgs(['--projectRoot', '.', '--projectRoot', '..']),
+    /"--projectRoot" may be specified only once/
+  );
+  assert.throws(
+    () => parseArgs(['--unexpected']),
+    /Unknown or misplaced argument "--unexpected"/
+  );
+});
+
+test('CLI reports malformed project-root usage without validating another path', () => {
+  const result = spawnSync(
+    process.execPath,
+    [CLI_PATH, '--projectRoot', '--unexpected'],
+    { encoding: 'utf8' }
+  );
+
+  assert.equal(result.status, 2);
+  assert.equal(result.stdout, '');
+  assert.match(result.stderr, /"--projectRoot" requires a value/);
+  assert.match(result.stderr, /Usage: validate-site-integrity/);
+});
 
 test('skips declarative Power Pages projects', (t) => {
   const projectRoot = createTempProject(t);

--- a/plugins/power-pages/scripts/tests/validate-localization.test.js
+++ b/plugins/power-pages/scripts/tests/validate-localization.test.js
@@ -2,6 +2,7 @@
 
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const fs = require('fs');
 const path = require('path');
 const { spawnSync } = require('child_process');
 
@@ -176,6 +177,235 @@ test('approves a complete runtime localization setup', (t) => {
   const projectRoot = createLocalizedReactProject(t);
   const result = runValidator(projectRoot);
   assert.equal(result.status, 0, result.stderr);
+});
+
+test('blocks mixed-direction runtime localization without a locale coordinator', (t) => {
+  const projectRoot = createLocalizedReactProject(t, {
+    locales: ['en-US', 'ar-SA'],
+    resourcePaths: {
+      'en-US': 'src/i18n/locales/en-US.json',
+      'ar-SA': 'src/i18n/locales/ar-SA.json',
+    },
+    bidirectionalReadiness: { status: 'ready', findings: [] },
+  });
+  writeProjectFile(projectRoot, 'src/i18n/locales/ar-SA.json', JSON.stringify({
+    greeting: 'مرحبا {{name}}',
+    navigation: { home: 'الرئيسية' },
+  }));
+
+  const result = runValidator(projectRoot);
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /requires one managed locale coordinator/i);
+});
+
+test('approves a mixed-direction runtime localization with a coordinator', (t) => {
+  const coordinatorPath = 'src/i18n/localeCoordinator.ts';
+  const projectRoot = createLocalizedReactProject(t, {
+    locales: ['en-US', 'ar-SA'],
+    resourcePaths: {
+      'en-US': 'src/i18n/locales/en-US.json',
+      'ar-SA': 'src/i18n/locales/ar-SA.json',
+    },
+    managedFiles: ['src/i18n/index.ts', coordinatorPath],
+    bidirectionalReadiness: { status: 'ready', findings: [] },
+  });
+  writeProjectFile(projectRoot, 'src/i18n/locales/ar-SA.json', JSON.stringify({
+    greeting: 'مرحبا {{name}}',
+    navigation: { home: 'الرئيسية' },
+  }));
+  writeProjectFile(projectRoot, coordinatorPath, `
+    import i18next from 'i18next';
+    export async function switchLocale(locale: string) {
+      await i18next.changeLanguage(locale);
+      document.documentElement.lang = locale;
+      document.documentElement.dir = locale === 'ar-SA' ? 'rtl' : 'ltr';
+      localStorage.setItem('site-locale', locale);
+    }
+  `);
+
+  const result = runValidator(projectRoot);
+  assert.equal(result.status, 0, result.stderr);
+});
+
+test('blocks a mixed-direction coordinator with a fixed document direction', (t) => {
+  const coordinatorPath = 'src/i18n/localeCoordinator.ts';
+  const projectRoot = createLocalizedReactProject(t, {
+    locales: ['en-US', 'ar-SA'],
+    resourcePaths: {
+      'en-US': 'src/i18n/locales/en-US.json',
+      'ar-SA': 'src/i18n/locales/ar-SA.json',
+    },
+    managedFiles: ['src/i18n/index.ts', coordinatorPath],
+    bidirectionalReadiness: { status: 'ready', findings: [] },
+  });
+  writeProjectFile(projectRoot, 'src/i18n/locales/ar-SA.json', JSON.stringify({
+    greeting: 'مرحبا {{name}}',
+    navigation: { home: 'الرئيسية' },
+  }));
+  writeProjectFile(projectRoot, coordinatorPath, `
+    import i18next from 'i18next';
+    export async function switchLocale(locale: string) {
+      await i18next.changeLanguage(locale);
+      document.documentElement.lang = locale;
+      document.documentElement.dir = 'ltr';
+      localStorage.setItem('site-locale', locale);
+    }
+  `);
+
+  const result = runValidator(projectRoot);
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /derive document direction from the selected locale/i);
+});
+
+test('enforces unavailable locales for same-direction locale sets', (t) => {
+  const projectRoot = createLocalizedReactProject(t, {
+    unavailableLocales: ['fr-FR'],
+  });
+
+  const result = runValidator(projectRoot);
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /requires one managed locale availability module/i);
+});
+
+test('allows a mixed-direction locale to remain unavailable pending remediation', (t) => {
+  const availabilityPath = 'src/i18n/localeAvailability.ts';
+  const projectRoot = createLocalizedReactProject(t, {
+    locales: ['en-US', 'ar-SA'],
+    resourcePaths: {
+      'en-US': 'src/i18n/locales/en-US.json',
+      'ar-SA': 'src/i18n/locales/ar-SA.json',
+    },
+    unavailableLocales: ['ar-SA'],
+    managedFiles: ['src/i18n/index.ts', availabilityPath],
+    bidirectionalReadiness: {
+      status: 'pending-remediation',
+      findings: [{ rule: 'directional-physical-css' }],
+    },
+  });
+  writeProjectFile(projectRoot, 'src/i18n/locales/ar-SA.json', JSON.stringify({
+    greeting: 'مرحبا {{name}}',
+    navigation: { home: 'الرئيسية' },
+  }));
+  writeProjectFile(projectRoot, 'src/theme.css', '.callout { padding-left: 1rem; }');
+  writeProjectFile(projectRoot, availabilityPath, `
+    const unavailableLocales = new Set(['ar-SA']);
+    export const isLocaleAvailable = (locale: string) => !unavailableLocales.has(locale);
+  `);
+  writeProjectFile(projectRoot, 'src/components/LanguageSelector.tsx', `
+    import { isLocaleAvailable } from '../i18n/localeAvailability';
+    export const LanguageSelector = () => {
+      document.documentElement.lang = 'en-US';
+      document.documentElement.dir = 'ltr';
+      return ['en-US', 'ar-SA'].filter(isLocaleAvailable).map((locale) => locale);
+    };
+  `);
+  fs.appendFileSync(
+    path.join(projectRoot, 'src/i18n/index.ts'),
+    "\nimport { isLocaleAvailable } from './localeAvailability';\n" +
+    "export const selectorLocales = ['en-US', 'ar-SA'].filter(isLocaleAvailable);\n"
+  );
+
+  const result = runValidator(projectRoot);
+  assert.equal(result.status, 0, result.stderr);
+});
+
+test('does not let pending remediation hide an available opposite-direction locale', (t) => {
+  const availabilityPath = 'src/i18n/localeAvailability.ts';
+  const projectRoot = createLocalizedReactProject(t, {
+    locales: ['en-US', 'ar-SA', 'fr-FR'],
+    resourcePaths: {
+      'en-US': 'src/i18n/locales/en-US.json',
+      'ar-SA': 'src/i18n/locales/ar-SA.json',
+      'fr-FR': 'src/i18n/locales/fr-FR.json',
+    },
+    unavailableLocales: ['fr-FR'],
+    managedFiles: ['src/i18n/index.ts', availabilityPath],
+    bidirectionalReadiness: {
+      status: 'pending-remediation',
+      findings: [{ rule: 'directional-physical-css' }],
+    },
+  });
+  const resource = JSON.stringify({
+    greeting: 'Hello {{name}}',
+    navigation: { home: 'Home' },
+  });
+  writeProjectFile(projectRoot, 'src/i18n/locales/ar-SA.json', resource);
+  writeProjectFile(projectRoot, 'src/i18n/locales/fr-FR.json', resource);
+  writeProjectFile(projectRoot, 'src/theme.css', '.callout { padding-left: 1rem; }');
+  writeProjectFile(projectRoot, availabilityPath, `
+    const unavailableLocales = new Set(['fr-FR']);
+    export const isLocaleAvailable = (locale: string) => !unavailableLocales.has(locale);
+  `);
+  writeProjectFile(projectRoot, 'src/components/LanguageSelector.tsx', `
+    import { isLocaleAvailable } from '../i18n/localeAvailability';
+    export const LanguageSelector = () => {
+      document.documentElement.lang = 'en-US';
+      document.documentElement.dir = 'ltr';
+      return ['en-US', 'ar-SA'].filter(isLocaleAvailable).map((locale) => locale);
+    };
+  `);
+  fs.appendFileSync(
+    path.join(projectRoot, 'src/i18n/index.ts'),
+    "\nimport { isLocaleAvailable } from './localeAvailability';\n" +
+    "export const selectorLocales = ['en-US', 'ar-SA'].filter(isLocaleAvailable);\n"
+  );
+
+  const result = runValidator(projectRoot);
+  assert.equal(result.status, 2);
+  assert.match(
+    result.stderr,
+    /every locale opposite to the default direction to be unavailable/i
+  );
+  assert.match(result.stderr, /directional-physical-css/i);
+});
+
+test('requires pending locale availability to be applied at activation boundaries', (t) => {
+  const availabilityPath = 'src/i18n/localeAvailability.ts';
+  const projectRoot = createLocalizedReactProject(t, {
+    locales: ['en-US', 'ar-SA'],
+    resourcePaths: {
+      'en-US': 'src/i18n/locales/en-US.json',
+      'ar-SA': 'src/i18n/locales/ar-SA.json',
+    },
+    unavailableLocales: ['ar-SA'],
+    managedFiles: ['src/i18n/index.ts', availabilityPath],
+    bidirectionalReadiness: {
+      status: 'pending-remediation',
+      findings: [{ rule: 'directional-physical-css' }],
+    },
+  });
+  writeProjectFile(projectRoot, 'src/i18n/locales/ar-SA.json', JSON.stringify({
+    greeting: 'مرحبا {{name}}',
+    navigation: { home: 'الرئيسية' },
+  }));
+  writeProjectFile(projectRoot, 'src/theme.css', '.callout { padding-left: 1rem; }');
+  writeProjectFile(projectRoot, availabilityPath, `
+    const unavailableLocales = new Set(['ar-SA']);
+    export const isLocaleAvailable = (locale: string) => !unavailableLocales.has(locale);
+  `);
+
+  const result = runValidator(projectRoot);
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /does not apply isLocaleAvailable/i);
+  assert.match(result.stderr, /directional-physical-css/i);
+});
+
+test('requires readiness metadata for mixed-direction localization', (t) => {
+  const projectRoot = createLocalizedReactProject(t, {
+    locales: ['en-US', 'ar-SA'],
+    resourcePaths: {
+      'en-US': 'src/i18n/locales/en-US.json',
+      'ar-SA': 'src/i18n/locales/ar-SA.json',
+    },
+  });
+  writeProjectFile(projectRoot, 'src/i18n/locales/ar-SA.json', JSON.stringify({
+    greeting: 'مرحبا {{name}}',
+    navigation: { home: 'الرئيسية' },
+  }));
+
+  const result = runValidator(projectRoot);
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /requires manifest bidirectionalReadiness metadata/i);
 });
 
 test('approves an explicitly unverified custom package with initialization evidence', (t) => {

--- a/plugins/power-pages/scripts/tests/validate-localization.test.js
+++ b/plugins/power-pages/scripts/tests/validate-localization.test.js
@@ -82,6 +82,43 @@ function createLocalizedReactProject(t, overrides = {}) {
   return projectRoot;
 }
 
+function createUnavailableLocaleProject(t, availabilitySource) {
+  const availabilityPath = 'src/i18n/localeAvailability.ts';
+  const projectRoot = createLocalizedReactProject(t, {
+    locales: ['en-US', 'ar-SA'],
+    resourcePaths: {
+      'en-US': 'src/i18n/locales/en-US.json',
+      'ar-SA': 'src/i18n/locales/ar-SA.json',
+    },
+    unavailableLocales: ['ar-SA'],
+    managedFiles: ['src/i18n/index.ts', availabilityPath],
+    bidirectionalReadiness: {
+      status: 'pending-remediation',
+      findings: [{ rule: 'directional-physical-css' }],
+    },
+  });
+  writeProjectFile(projectRoot, 'src/i18n/locales/ar-SA.json', JSON.stringify({
+    greeting: 'مرحبا {{name}}',
+    navigation: { home: 'الرئيسية' },
+  }));
+  writeProjectFile(projectRoot, 'src/theme.css', '.callout { padding-left: 1rem; }');
+  writeProjectFile(projectRoot, availabilityPath, availabilitySource);
+  writeProjectFile(projectRoot, 'src/components/LanguageSelector.tsx', `
+    import { isLocaleAvailable } from '../i18n/localeAvailability';
+    export const LanguageSelector = () => {
+      document.documentElement.lang = 'en-US';
+      document.documentElement.dir = 'ltr';
+      return ['en-US', 'ar-SA'].filter(isLocaleAvailable);
+    };
+  `);
+  fs.appendFileSync(
+    path.join(projectRoot, 'src/i18n/index.ts'),
+    "\nimport { isLocaleAvailable } from './localeAvailability';\n" +
+    "export const selectorLocales = ['en-US', 'ar-SA'].filter(isLocaleAvailable);\n"
+  );
+  return projectRoot;
+}
+
 test('approves when no localization manifest exists', (t) => {
   const projectRoot = createTempProject(t);
   writeProjectFile(projectRoot, 'powerpages.config.json', '{}');
@@ -311,6 +348,75 @@ test('allows a mixed-direction locale to remain unavailable pending remediation'
 
   const result = runValidator(projectRoot);
   assert.equal(result.status, 0, result.stderr);
+});
+
+test('accepts equivalent unavailable-locale rejection forms', (t) => {
+  const implementations = [
+    `
+      const unavailableLocales = new Set(['ar-SA']);
+      export const isLocaleAvailable = (locale: string) =>
+        unavailableLocales.has(locale) === false;
+    `,
+    `
+      const unavailableLocales = ['ar-SA'];
+      export function isLocaleAvailable(locale: string) {
+        if (unavailableLocales.includes(locale)) return false;
+        return true;
+      }
+    `,
+    `
+      const unavailableLocales = new Set(['ar-SA']);
+      export const isLocaleAvailable = (locale: string) =>
+        unavailableLocales.has(locale) ? false : true;
+    `,
+    `
+      const unavailableLocales = new Set(['ar-SA']);
+      export const isLocaleAvailable = (locale: string) =>
+        true !== unavailableLocales.has(locale);
+    `,
+    `
+      const unavailableLocales = new Set(['ar-SA']);
+      const isLocaleUnavailable = (locale: string) =>
+        unavailableLocales.has(locale);
+      export const isLocaleAvailable = (locale: string) =>
+        !isLocaleUnavailable(locale);
+    `,
+  ];
+
+  for (const implementation of implementations) {
+    const projectRoot = createUnavailableLocaleProject(t, implementation);
+    const result = runValidator(projectRoot);
+    assert.equal(result.status, 0, `${implementation}\n${result.stderr}`);
+  }
+});
+
+test('rejects inverted unavailable-locale predicates', (t) => {
+  const implementations = [
+    `
+      const unavailableLocales = new Set(['ar-SA']);
+      export const isLocaleAvailable = (locale: string) =>
+        unavailableLocales.has(locale);
+    `,
+    `
+      const unavailableLocales = new Set(['ar-SA']);
+      export const isLocaleAvailable = (locale: string) =>
+        unavailableLocales.has(locale) === true;
+    `,
+    `
+      const unavailableLocales = new Set(['ar-SA']);
+      export function isLocaleAvailable(locale: string) {
+        if (!unavailableLocales.has(locale)) return false;
+        return true;
+      }
+    `,
+  ];
+
+  for (const implementation of implementations) {
+    const projectRoot = createUnavailableLocaleProject(t, implementation);
+    const result = runValidator(projectRoot);
+    assert.equal(result.status, 2);
+    assert.match(result.stderr, /must export isLocaleAvailable and reject entries/i);
+  }
 });
 
 test('does not let pending remediation hide an available opposite-direction locale', (t) => {

--- a/plugins/power-pages/scripts/tests/validate-localization.test.js
+++ b/plugins/power-pages/scripts/tests/validate-localization.test.js
@@ -264,7 +264,11 @@ test('enforces unavailable locales for same-direction locale sets', (t) => {
 
   const result = runValidator(projectRoot);
   assert.equal(result.status, 2);
-  assert.match(result.stderr, /requires one managed locale availability module/i);
+  assert.match(
+    result.stderr,
+    /Unavailable locales require one managed locale availability module/i
+  );
+  assert.doesNotMatch(result.stderr, /Pending bidirectional remediation requires one/i);
 });
 
 test('allows a mixed-direction locale to remain unavailable pending remediation', (t) => {

--- a/plugins/power-pages/scripts/tests/validate-localization.test.js
+++ b/plugins/power-pages/scripts/tests/validate-localization.test.js
@@ -381,6 +381,42 @@ test('accepts equivalent unavailable-locale rejection forms', (t) => {
       export const isLocaleAvailable = (locale: string) =>
         !isLocaleUnavailable(locale);
     `,
+    "const unavailableLocales = new Set(['ar-SA']);\r\n" +
+      "export const isLocaleAvailable = (locale: string) =>\r\n" +
+      "  !unavailableLocales.has(\r\n" +
+      "    locale\r\n" +
+      "  );\r\n",
+    `
+      const unavailableLocales = new Set(['ar-SA']);
+      const normalizeLocale = (locale: string) => locale;
+      export const isLocaleAvailable = (locale: string) =>
+        unavailableLocales.has(
+          normalizeLocale(locale)
+        ) === false;
+    `,
+    `
+      const unavailableLocales = new Set(['ar-SA']);
+      export const isLocaleAvailable = (locale: string) =>
+        unavailableLocales.has /* set membership */ (
+          locale
+        ) ? false : true;
+    `,
+    `
+      const unavailableLocales = new Set(['ar-SA']);
+      export const isLocaleAvailable = (locale: string) =>
+        unavailableLocales.has(locale.replace(')', '')) === false;
+    `,
+    `
+      const unavailableLocales = new Set(['ar-SA']);
+      const isLocaleUnavailable = (locale: string) =>
+        unavailableLocales.has(
+          locale
+        );
+      export const isLocaleAvailable = (locale: string) =>
+        !isLocaleUnavailable(
+          locale
+        );
+    `,
   ];
 
   for (const implementation of implementations) {
@@ -408,6 +444,26 @@ test('rejects inverted unavailable-locale predicates', (t) => {
         if (!unavailableLocales.has(locale)) return false;
         return true;
       }
+    `,
+    `
+      const unavailableLocales = new Set(['ar-SA']);
+      function unrelated(locale: string) {
+        return !unavailableLocales.has(locale);
+      }
+      export const isLocaleAvailable = (locale: string) =>
+        unavailableLocales.has(locale);
+    `,
+    `
+      const unavailableLocales = new Set(['ar-SA']);
+      // Example only: return !unavailableLocales.has(locale);
+      export const isLocaleAvailable = (locale: string) =>
+        unavailableLocales.has(locale);
+    `,
+    `
+      const unavailableLocales = new Set(['ar-SA']);
+      const example = 'return !unavailableLocales.has(locale)';
+      export const isLocaleAvailable = (locale: string) =>
+        unavailableLocales.has(locale);
     `,
   ];
 

--- a/plugins/power-pages/scripts/tests/validate-site.test.js
+++ b/plugins/power-pages/scripts/tests/validate-site.test.js
@@ -61,3 +61,15 @@ test('create-site validator blocks a direction mismatch', (t) => {
   assert.equal(result.status, 2);
   assert.match(result.stderr, /resolves to "rtl"/);
 });
+
+test('create-site validator blocks direction-sensitive physical CSS', (t) => {
+  const projectRoot = createProject(
+    t,
+    '<html lang="en-US" dir="ltr"><body><div id="root"></div></body></html>'
+  );
+  writeProjectFile(projectRoot, 'src/theme.css', '.callout { padding-left: 1rem; }');
+
+  const result = runValidator(projectRoot);
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /Bidirectional readiness.*directional-physical-css/);
+});

--- a/plugins/power-pages/scripts/validate-site-integrity.js
+++ b/plugins/power-pages/scripts/validate-site-integrity.js
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+'use strict';
+
+const path = require('path');
+const {
+  findProjectRoot,
+} = require('./lib/validation-helpers');
+const {
+  validateSiteIntegrity,
+} = require('./lib/site-integrity');
+
+function parseArgs(argv) {
+  const args = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    if (argv[index] === '--projectRoot') args.projectRoot = argv[index + 1];
+  }
+  return args;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const requestedRoot = path.resolve(args.projectRoot || process.cwd());
+  const projectRoot = findProjectRoot(requestedRoot);
+  if (!projectRoot) {
+    process.stdout.write('[power-pages] Site integrity skipped: no Power Pages project found.\n');
+    return 0;
+  }
+
+  const result = validateSiteIntegrity(projectRoot);
+  if (result.skipped) {
+    process.stdout.write(`[power-pages] Site integrity skipped: ${result.reason}\n`);
+    return 0;
+  }
+
+  for (const finding of result.reviewFindings) {
+    process.stdout.write(
+      `[power-pages] Site integrity review ${finding.file}:${finding.line} ` +
+      `[${finding.rule}]: ${finding.message}\n`
+    );
+  }
+  if (result.errors.length > 0) {
+    process.stderr.write(
+      `[power-pages] Site integrity validation failed:\n- ${result.errors.join('\n- ')}\n`
+    );
+    return 2;
+  }
+  process.stdout.write('[power-pages] Site integrity validation passed.\n');
+  return 0;
+}
+
+if (require.main === module) {
+  process.exitCode = main();
+}
+
+module.exports = {
+  main,
+  parseArgs,
+};

--- a/plugins/power-pages/scripts/validate-site-integrity.js
+++ b/plugins/power-pages/scripts/validate-site-integrity.js
@@ -6,16 +6,16 @@ const {
   findProjectRoot,
 } = require('./lib/validation-helpers');
 const {
+  parseOptionalProjectRootArgs,
+} = require('./lib/cli-arguments');
+const {
   validateSiteIntegrity,
 } = require('./lib/site-integrity');
 
-function parseArgs(argv) {
-  const args = {};
-  for (let index = 0; index < argv.length; index += 1) {
-    if (argv[index] === '--projectRoot') args.projectRoot = argv[index + 1];
-  }
-  return args;
-}
+const USAGE =
+  'Usage: validate-site-integrity.js [--projectRoot <path>]';
+
+const parseArgs = (argv) => parseOptionalProjectRootArgs(argv, USAGE);
 
 function main() {
   const args = parseArgs(process.argv.slice(2));
@@ -49,7 +49,12 @@ function main() {
 }
 
 if (require.main === module) {
-  process.exitCode = main();
+  try {
+    process.exitCode = main();
+  } catch (error) {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 2;
+  }
 }
 
 module.exports = {

--- a/plugins/power-pages/skills/add-ai-webapi/SKILL.md
+++ b/plugins/power-pages/skills/add-ai-webapi/SKILL.md
@@ -91,6 +91,7 @@ Integrate Power Pages generative-AI summarization APIs into a SPA site. This ski
 - **Raw `fetch` + CSRF.** Every summarization request attaches `__RequestVerificationToken` (from `/_layout/tokenhtml`) and `X-Requested-With: XMLHttpRequest`. Never route through an OData wrapper.
 - **Skip `/integrate-webapi` when it's not needed.** If every confirmed target is Search Summary (which has no per-table Web API prerequisites), or every Layer 1/2 prerequisite already exists on disk, the skill goes straight from Phase 3 to Phase 5.
 - **Use TaskCreate/TaskUpdate** — create the todo list upfront with all phases before starting.
+- **Preserve site integrity.** Before adding or tweaking an AI surface, read `${PLUGIN_ROOT}/references/site-modification-integrity.md`; localization covers labels, loading, empty, error, citation, recommendation, and remediation states, and the UI must remain bidirectional and expansion-safe.
 
 > **Prerequisites:**
 >

--- a/plugins/power-pages/skills/add-cloud-flow/SKILL.md
+++ b/plugins/power-pages/skills/add-cloud-flow/SKILL.md
@@ -29,6 +29,7 @@ For already-registered flows, the skill skips metadata and role creation and goe
 - **Web roles drive access**: Every flow must have at least one web role. Anonymous Users role is valid but must be confirmed.
 - **Scenario determines roles**: Understand what each flow does and who triggers it before picking roles.
 - **Use TaskCreate/TaskUpdate**: Track all phases upfront before starting any work.
+- **Preserve site integrity**: Before wiring a flow into a page or component, read `${PLUGIN_ROOT}/references/site-modification-integrity.md`; localize every new visible state when configured and keep the UI bidirectional and expansion-safe.
 
 > **Prerequisites:**
 > - An existing Power Pages code site with `.powerpages-site` deployed

--- a/plugins/power-pages/skills/add-localization/SKILL.md
+++ b/plugins/power-pages/skills/add-localization/SKILL.md
@@ -22,7 +22,8 @@ environment languages or translates Dataverse records.
 
 **Initial request:** $ARGUMENTS
 
-Read `${PLUGIN_ROOT}/references/i18n-frameworks.md` before planning or editing.
+Read `${PLUGIN_ROOT}/references/i18n-frameworks.md` and
+`${PLUGIN_ROOT}/references/bidirectional-design.md` before planning or editing.
 
 ## Core principles
 
@@ -37,6 +38,8 @@ Read `${PLUGIN_ROOT}/references/i18n-frameworks.md` before planning or editing.
 - Always show: **AI translations may contain errors - please verify them before publishing.**
 - Treat `[FROM_CREATE_SITE]` in `$ARGUMENTS` as invocation context. It suppresses
   this skill's deploy prompt so create-site remains deployment owner.
+- Generate a locale coordinator only for React, Vue, and runtime Angular.
+  Single-language, Angular static, and Astro static sites do not receive it.
 
 ## Workflow
 
@@ -253,6 +256,27 @@ Use `AskUserQuestion`:
 
 If agent-generated is selected, immediately display the AI translation warning.
 
+### 2.6 Direction transition and readiness audit
+
+Resolve every existing and proposed locale with:
+
+```bash
+node "${PLUGIN_ROOT}/scripts/lib/localization-config.js" resolve-locale --locale "<LOCALE>"
+```
+
+Classify the existing and resulting sets as `ltr-only`, `rtl-only`, or `mixed`.
+When this operation first changes an LTR-only or RTL-only site to `mixed`, run:
+
+```bash
+node "${PLUGIN_ROOT}/scripts/audit-bidirectional-readiness.js" --projectRoot "<PROJECT_ROOT>"
+```
+
+Add every finding to the Phase 3 plan. Include logical-CSS remediation,
+validated physical exceptions, mixed/user content, localized formatting,
+script font coverage, directional assets, calendars/date-pickers, gestures,
+drawers, breadcrumbs, tables, charts, carousels, overlays, SVG/canvas, and
+third-party components. Do not modify files before plan approval.
+
 ---
 
 ## Phase 3: Plan and approve
@@ -271,6 +295,9 @@ Present:
   and the approved canonical `lang` plus resolved `dir` attribute repair.
 - Language-selector placement and runtime/static behavior.
 - Build, validator, browser, RTL, and token checks.
+- Direction-set transition, readiness findings, proposed remediations, physical
+  exceptions, script-font changes, and whether any locale may remain
+  unavailable pending remediation.
 - Known limitations and any approved translation replacements.
 
 <!-- gate: add-localization:3.plan-approval | category=plan | cancel-leaves=nothing -->
@@ -302,6 +329,12 @@ or resource hierarchy. In repair mode, apply only the approved delta. Never
 remove a package, switch Angular mode, or replace custom initialization unless
 the approved plan names that change.
 
+For runtime mode, create or adopt exactly one locale coordinator at the path
+defined in the framework reference. The language selector must call
+`switchLocale`; it must not independently update translations, persistence,
+`lang`, or `dir`. Add metadata/font preparation and geometry notifications only
+when the site needs them. Do not create a coordinator for static mode.
+
 ---
 
 ## Phase 5: Extract and localize content
@@ -331,6 +364,12 @@ approved root-document repair: set static `lang` to the approved canonical
 default locale and `dir` to that locale's resolved direction. Do not infer or
 substitute a different source locale during implementation.
 
+Apply approved bidirectional remediation. Use logical CSS by default. Add
+`<bdi>`/`dir="auto"` at unknown-content boundaries, explicit isolation for
+machine values, `Intl` formatting for locale-sensitive data, and script-aware
+font profiles only where the configured scripts need them. Preserve brand
+character across font profiles.
+
 Write `.powerpages-localization.json` using reference schema version 1
 after the approved implementation is complete. Record `packageVerification`
 from the package-validator result. For an unverified alternative, record
@@ -350,6 +389,17 @@ For Astro built-in i18n, no npm package-validator result exists. Record
   "source": "known-capability"
 }
 ```
+
+For mixed-direction sets, also record `bidirectionalReadiness`. Keep a locale
+in `unavailableLocales` when technical blockers remain. It must be excluded
+from selectors, browser auto-detection, alternate-language metadata, and
+production static output. Its resources may remain available in development
+for remediation. Generate one managed `localeAvailability` module that exports
+`isLocaleAvailable`, rejects entries in `unavailableLocales`, and is applied
+by every selector, locale switch/detection path, alternate-language metadata
+generator, and static locale output configuration. The manifest alone does not
+disable a locale. While readiness is `pending-remediation`, every configured
+locale whose direction is opposite to the default locale remains unavailable.
 
 ---
 
@@ -371,10 +421,17 @@ with Playwright:
 - `html[lang]` and `html[dir]`.
 - Browser console has no localization errors.
 - One RTL locale when configured.
+- Every representative route in one LTR and one RTL locale at desktop and
+  narrow/mobile viewports when the configured set is mixed.
+- Script font loading, mixed-direction names/comments/URLs/identifiers,
+  locale-aware dates/numbers/percentages, directional icons, calendars, and
+  any audited complex component.
 
 For static modes, verify equivalent locale URLs/builds. For runtime modes,
 verify persisted selection, browser-language matching, invalid saved-value
-fallback, and no page reload during switching.
+fallback, no page reload, and both LTR -> RTL -> LTR and RTL -> LTR -> RTL
+round trips. Preserve route, form state, focus, and application state. Verify
+that stale resource requests cannot overwrite a newer selection.
 
 For an explicitly unverified package, all build, initialization, switching or
 route navigation, resource loading, `lang`/`dir`, and console checks are
@@ -392,6 +449,15 @@ with a one-line reason. Include locale/key counts, blank/stale values,
 translation warning, build result, browser checks, and RTL areas needing
 manual visual review.
 
+Classify the result as:
+
+- **Ready** — the new locale may be enabled.
+- **Approved with limitations** — only usable degradation remains; show the
+  exact component/page impact and browser evidence.
+- **Pending remediation** — build/runtime failure, incorrect `lang`/`dir`,
+  unreadable text, unreachable critical controls, or serious accessibility
+  failure remains; keep the affected locale unavailable.
+
 <!-- gate: add-localization:7.review | category=plan | cancel-leaves=localized-site-files -->
 
 > 🚦 **Gate (plan · add-localization:7.review):** Maker accepts the verified localization result or requests a focused revision.
@@ -400,8 +466,19 @@ manual visual review.
 > **Why we ask:** Translation wording and selector placement require maker review even when technical checks pass.
 > **Cancel leaves:** Localized site files — the verified localization changes remain on disk for review or revision.
 
-Use `AskUserQuestion` with **Accept changes** and **Request revisions**. Apply
-requested revisions, then repeat Phase 6 and this gate.
+Use `AskUserQuestion`:
+
+- For **Ready**: **Accept changes** and **Request revisions**.
+- For usable limitations: **Fix before enabling**, **Enable with documented
+  limitations**, **Save but keep locale unavailable**, and **Request revisions**.
+- For **Pending remediation**: **Fix blockers now**, **Save but keep locale
+  unavailable**, and **Request revisions**. Do not offer enablement.
+
+Explicit acceptance applies only to usable degradation. It cannot override a
+build/runtime failure, incorrect direction, unreadable content, unreachable
+critical control, or serious accessibility failure. Apply requested revisions,
+then repeat Phase 6 and this gate. If the maker saves a pending locale, do not
+offer deployment in Phase 8.
 
 ---
 

--- a/plugins/power-pages/skills/add-localization/SKILL.md
+++ b/plugins/power-pages/skills/add-localization/SKILL.md
@@ -23,7 +23,9 @@ environment languages or translates Dataverse records.
 **Initial request:** $ARGUMENTS
 
 Read `${PLUGIN_ROOT}/references/i18n-frameworks.md` and
-`${PLUGIN_ROOT}/references/bidirectional-design.md` before planning or editing.
+`${PLUGIN_ROOT}/references/bidirectional-design.md` before planning or editing. Also apply
+`${PLUGIN_ROOT}/references/site-modification-integrity.md` to all existing and future visible
+site changes.
 
 ## Core principles
 
@@ -400,6 +402,8 @@ by every selector, locale switch/detection path, alternate-language metadata
 generator, and static locale output configuration. The manifest alone does not
 disable a locale. While readiness is `pending-remediation`, every configured
 locale whose direction is opposite to the default locale remains unavailable.
+Record each pending scanner finding with its exact `file`, `line`, `rule`, and `message`
+so lifecycle validation can defer known work without allowing new regressions.
 
 ---
 

--- a/plugins/power-pages/skills/add-localization/scripts/validate-localization.js
+++ b/plugins/power-pages/skills/add-localization/scripts/validate-localization.js
@@ -13,13 +13,18 @@ const {
   KNOWN_PACKAGES,
   LOCALIZATION_CAPABILITIES,
   MANIFEST_NAME,
+  classifyLocaleDirections,
   detectFramework,
   detectLocalization,
   hasLocaleNavigationSignal,
+  getLocaleDirection,
   protectedTokenSignature,
   validateLocalizationManifestShape,
   validateLocales,
 } = require('../../../scripts/lib/localization-config');
+const {
+  auditBidirectionalReadiness,
+} = require('../../../scripts/lib/bidirectional-readiness');
 
 function readJson(filePath) {
   try {
@@ -253,6 +258,24 @@ function validateLocalization(projectRoot) {
     if (!manifest.locales.includes(manifest.defaultLocale)) {
       errors.push('Manifest defaultLocale must be one of the configured locales.');
     }
+    if (Array.isArray(manifest.unavailableLocales)) {
+      const unavailableValidation = validateLocales(manifest.unavailableLocales);
+      if (!unavailableValidation.valid || unavailableValidation.duplicates.length ||
+          unavailableValidation.canonicalization.length ||
+          unavailableValidation.locales.length !== manifest.unavailableLocales.length) {
+        errors.push(
+          'Manifest unavailableLocales must be valid, canonical, and unique BCP-47 tags.'
+        );
+      }
+      for (const locale of manifest.unavailableLocales) {
+        if (!manifest.locales.includes(locale)) {
+          errors.push(`Unavailable locale ${locale} must also appear in manifest locales.`);
+        }
+        if (locale === manifest.defaultLocale) {
+          errors.push('Manifest defaultLocale cannot be unavailable.');
+        }
+      }
+    }
   }
 
   const packageJson = readJson(path.join(projectRoot, 'package.json')) || {};
@@ -304,6 +327,72 @@ function validateLocalization(projectRoot) {
     errors.push('Managed files do not configure document language (lang).');
   }
 
+  const unavailableLocales = Array.isArray(manifest.unavailableLocales)
+    ? manifest.unavailableLocales
+    : [];
+  const hasAvailabilityImplementation = unavailableLocales.length > 0
+    ? validateLocaleAvailability(
+      projectRoot,
+      allManagedFiles,
+      unavailableLocales,
+      errors
+    )
+    : true;
+
+  if (Array.isArray(manifest.locales) && manifest.locales.length >= 2) {
+    const directionSet = classifyLocaleDirections(manifest.locales);
+    if (directionSet.classification === 'mixed') {
+      const bidiAudit = auditBidirectionalReadiness(projectRoot);
+      const readinessPending =
+        manifest.bidirectionalReadiness?.status === 'pending-remediation';
+      if (!manifest.bidirectionalReadiness) {
+        errors.push(
+          'Mixed-direction localization requires manifest bidirectionalReadiness metadata.'
+        );
+      }
+      const unavailableLocaleSet = new Set(unavailableLocales);
+      const defaultDirection = getLocaleDirection(manifest.defaultLocale);
+      const oppositeDirectionLocales = manifest.locales.filter(
+        (locale) => getLocaleDirection(locale) !== defaultDirection
+      );
+      const allOppositeLocalesUnavailable = oppositeDirectionLocales.every(
+        (locale) => unavailableLocaleSet.has(locale)
+      );
+      if (readinessPending && !allOppositeLocalesUnavailable) {
+        errors.push(
+          'Pending bidirectional remediation requires every locale opposite to the ' +
+          'default direction to be unavailable.'
+        );
+      }
+      if (readinessPending && !hasAvailabilityImplementation) {
+        errors.push(
+          'Pending bidirectional remediation requires managed availability logic that ' +
+          'excludes each unavailable opposite-direction locale.'
+        );
+      }
+      const canSuppressReadinessErrors =
+        readinessPending &&
+        allOppositeLocalesUnavailable &&
+        hasAvailabilityImplementation;
+      if (!canSuppressReadinessErrors) {
+        for (const finding of bidiAudit.findings.filter((item) => item.severity === 'error')) {
+          errors.push(
+            `Bidirectional readiness ${finding.file}:${finding.line} ` +
+            `[${finding.rule}]: ${finding.message}`
+          );
+        }
+      }
+      const availableLocales = manifest.locales.filter(
+        (locale) => !unavailableLocaleSet.has(locale)
+      );
+      const availableDirectionSet = classifyLocaleDirections(availableLocales);
+      if (manifest.mode === 'runtime' &&
+          availableDirectionSet.classification === 'mixed') {
+        validateRuntimeCoordinator(projectRoot, allManagedFiles, errors);
+      }
+    }
+  }
+
   return errors;
 }
 
@@ -328,6 +417,120 @@ function configuresDocumentAttribute(source, attribute) {
   return propertyAssignment.test(source) ||
     setAttribute.test(source) ||
     staticHtmlAttribute.test(source);
+}
+
+function validateLocaleAvailability(
+  projectRoot,
+  allManagedFiles,
+  unavailableLocales,
+  errors
+) {
+  const availabilityPaths = allManagedFiles.filter((relativePath) =>
+    /locale[-_.]?availability/i.test(path.basename(relativePath))
+  );
+  if (availabilityPaths.length !== 1) {
+    errors.push(
+      'Pending bidirectional remediation requires one managed locale availability module.'
+    );
+    return false;
+  }
+
+  const availabilityPath = availabilityPaths[0];
+  const fullAvailabilityPath = path.join(projectRoot, availabilityPath);
+  if (!fs.existsSync(fullAvailabilityPath)) return false;
+  const availabilitySource = fs.readFileSync(fullAvailabilityPath, 'utf8');
+  let valid = true;
+  if (!/\bexport\s+(?:function|const)\s+isLocaleAvailable\b/.test(availabilitySource) ||
+      !/!\s*unavailableLocales\.(?:has|includes)\s*\(/.test(availabilitySource)) {
+    errors.push(
+      'The locale availability module must export isLocaleAvailable and reject ' +
+      'entries in unavailableLocales.'
+    );
+    valid = false;
+  }
+  for (const locale of unavailableLocales) {
+    if (!availabilitySource.includes(locale)) {
+      errors.push(`Locale availability module does not exclude ${locale}.`);
+      valid = false;
+    }
+  }
+
+  const boundaryPattern =
+    /LanguageSelector|language selector|locale-switcher|switchLanguage|changeLanguage|navigator\.languages?|\bhreflang\b|rel\s*=\s*['"]alternate|(?:^|\W)locales?\s*:/im;
+  const boundaryFiles = allManagedFiles
+    .filter((relativePath) => relativePath !== availabilityPath)
+    .filter((relativePath) => fs.existsSync(path.join(projectRoot, relativePath)))
+    .map((relativePath) => ({
+      relativePath,
+      source: fs.readFileSync(path.join(projectRoot, relativePath), 'utf8'),
+    }))
+    .filter(({ source }) => boundaryPattern.test(source));
+  for (const { relativePath, source } of boundaryFiles) {
+    if (!/\bisLocaleAvailable\s*\(|\bfilter\s*\(\s*isLocaleAvailable\b/.test(source)) {
+      errors.push(
+        `Locale activation boundary ${relativePath} does not apply isLocaleAvailable.`
+      );
+      valid = false;
+    }
+  }
+  if (boundaryFiles.length === 0) {
+    errors.push(
+      'Managed files do not expose a locale activation boundary that applies availability.'
+    );
+    valid = false;
+  }
+  return valid;
+}
+
+function validateRuntimeCoordinator(projectRoot, allManagedFiles, errors) {
+  const coordinatorPaths = allManagedFiles.filter((relativePath) =>
+    /locale[-_.]?coordinator/i.test(path.basename(relativePath))
+  );
+  if (coordinatorPaths.length !== 1) {
+    errors.push(
+      'Mixed-direction runtime localization requires one managed locale coordinator file.'
+    );
+    return;
+  }
+
+  const [coordinatorPath] = coordinatorPaths;
+  const fullPath = path.join(projectRoot, coordinatorPath);
+  if (!fs.existsSync(fullPath)) return;
+  const source = fs.readFileSync(fullPath, 'utf8');
+  const requirements = [
+    [/switchLocale/i, 'an exported or public switchLocale operation'],
+    [
+      /document\.documentElement\.(?:lang|setAttribute\(['"]lang)/i,
+      'document language updates',
+    ],
+    [
+      /document\.documentElement\.(?:dir|setAttribute\(['"]dir)/i,
+      'document direction updates',
+    ],
+    [
+      /changeLanguage|setActiveLang|locale\.value|activeLocale/i,
+      'localization-library activation',
+    ],
+    [/localStorage/i, 'locale preference persistence'],
+  ];
+  for (const [pattern, description] of requirements) {
+    if (!pattern.test(source)) {
+      errors.push(`Locale coordinator ${coordinatorPath} is missing ${description}.`);
+    }
+  }
+  const localeDerivedDirection =
+    /document\.documentElement\.dir\s*=\s*(?!['"](?:ltr|rtl)['"]\s*;)[^;\n]*(?:locale|direction|dirBy|resolve|getLocale)/i.test(
+      source
+    ) ||
+    /document\.documentElement\.setAttribute\(\s*['"]dir['"]\s*,\s*(?!['"](?:ltr|rtl)['"]\s*\))[^)\n]*(?:locale|direction|dirBy|resolve|getLocale)/i.test(
+      source
+    );
+  if (!localeDerivedDirection) {
+    errors.push(
+      `Locale coordinator ${coordinatorPath} must derive document direction from ` +
+      'the selected locale instead of assigning a fixed direction.'
+    );
+  }
 }
 
 function validateFrameworkModePackage(projectRoot, manifest, dependencies, detected, errors) {
@@ -409,4 +612,5 @@ module.exports = {
   validateManifestShape: validateLocalizationManifestShape,
   validateFrameworkModePackage,
   validateLocalization,
+  validateRuntimeCoordinator,
 };

--- a/plugins/power-pages/skills/add-localization/scripts/validate-localization.js
+++ b/plugins/power-pages/skills/add-localization/scripts/validate-localization.js
@@ -419,8 +419,216 @@ function configuresDocumentAttribute(source, attribute) {
     staticHtmlAttribute.test(source);
 }
 
+function readIgnoredSourceSegment(source, index) {
+  const quote = source[index];
+  if (quote === '"' || quote === "'" || quote === '`') {
+    let escaped = false;
+    for (let cursor = index + 1; cursor < source.length; cursor += 1) {
+      if (escaped) {
+        escaped = false;
+      } else if (source[cursor] === '\\') {
+        escaped = true;
+      } else if (source[cursor] === quote) {
+        return cursor + 1;
+      }
+    }
+    return source.length;
+  }
+  if (source.startsWith('//', index)) {
+    const newline = source.indexOf('\n', index + 2);
+    return newline < 0 ? source.length : newline;
+  }
+  if (source.startsWith('/*', index)) {
+    const end = source.indexOf('*/', index + 2);
+    return end < 0 ? source.length : end + 2;
+  }
+  return index;
+}
+
+function maskStringsAndComments(source) {
+  let result = '';
+  for (let index = 0; index < source.length;) {
+    const end = readIgnoredSourceSegment(source, index);
+    if (end > index) {
+      // Preserve line breaks and source offsets while preventing examples in
+      // comments or strings from satisfying executable-code validation.
+      result += source.slice(index, end).replace(/[^\r\n]/g, ' ');
+      index = end;
+    } else {
+      result += source[index];
+      index += 1;
+    }
+  }
+  return result;
+}
+
+function skipWhitespaceAndComments(source, start) {
+  let index = start;
+  while (index < source.length) {
+    if (/\s/.test(source[index])) {
+      index += 1;
+      continue;
+    }
+    const end = readIgnoredSourceSegment(source, index);
+    if (end === index || !source.startsWith('/', index)) break;
+    index = end;
+  }
+  return index;
+}
+
+function findMatchingDelimiter(source, openIndex, open, close) {
+  let depth = 0;
+  for (let index = openIndex; index < source.length; index += 1) {
+    const end = readIgnoredSourceSegment(source, index);
+    if (end > index) {
+      index = end - 1;
+      continue;
+    }
+    if (source[index] === open) depth += 1;
+    if (source[index] === close) {
+      depth -= 1;
+      if (depth === 0) return index;
+    }
+  }
+  return -1;
+}
+
+function findAssignmentOperator(source, start) {
+  for (let index = start; index < source.length; index += 1) {
+    const end = readIgnoredSourceSegment(source, index);
+    if (end > index) {
+      index = end - 1;
+      continue;
+    }
+    if (source[index] !== '=') continue;
+    const previous = source[index - 1] || '';
+    const next = source[index + 1] || '';
+    if (next !== '=' && next !== '>' && !/[=!<>]/.test(previous)) return index;
+  }
+  return -1;
+}
+
+function findArrowOperator(source, start) {
+  for (let index = start; index < source.length - 1; index += 1) {
+    const end = readIgnoredSourceSegment(source, index);
+    if (end > index) {
+      index = end - 1;
+      continue;
+    }
+    if (source.startsWith('=>', index)) return index;
+  }
+  return -1;
+}
+
+function findStatementEnd(source, start) {
+  const delimiters = { '(': ')', '[': ']', '{': '}' };
+  const stack = [];
+  for (let index = start; index < source.length; index += 1) {
+    const end = readIgnoredSourceSegment(source, index);
+    if (end > index) {
+      index = end - 1;
+      continue;
+    }
+    const character = source[index];
+    if (delimiters[character]) {
+      stack.push(delimiters[character]);
+    } else if (stack.at(-1) === character) {
+      stack.pop();
+    } else if (character === ';' && stack.length === 0) {
+      return index + 1;
+    }
+  }
+  return source.length;
+}
+
+function extractLocaleAvailabilityImplementation(source) {
+  const masked = maskStringsAndComments(source);
+  const functionDeclaration =
+    /\bexport\s+function\s+isLocaleAvailable\b/.exec(masked);
+  if (functionDeclaration) {
+    const parameters = masked.indexOf('(', functionDeclaration.index);
+    if (parameters < 0) return null;
+    const parametersEnd = findMatchingDelimiter(source, parameters, '(', ')');
+    if (parametersEnd < 0) return null;
+    const body = masked.indexOf('{', parametersEnd + 1);
+    if (body < 0) return null;
+    const bodyEnd = findMatchingDelimiter(source, body, '{', '}');
+    if (bodyEnd < 0) return null;
+    return source.slice(functionDeclaration.index, bodyEnd + 1);
+  }
+
+  const constDeclaration =
+    /\bexport\s+const\s+isLocaleAvailable\b/.exec(masked);
+  if (!constDeclaration) return null;
+  const assignment = findAssignmentOperator(
+    source,
+    constDeclaration.index + constDeclaration[0].length
+  );
+  if (assignment < 0) return null;
+  const arrow = findArrowOperator(source, assignment + 1);
+  if (arrow < 0) return null;
+  const body = skipWhitespaceAndComments(source, arrow + 2);
+  const end = source[body] === '{'
+    ? findMatchingDelimiter(source, body, '{', '}') + 1
+    : findStatementEnd(source, body);
+  if (end <= body) return null;
+  return source.slice(constDeclaration.index, end);
+}
+
+function normalizeMembershipCalls(source) {
+  const masked = maskStringsAndComments(source);
+  let result = '';
+  for (let index = 0; index < source.length;) {
+    const identifier = 'unavailableLocales';
+    const startsMembership =
+      masked.startsWith(identifier, index) &&
+      !/[\w$]/.test(masked[index - 1] || '') &&
+      !/[\w$]/.test(masked[index + identifier.length] || '');
+    if (!startsMembership) {
+      result += masked[index];
+      index += 1;
+      continue;
+    }
+
+    let cursor = skipWhitespaceAndComments(source, index + identifier.length);
+    if (source[cursor] !== '.') {
+      result += masked[index];
+      index += 1;
+      continue;
+    }
+    cursor = skipWhitespaceAndComments(source, cursor + 1);
+    const method = source.startsWith('includes', cursor) ? 'includes'
+      : source.startsWith('has', cursor) ? 'has'
+        : null;
+    if (!method || /[\w$]/.test(source[cursor + method.length] || '')) {
+      result += masked[index];
+      index += 1;
+      continue;
+    }
+    cursor = skipWhitespaceAndComments(source, cursor + method.length);
+    if (source[cursor] !== '(') {
+      result += masked[index];
+      index += 1;
+      continue;
+    }
+    const callEnd = findMatchingDelimiter(source, cursor, '(', ')');
+    if (callEnd < 0) {
+      result += masked[index];
+      index += 1;
+      continue;
+    }
+    result += ' __UNAVAILABLE_MEMBERSHIP__ ';
+    index = callEnd + 1;
+  }
+  return result;
+}
+
 function rejectsUnavailableLocales(source) {
-  const membership = String.raw`unavailableLocales\.(?:has|includes)\s*\([^)]*\)`;
+  const implementation = extractLocaleAvailabilityImplementation(source);
+  if (!implementation) return false;
+  const normalizedImplementation = normalizeMembershipCalls(implementation);
+  const normalizedSource = normalizeMembershipCalls(source);
+  const membership = '__UNAVAILABLE_MEMBERSHIP__';
   const returnedExpression = String.raw`(?:return\s+|=>\s*)`;
 
   // Generated and subsequently refactored projects can express the same boolean
@@ -445,7 +653,9 @@ function rejectsUnavailableLocales(source) {
       's'
     ),
   ];
-  if (directRejections.some((pattern) => pattern.test(source))) return true;
+  if (directRejections.some((pattern) => pattern.test(normalizedImplementation))) {
+    return true;
+  }
 
   // Also allow the common refactor where membership is wrapped in a clearly named
   // positive helper and isLocaleAvailable returns its negation.
@@ -460,7 +670,8 @@ function rejectsUnavailableLocales(source) {
     const availabilityNegatesHelper = new RegExp(
       String.raw`${returnedExpression}!\s*${helper}\s*\(`
     );
-    if (helperDefinition.test(source) && availabilityNegatesHelper.test(source)) {
+    if (helperDefinition.test(normalizedSource) &&
+        availabilityNegatesHelper.test(normalizedImplementation)) {
       return true;
     }
   }

--- a/plugins/power-pages/skills/add-localization/scripts/validate-localization.js
+++ b/plugins/power-pages/skills/add-localization/scripts/validate-localization.js
@@ -419,6 +419,54 @@ function configuresDocumentAttribute(source, attribute) {
     staticHtmlAttribute.test(source);
 }
 
+function rejectsUnavailableLocales(source) {
+  const membership = String.raw`unavailableLocales\.(?:has|includes)\s*\([^)]*\)`;
+  const returnedExpression = String.raw`(?:return\s+|=>\s*)`;
+
+  // Generated and subsequently refactored projects can express the same boolean
+  // contract in several forms. Keep this allowlist narrow so a direct, inverted
+  // membership result does not accidentally validate.
+  const directRejections = [
+    new RegExp(String.raw`${returnedExpression}!\s*${membership}`),
+    new RegExp(
+      String.raw`${returnedExpression}${membership}\s*` +
+      String.raw`(?:={2,3}\s*false|!={1,2}\s*true)`
+    ),
+    new RegExp(
+      String.raw`${returnedExpression}(?:false\s*={2,3}|true\s*!={1,2})\s*` +
+      membership
+    ),
+    new RegExp(
+      String.raw`${returnedExpression}${membership}\s*\?\s*false\s*:\s*true`
+    ),
+    new RegExp(
+      String.raw`if\s*\(\s*${membership}\s*\)\s*` +
+      String.raw`(?:return\s+false\b|\{[^{}]*\breturn\s+false\b[^{}]*\})`,
+      's'
+    ),
+  ];
+  if (directRejections.some((pattern) => pattern.test(source))) return true;
+
+  // Also allow the common refactor where membership is wrapped in a clearly named
+  // positive helper and isLocaleAvailable returns its negation.
+  for (const helper of ['isLocaleUnavailable', 'isUnavailableLocale']) {
+    const helperDefinition = new RegExp(
+      String.raw`(?:function\s+${helper}\s*\([^)]*\)\s*\{[^{}]*` +
+      String.raw`\breturn\s+${membership}|` +
+      String.raw`const\s+${helper}\s*=\s*(?:\([^)]*\)|[A-Za-z_$][\w$]*)\s*` +
+      String.raw`=>\s*${membership})`,
+      's'
+    );
+    const availabilityNegatesHelper = new RegExp(
+      String.raw`${returnedExpression}!\s*${helper}\s*\(`
+    );
+    if (helperDefinition.test(source) && availabilityNegatesHelper.test(source)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function validateLocaleAvailability(
   projectRoot,
   allManagedFiles,
@@ -441,7 +489,7 @@ function validateLocaleAvailability(
   const availabilitySource = fs.readFileSync(fullAvailabilityPath, 'utf8');
   let valid = true;
   if (!/\bexport\s+(?:function|const)\s+isLocaleAvailable\b/.test(availabilitySource) ||
-      !/!\s*unavailableLocales\.(?:has|includes)\s*\(/.test(availabilitySource)) {
+      !rejectsUnavailableLocales(availabilitySource)) {
     errors.push(
       'The locale availability module must export isLocaleAvailable and reject ' +
       'entries in unavailableLocales.'

--- a/plugins/power-pages/skills/add-localization/scripts/validate-localization.js
+++ b/plugins/power-pages/skills/add-localization/scripts/validate-localization.js
@@ -430,7 +430,7 @@ function validateLocaleAvailability(
   );
   if (availabilityPaths.length !== 1) {
     errors.push(
-      'Pending bidirectional remediation requires one managed locale availability module.'
+      'Unavailable locales require one managed locale availability module.'
     );
     return false;
   }

--- a/plugins/power-pages/skills/add-seo/SKILL.md
+++ b/plugins/power-pages/skills/add-seo/SKILL.md
@@ -22,6 +22,7 @@ Add essential SEO assets to a Power Pages code site: `robots.txt`, `sitemap.xml`
 - **Crawlability first:** Every public page must be discoverable by search engines via a valid `robots.txt` and `sitemap.xml` before any other SEO work matters.
 - **Accurate metadata:** Meta tags (title, description, Open Graph) must truthfully represent page content — misleading metadata harms rankings.
 - **Framework-aware placement:** SEO assets must be placed in the correct location for the detected framework (public directory, layout component, etc.).
+- **Preserve localized metadata:** Read `${PLUGIN_ROOT}/references/site-modification-integrity.md`. When localization exists, keep language-specific titles, descriptions, social metadata, alternate links, and static locale routes synchronized without advertising unavailable locales.
 
 **Initial request:** $ARGUMENTS
 

--- a/plugins/power-pages/skills/add-server-logic/SKILL.md
+++ b/plugins/power-pages/skills/add-server-logic/SKILL.md
@@ -24,6 +24,7 @@ Create and manage one or more Power Pages Server Logic files — server-side Jav
 - **Five functions only**: A server logic file can only export these top-level functions: `get`, `post`, `put`, `patch`, `del`. The name `delete` is a reserved word in JavaScript and cannot be used.
 - **Always return a string**: Every function must return a string. Use `JSON.stringify()` when returning objects or arrays.
 - **Use TaskCreate/TaskUpdate**: Track all progress throughout all phases — create the todo list upfront with all phases before starting any work.
+- **Preserve frontend integrity**: If Phase 9 adds or changes SPA UI, first read `${PLUGIN_ROOT}/references/site-modification-integrity.md`; synchronize visible states across configured locale resources and keep the UI bidirectional and expansion-safe. Backend-only runs do not need localization changes.
 
 > **Prerequisites:**
 > - An existing Power Pages code site created

--- a/plugins/power-pages/skills/create-site/SKILL.md
+++ b/plugins/power-pages/skills/create-site/SKILL.md
@@ -28,6 +28,7 @@ Guide the user through creating a complete, production-quality Power Pages code 
 - **Git checkpoints**: Commit after every individual page and component — each gets its own commit so breaking changes can be reverted.
 - **Site content language is independent of Dataverse language**: Generate every user-visible SPA string in the approved content language. Dataverse and Power Pages platform-managed messages remain English (`en-US`, LCID `1033`) in this workflow.
 - **Bidirectional by default**: Read `${PLUGIN_ROOT}/references/bidirectional-design.md`. Every site must use direction-neutral layout, mixed-content boundaries, and script-capable typography even when its initial language has only one direction. A later LTR/RTL locale must not require a general redesign.
+- **Lifecycle-ready output**: Follow `${PLUGIN_ROOT}/references/site-modification-integrity.md` so later pages and components can preserve localization, direction, and content-expansion behavior through the shared post-modification validator.
 
 **Constraint**: Only static SPA frameworks are supported (React, Vue, Angular, Astro). NOT supported: Next.js, Nuxt.js, Remix, SvelteKit, Liquid.
 

--- a/plugins/power-pages/skills/create-site/SKILL.md
+++ b/plugins/power-pages/skills/create-site/SKILL.md
@@ -27,6 +27,7 @@ Guide the user through creating a complete, production-quality Power Pages code 
 - **Use real images**: Source high-quality photos from Unsplash wherever pages need visual content — hero sections, feature cards, about pages, backgrounds, etc. Use `https://images.unsplash.com/photo-{id}?w={width}&h={height}&fit=crop` URLs with specific photo IDs found via `WebSearch`. Never leave image placeholders or broken `<img>` tags pointing to nonexistent files.
 - **Git checkpoints**: Commit after every individual page and component — each gets its own commit so breaking changes can be reverted.
 - **Site content language is independent of Dataverse language**: Generate every user-visible SPA string in the approved content language. Dataverse and Power Pages platform-managed messages remain English (`en-US`, LCID `1033`) in this workflow.
+- **Bidirectional by default**: Read `${PLUGIN_ROOT}/references/bidirectional-design.md`. Every site must use direction-neutral layout, mixed-content boundaries, and script-capable typography even when its initial language has only one direction. A later LTR/RTL locale must not require a general redesign.
 
 **Constraint**: Only static SPA frameworks are supported (React, Vue, Angular, Astro). NOT supported: Next.js, Nuxt.js, Remix, SvelteKit, Liquid.
 
@@ -352,7 +353,7 @@ Immediately after the dev server starts, verify the scaffold is working:
 
    The `marker` string is the comment tag Phase 5 emits into the page source as a reserved anchor that `/add-ai-webapi` later finds. Keep the shape uniform — one marker per placement, always the same tag, so the follow-up skill's explore step can grep for them deterministically.
 
-5. Read the design aesthetics reference: `${PLUGIN_ROOT}/skills/create-site/references/design-aesthetics.md`
+5. Read the design aesthetics reference `${PLUGIN_ROOT}/skills/create-site/references/design-aesthetics.md` and the shared bidirectional standard `${PLUGIN_ROOT}/references/bidirectional-design.md`.
 6. **Map aesthetic + mood to design choices** using the Aesthetic x Mood Mapping table from the design reference. Record the chosen font direction, color direction, and motion direction.
    Font choices must support the complete writing system used by `SITE_LOCALE`.
    Verify glyph coverage and shaping rather than selecting a Latin-only font
@@ -510,7 +511,7 @@ The scaffold is a temporary loading screen — it must be **completely replaced*
 
 > **Narrate progress in the loader**: Before each of the steps below, update `<PROJECT_ROOT>/public/scaffold-status.json` so the user — who may still be watching the Home page loader — sees what's actually happening instead of the hardcoded placeholder cycle. Use a short present-participle `message` (e.g., `"Creating Navbar component"`, `"Creating Contact page"`). Include any useful grouping context inline in the message itself. The loader picks up changes within ~1.5 seconds. Updates become no-ops once step 4 replaces the Home page.
 
-1. **Design foundations** — **Completely rewrite** `theme.css` (or `styles.css` for Angular) from scratch with the chosen color palette as CSS custom properties, Google Fonts, motion/animation utilities, and background treatments. The scaffold's loading screen CSS is discarded entirely. Commit after this step. *Before starting, set the loader status to `{ "message": "Applying design tokens" }`.*
+1. **Design foundations** — **Completely rewrite** `theme.css` (or `styles.css` for Angular) from scratch with the chosen color palette as CSS custom properties, Google Fonts, motion/animation utilities, background treatments, and logical CSS properties. The selected font stack must cover `SITE_LOCALE`'s resolved script. Do not use physical left/right layout as the default, even for an initially LTR-only site. The scaffold's loading screen CSS is discarded entirely. Commit after this step. *Before starting, set the loader status to `{ "message": "Applying design tokens" }`.*
 2. **Layout** — **Rewrite** the Layout component (and Header/Footer for Astro) with proper navigation, header, and footer that reflect the chosen design. The scaffold's passthrough Layout is replaced with a real layout structure. *Set status to `{ "message": "Rewriting Layout" }`.*
 3. **Shared components** — Build reusable components (Navbar, Footer, ContactForm, etc.) that pages will use. *For each component, set status to `{ "message": "Creating <Component> component" }`.*
 4. **Pages** — Create route components for each requested page, **replacing** the scaffold Home page and About placeholder entirely. Each page component must update `document.title` on mount to reflect the current page (e.g., `"Contact — Contoso Portal"`). Use the framework's idiomatic lifecycle hook: `useEffect` (React), `onMounted` (Vue), `ngOnInit` (Angular), or a `<title>` tag in the frontmatter (Astro). Format: `"<Page Name> — <Site Name>"`, with the home page using just `"<Site Name>"`. *For each page, set status to `{ "message": "Creating <Page> page" }` before writing the file. The loader disappears when the Home page itself is replaced — no further status updates are needed after that.*
@@ -551,8 +552,20 @@ The scaffold is a temporary loading screen — it must be **completely replaced*
   stable routes avoid breaking bookmarks, analytics, integrations, tests, and
   a later `/add-localization` setup. Use localized paths only when the maker
   explicitly requests them for a permanently single-language SEO strategy.
-- For RTL locales, use logical CSS properties, preserve sensible reading order,
-  and mirror only directional controls/icons.
+- For every locale, use logical CSS properties and preserve meaningful DOM
+  reading/focus order. Do not reverse arrays or use `row-reverse` to simulate
+  RTL. Initial RTL sites must also be visually verified in RTL.
+- Wrap independently inserted unknown-direction content (names, comments,
+  titles, search queries) with `<bdi>` or `dir="auto"`. Keep URLs, email,
+  code, file paths, GUIDs, and other machine values explicitly isolated,
+  normally LTR. Use `dir="auto"` for free-form multilingual inputs.
+- Format dates, numbers, currency, percentages, and relative time with `Intl`
+  APIs rather than concatenating locale-sensitive punctuation or symbols.
+- Classify directional icons and assets as unchanged, mirrored, or replaced.
+  Mirror only controls whose semantics follow reading progression.
+- A required physical declaration may remain only with an adjacent
+  `/* bidi-physical: <specific reason>; verify=ltr,rtl */` directive and
+  successful browser verification in both directions.
 
 **Important**: Build real, functional UI with distinctive design applied — not placeholder "coming soon" pages, and not generic unstyled markup. Every page and component should reflect the chosen aesthetic from the moment it's created. The scaffold loading screen should be completely gone after this phase — no trace of the Power Pages branded animation should remain.
 
@@ -614,6 +627,19 @@ After each significant change (new page or component), browse the site via Playw
 
 The user is previewing in their own browser via the dev server URL shared in Phase 2.7.
 
+Run the deterministic readiness audit after all pages and components exist:
+
+```bash
+node "${PLUGIN_ROOT}/scripts/audit-bidirectional-readiness.js" --projectRoot "<PROJECT_ROOT>"
+```
+
+Fix every `error` finding. Review every physical-geometry finding in the live
+site. For an intentionally physical product requirement, keep the declaration,
+add the validated adjacent `bidi-physical` directive, and verify that component
+in both LTR and RTL. Use pseudo-opposite-direction content to check wrapping,
+navigation, forms, mixed names/identifiers, icons, calendars, and narrow/mobile
+layout even when no second real locale exists yet.
+
 ### 5.6 Clean Up the Live Status File
 
 Once the scaffold loader is gone, `public/scaffold-status.json` is just dead weight that would ship with the deployed site. Delete the file from `<PROJECT_ROOT>/public/` and commit the removal alongside the final implementation.
@@ -652,7 +678,7 @@ and its existing deployment prompt.
 
 When `LOCALIZATION_REQUESTED=false`, skip the child workflow.
 
-> **GATE: Do NOT proceed to Phase 6 until ALL customization is complete with design applied.** The site must have distinctive typography (Google Fonts — no generic Inter/Roboto/Arial), a cohesive color palette (CSS variables), motion/animations, and all requested pages/features before moving to accessibility verification.
+> **GATE: Do NOT proceed to Phase 6 until ALL customization is complete with design applied.** The site must have distinctive script-capable typography (Google Fonts — no generic Inter/Roboto/Arial), a cohesive color palette (CSS variables), motion/animations, logical direction-neutral layout, and all requested pages/features before moving to accessibility verification.
 
 **Output**: All pages, components, design elements, and requested localization implemented and verified
 

--- a/plugins/power-pages/skills/create-site/assets/angular/src/app/pages/home.component.ts
+++ b/plugins/power-pages/skills/create-site/assets/angular/src/app/pages/home.component.ts
@@ -24,7 +24,7 @@ html, body { overflow: hidden; background: var(--pp-bg); color: var(--pp-text); 
 .loading-wrapper { position: fixed; inset: 0; display: flex; align-items: center; justify-content: center; background: var(--pp-bg); }
 .ambient { position: fixed; inset: 0; z-index: 0; overflow: hidden; }
 .ambient::before {
-  content: ''; position: absolute; width: 160%; height: 160%; top: -30%; left: -30%;
+  content: ''; position: absolute; width: 160%; height: 160%; top: -30%; inset-inline-start: -30%;
   background:
     radial-gradient(ellipse 600px 600px at 25% 30%, rgba(167, 139, 219, 0.12) 0%, transparent 70%),
     radial-gradient(ellipse 500px 500px at 75% 70%, rgba(90, 155, 213, 0.08) 0%, transparent 70%),
@@ -87,10 +87,10 @@ html, body { overflow: hidden; background: var(--pp-bg); color: var(--pp-text); 
 @keyframes spin { to { transform: rotate(360deg); } }
 .progress-container { width: 320px; opacity: 0; animation: fadeSlideUp 1s ease-out 1.5s forwards; display: flex; flex-direction: column; align-items: center; gap: 14px; }
 .progress-track { width: 100%; height: 3px; background: rgba(139, 111, 192, 0.1); border-radius: 4px; overflow: hidden; position: relative; }
-.progress-fill { height: 100%; width: 40%; border-radius: 4px; background: linear-gradient(90deg, transparent, var(--pp-violet), var(--pp-lavender), var(--pp-sky), transparent); position: absolute; top: 0; left: -40%; animation: infiniteSlide 2s cubic-bezier(0.4, 0, 0.2, 1) infinite; }
-.progress-fill::after { content: ''; position: absolute; right: 10%; top: -3px; width: 8px; height: 8px; border-radius: 50%; background: var(--pp-sky); box-shadow: 0 0 8px rgba(90, 155, 213, 0.5), 0 0 16px rgba(90, 155, 213, 0.2); opacity: 0.9; }
-@keyframes infiniteSlide { 0% { left: -40%; } 100% { left: 100%; } }
-.progress-track.complete .progress-fill { width: 100%; left: 0; animation: none; background: linear-gradient(90deg, var(--pp-violet), var(--pp-lavender), var(--pp-sky)); transition: all 0.8s ease; }
+.progress-fill { height: 100%; width: 40%; border-radius: 4px; background: linear-gradient(90deg, transparent, var(--pp-violet), var(--pp-lavender), var(--pp-sky), transparent); position: absolute; top: 0; inset-inline-start: -40%; animation: infiniteSlide 2s cubic-bezier(0.4, 0, 0.2, 1) infinite; }
+.progress-fill::after { content: ''; position: absolute; inset-inline-end: 10%; top: -3px; width: 8px; height: 8px; border-radius: 50%; background: var(--pp-sky); box-shadow: 0 0 8px rgba(90, 155, 213, 0.5), 0 0 16px rgba(90, 155, 213, 0.2); opacity: 0.9; }
+@keyframes infiniteSlide { 0% { inset-inline-start: -40%; } 100% { inset-inline-start: 100%; } }
+.progress-track.complete .progress-fill { width: 100%; inset-inline-start: 0; animation: none; background: linear-gradient(90deg, var(--pp-violet), var(--pp-lavender), var(--pp-sky)); transition: all 0.8s ease; }
 .progress-track.complete .progress-fill::after { display: none; }
 .progress-label-text { font-size: 12px; color: var(--pp-text-muted); font-family: 'DM Sans', sans-serif; letter-spacing: 0.3px; }
 .feature-cards { display: flex; gap: 16px; margin-top: 16px; opacity: 0; animation: fadeSlideUp 1s ease-out 2s forwards; }
@@ -102,7 +102,7 @@ html, body { overflow: hidden; background: var(--pp-bg); color: var(--pp-text); 
 .connector-lines { position: fixed; inset: 0; z-index: 2; pointer-events: none; overflow: hidden; }
 .connector { position: absolute; height: 1px; background: linear-gradient(90deg, transparent, rgba(139, 111, 192, 0.12), transparent); animation: connectorSweep 6s ease-in-out infinite; }
 @keyframes connectorSweep { 0%, 100% { transform: translateX(-100%); opacity: 0; } 20% { opacity: 1; } 80% { opacity: 1; } 100% { transform: translateX(100vw); opacity: 0; } }
-.scanline { position: fixed; left: 0; right: 0; height: 1px; background: linear-gradient(90deg, transparent 0%, var(--pp-lavender) 50%, transparent 100%); opacity: 0.06; z-index: 2; animation: scanDrop 8s linear infinite; pointer-events: none; }
+.scanline { position: fixed; inset-inline: 0; height: 1px; background: linear-gradient(90deg, transparent 0%, var(--pp-lavender) 50%, transparent 100%); opacity: 0.06; z-index: 2; animation: scanDrop 8s linear infinite; pointer-events: none; }
 @keyframes scanDrop { 0% { top: -2px; } 100% { top: 100%; } }
 .tip-area { text-align: center; margin-top: 12px; opacity: 0; animation: fadeSlideUp 1s ease-out 3s forwards; }
 .tip-label { font-size: 10px; letter-spacing: 2px; text-transform: uppercase; color: var(--pp-text-muted); margin-bottom: 8px; font-family: 'Outfit', sans-serif; }
@@ -110,7 +110,7 @@ html, body { overflow: hidden; background: var(--pp-bg); color: var(--pp-text); 
 @keyframes fadeSlideUp { from { opacity: 0; transform: translateY(16px); } to { opacity: 1; transform: translateY(0); } }
 .center-stage.complete .main-heading { animation: completePulse 2s ease-in-out infinite alternate; }
 @keyframes completePulse { 0% { filter: brightness(1); } 100% { filter: brightness(1.15); } }
-.input-banner { position: fixed; top: 24px; right: 24px; z-index: 100; display: flex; align-items: center; gap: 12px; background: linear-gradient(135deg, #FFF4D6 0%, #FFE9B3 100%); border: 1px solid #F5B800; color: #5C3D00; padding: 12px 14px 12px 22px; border-radius: 999px; font-family: 'Outfit', sans-serif; font-size: 14px; font-weight: 500; box-shadow: 0 4px 16px rgba(245, 184, 0, 0.25); max-width: min(360px, calc(100vw - 48px)); animation: bannerEnter 0.4s cubic-bezier(0.22, 1, 0.36, 1); }
+.input-banner { position: fixed; top: 24px; inset-inline-end: 24px; z-index: 100; display: flex; align-items: center; gap: 12px; background: linear-gradient(135deg, #FFF4D6 0%, #FFE9B3 100%); border: 1px solid #F5B800; color: #5C3D00; padding-block: 12px; padding-inline: 22px 14px; border-radius: 999px; font-family: 'Outfit', sans-serif; font-size: 14px; font-weight: 500; box-shadow: 0 4px 16px rgba(245, 184, 0, 0.25); max-width: min(360px, calc(100vw - 48px)); animation: bannerEnter 0.4s cubic-bezier(0.22, 1, 0.36, 1); }
 .input-banner[hidden] { display: none; }
 .input-banner-icon { font-size: 18px; animation: bannerPulse 1.5s ease-in-out infinite; flex-shrink: 0; }
 .input-banner-text { line-height: 1.4; flex: 1; min-width: 0; }
@@ -120,7 +120,7 @@ html, body { overflow: hidden; background: var(--pp-bg); color: var(--pp-text); 
 .input-banner-close:hover { background: rgba(92, 61, 0, 0.2); transform: scale(1.05); }
 @keyframes bannerPulse { 0%, 100% { transform: scale(1); } 50% { transform: scale(1.2); } }
 @keyframes bannerEnter { from { opacity: 0; transform: translateY(-12px); } to { opacity: 1; transform: translateY(0); } }
-@media (max-width: 600px) { .main-heading { font-size: 24px; } .progress-container { width: 260px; } .feature-cards { flex-direction: column; align-items: center; } .orbit-system { width: 180px; height: 180px; } .input-banner { top: 12px; right: 12px; padding: 10px 12px 10px 16px; font-size: 13px; max-width: calc(100vw - 24px); } }
+@media (max-width: 600px) { .main-heading { font-size: 24px; } .progress-container { width: 260px; } .feature-cards { flex-direction: column; align-items: center; } .orbit-system { width: 180px; height: 180px; } .input-banner { top: 12px; inset-inline-end: 12px; padding-block: 10px; padding-inline: 16px 12px; font-size: 13px; max-width: calc(100vw - 24px); } }
   `],
   template: `
     <div class="loading-wrapper">
@@ -210,7 +210,7 @@ export class HomeComponent implements AfterViewInit, OnDestroy {
       const size = Math.random() * 3 + 1
       const colors = ['rgba(167,139,219,0.5)', 'rgba(128,136,217,0.5)', 'rgba(90,155,213,0.5)', 'rgba(139,111,192,0.5)']
       const color = colors[Math.floor(Math.random() * colors.length)]
-      p.style.cssText = `width:${size}px;height:${size}px;left:${Math.random() * 100}%;background:${color};box-shadow:0 0 ${size * 2}px ${color};animation-duration:${Math.random() * 15 + 12}s;animation-delay:${Math.random() * 10}s;`
+      p.style.cssText = `width:${size}px;height:${size}px;inset-inline-start:${Math.random() * 100}%;background:${color};box-shadow:0 0 ${size * 2}px ${color};animation-duration:${Math.random() * 15 + 12}s;animation-delay:${Math.random() * 10}s;`
       particlesEl.appendChild(p)
       this.timeouts.push(window.setTimeout(() => p.remove(), 30000))
     }

--- a/plugins/power-pages/skills/create-site/assets/astro/src/pages/index.astro
+++ b/plugins/power-pages/skills/create-site/assets/astro/src/pages/index.astro
@@ -89,7 +89,7 @@ html, body { overflow: hidden; background: var(--pp-bg); color: var(--pp-text); 
 .loading-wrapper { position: fixed; inset: 0; display: flex; align-items: center; justify-content: center; background: var(--pp-bg); }
 .ambient { position: fixed; inset: 0; z-index: 0; overflow: hidden; }
 .ambient::before {
-  content: ''; position: absolute; width: 160%; height: 160%; top: -30%; left: -30%;
+  content: ''; position: absolute; width: 160%; height: 160%; top: -30%; inset-inline-start: -30%;
   background:
     radial-gradient(ellipse 600px 600px at 25% 30%, rgba(167, 139, 219, 0.12) 0%, transparent 70%),
     radial-gradient(ellipse 500px 500px at 75% 70%, rgba(90, 155, 213, 0.08) 0%, transparent 70%),
@@ -152,10 +152,10 @@ html, body { overflow: hidden; background: var(--pp-bg); color: var(--pp-text); 
 @keyframes spin { to { transform: rotate(360deg); } }
 .progress-container { width: 320px; opacity: 0; animation: fadeSlideUp 1s ease-out 1.5s forwards; display: flex; flex-direction: column; align-items: center; gap: 14px; }
 .progress-track { width: 100%; height: 3px; background: rgba(139, 111, 192, 0.1); border-radius: 4px; overflow: hidden; position: relative; }
-.progress-fill { height: 100%; width: 40%; border-radius: 4px; background: linear-gradient(90deg, transparent, var(--pp-violet), var(--pp-lavender), var(--pp-sky), transparent); position: absolute; top: 0; left: -40%; animation: infiniteSlide 2s cubic-bezier(0.4, 0, 0.2, 1) infinite; }
-.progress-fill::after { content: ''; position: absolute; right: 10%; top: -3px; width: 8px; height: 8px; border-radius: 50%; background: var(--pp-sky); box-shadow: 0 0 8px rgba(90, 155, 213, 0.5), 0 0 16px rgba(90, 155, 213, 0.2); opacity: 0.9; }
-@keyframes infiniteSlide { 0% { left: -40%; } 100% { left: 100%; } }
-.progress-track.complete .progress-fill { width: 100%; left: 0; animation: none; background: linear-gradient(90deg, var(--pp-violet), var(--pp-lavender), var(--pp-sky)); transition: all 0.8s ease; }
+.progress-fill { height: 100%; width: 40%; border-radius: 4px; background: linear-gradient(90deg, transparent, var(--pp-violet), var(--pp-lavender), var(--pp-sky), transparent); position: absolute; top: 0; inset-inline-start: -40%; animation: infiniteSlide 2s cubic-bezier(0.4, 0, 0.2, 1) infinite; }
+.progress-fill::after { content: ''; position: absolute; inset-inline-end: 10%; top: -3px; width: 8px; height: 8px; border-radius: 50%; background: var(--pp-sky); box-shadow: 0 0 8px rgba(90, 155, 213, 0.5), 0 0 16px rgba(90, 155, 213, 0.2); opacity: 0.9; }
+@keyframes infiniteSlide { 0% { inset-inline-start: -40%; } 100% { inset-inline-start: 100%; } }
+.progress-track.complete .progress-fill { width: 100%; inset-inline-start: 0; animation: none; background: linear-gradient(90deg, var(--pp-violet), var(--pp-lavender), var(--pp-sky)); transition: all 0.8s ease; }
 .progress-track.complete .progress-fill::after { display: none; }
 .progress-label-text { font-size: 12px; color: var(--pp-text-muted); font-family: 'DM Sans', sans-serif; letter-spacing: 0.3px; }
 .feature-cards { display: flex; gap: 16px; margin-top: 16px; opacity: 0; animation: fadeSlideUp 1s ease-out 2s forwards; }
@@ -167,7 +167,7 @@ html, body { overflow: hidden; background: var(--pp-bg); color: var(--pp-text); 
 .connector-lines { position: fixed; inset: 0; z-index: 2; pointer-events: none; overflow: hidden; }
 .connector { position: absolute; height: 1px; background: linear-gradient(90deg, transparent, rgba(139, 111, 192, 0.12), transparent); animation: connectorSweep 6s ease-in-out infinite; }
 @keyframes connectorSweep { 0%, 100% { transform: translateX(-100%); opacity: 0; } 20% { opacity: 1; } 80% { opacity: 1; } 100% { transform: translateX(100vw); opacity: 0; } }
-.scanline { position: fixed; left: 0; right: 0; height: 1px; background: linear-gradient(90deg, transparent 0%, var(--pp-lavender) 50%, transparent 100%); opacity: 0.06; z-index: 2; animation: scanDrop 8s linear infinite; pointer-events: none; }
+.scanline { position: fixed; inset-inline: 0; height: 1px; background: linear-gradient(90deg, transparent 0%, var(--pp-lavender) 50%, transparent 100%); opacity: 0.06; z-index: 2; animation: scanDrop 8s linear infinite; pointer-events: none; }
 @keyframes scanDrop { 0% { top: -2px; } 100% { top: 100%; } }
 .tip-area { text-align: center; margin-top: 12px; opacity: 0; animation: fadeSlideUp 1s ease-out 3s forwards; }
 .tip-label { font-size: 10px; letter-spacing: 2px; text-transform: uppercase; color: var(--pp-text-muted); margin-bottom: 8px; font-family: 'Outfit', sans-serif; }
@@ -175,7 +175,7 @@ html, body { overflow: hidden; background: var(--pp-bg); color: var(--pp-text); 
 @keyframes fadeSlideUp { from { opacity: 0; transform: translateY(16px); } to { opacity: 1; transform: translateY(0); } }
 .center-stage.complete .main-heading { animation: completePulse 2s ease-in-out infinite alternate; }
 @keyframes completePulse { 0% { filter: brightness(1); } 100% { filter: brightness(1.15); } }
-.input-banner { position: fixed; top: 24px; right: 24px; z-index: 100; display: flex; align-items: center; gap: 12px; background: linear-gradient(135deg, #FFF4D6 0%, #FFE9B3 100%); border: 1px solid #F5B800; color: #5C3D00; padding: 12px 14px 12px 22px; border-radius: 999px; font-family: 'Outfit', sans-serif; font-size: 14px; font-weight: 500; box-shadow: 0 4px 16px rgba(245, 184, 0, 0.25); max-width: min(360px, calc(100vw - 48px)); animation: bannerEnter 0.4s cubic-bezier(0.22, 1, 0.36, 1); }
+.input-banner { position: fixed; top: 24px; inset-inline-end: 24px; z-index: 100; display: flex; align-items: center; gap: 12px; background: linear-gradient(135deg, #FFF4D6 0%, #FFE9B3 100%); border: 1px solid #F5B800; color: #5C3D00; padding-block: 12px; padding-inline: 22px 14px; border-radius: 999px; font-family: 'Outfit', sans-serif; font-size: 14px; font-weight: 500; box-shadow: 0 4px 16px rgba(245, 184, 0, 0.25); max-width: min(360px, calc(100vw - 48px)); animation: bannerEnter 0.4s cubic-bezier(0.22, 1, 0.36, 1); }
 .input-banner[hidden] { display: none; }
 .input-banner-icon { font-size: 18px; animation: bannerPulse 1.5s ease-in-out infinite; flex-shrink: 0; }
 .input-banner-text { line-height: 1.4; flex: 1; min-width: 0; }
@@ -185,7 +185,7 @@ html, body { overflow: hidden; background: var(--pp-bg); color: var(--pp-text); 
 .input-banner-close:hover { background: rgba(92, 61, 0, 0.2); transform: scale(1.05); }
 @keyframes bannerPulse { 0%, 100% { transform: scale(1); } 50% { transform: scale(1.2); } }
 @keyframes bannerEnter { from { opacity: 0; transform: translateY(-12px); } to { opacity: 1; transform: translateY(0); } }
-@media (max-width: 600px) { .main-heading { font-size: 24px; } .progress-container { width: 260px; } .feature-cards { flex-direction: column; align-items: center; } .orbit-system { width: 180px; height: 180px; } .input-banner { top: 12px; right: 12px; padding: 10px 12px 10px 16px; font-size: 13px; max-width: calc(100vw - 24px); } }
+@media (max-width: 600px) { .main-heading { font-size: 24px; } .progress-container { width: 260px; } .feature-cards { flex-direction: column; align-items: center; } .orbit-system { width: 180px; height: 180px; } .input-banner { top: 12px; inset-inline-end: 12px; padding-block: 10px; padding-inline: 16px 12px; font-size: 13px; max-width: calc(100vw - 24px); } }
 </style>
 
 <script>
@@ -204,7 +204,7 @@ html, body { overflow: hidden; background: var(--pp-bg); color: var(--pp-text); 
     const size = Math.random() * 3 + 1
     const colors = ['rgba(167,139,219,0.5)', 'rgba(128,136,217,0.5)', 'rgba(90,155,213,0.5)', 'rgba(139,111,192,0.5)']
     const color = colors[Math.floor(Math.random() * colors.length)]
-    p.style.cssText = `width:${size}px;height:${size}px;left:${Math.random() * 100}%;background:${color};box-shadow:0 0 ${size * 2}px ${color};animation-duration:${Math.random() * 15 + 12}s;animation-delay:${Math.random() * 10}s;`
+    p.style.cssText = `width:${size}px;height:${size}px;inset-inline-start:${Math.random() * 100}%;background:${color};box-shadow:0 0 ${size * 2}px ${color};animation-duration:${Math.random() * 15 + 12}s;animation-delay:${Math.random() * 10}s;`
     particlesEl.appendChild(p)
     setTimeout(() => p.remove(), 30000)
   }

--- a/plugins/power-pages/skills/create-site/assets/react/src/pages/Home.tsx
+++ b/plugins/power-pages/skills/create-site/assets/react/src/pages/Home.tsx
@@ -20,7 +20,7 @@ html, body { overflow: hidden; background: var(--pp-bg); color: var(--pp-text); 
 .loading-wrapper { position: fixed; inset: 0; display: flex; align-items: center; justify-content: center; background: var(--pp-bg); }
 .ambient { position: fixed; inset: 0; z-index: 0; overflow: hidden; }
 .ambient::before {
-  content: ''; position: absolute; width: 160%; height: 160%; top: -30%; left: -30%;
+  content: ''; position: absolute; width: 160%; height: 160%; top: -30%; inset-inline-start: -30%;
   background:
     radial-gradient(ellipse 600px 600px at 25% 30%, rgba(167, 139, 219, 0.12) 0%, transparent 70%),
     radial-gradient(ellipse 500px 500px at 75% 70%, rgba(90, 155, 213, 0.08) 0%, transparent 70%),
@@ -83,10 +83,10 @@ html, body { overflow: hidden; background: var(--pp-bg); color: var(--pp-text); 
 @keyframes spin { to { transform: rotate(360deg); } }
 .progress-container { width: 320px; opacity: 0; animation: fadeSlideUp 1s ease-out 1.5s forwards; display: flex; flex-direction: column; align-items: center; gap: 14px; }
 .progress-track { width: 100%; height: 3px; background: rgba(139, 111, 192, 0.1); border-radius: 4px; overflow: hidden; position: relative; }
-.progress-fill { height: 100%; width: 40%; border-radius: 4px; background: linear-gradient(90deg, transparent, var(--pp-violet), var(--pp-lavender), var(--pp-sky), transparent); position: absolute; top: 0; left: -40%; animation: infiniteSlide 2s cubic-bezier(0.4, 0, 0.2, 1) infinite; }
-.progress-fill::after { content: ''; position: absolute; right: 10%; top: -3px; width: 8px; height: 8px; border-radius: 50%; background: var(--pp-sky); box-shadow: 0 0 8px rgba(90, 155, 213, 0.5), 0 0 16px rgba(90, 155, 213, 0.2); opacity: 0.9; }
-@keyframes infiniteSlide { 0% { left: -40%; } 100% { left: 100%; } }
-.progress-track.complete .progress-fill { width: 100%; left: 0; animation: none; background: linear-gradient(90deg, var(--pp-violet), var(--pp-lavender), var(--pp-sky)); transition: all 0.8s ease; }
+.progress-fill { height: 100%; width: 40%; border-radius: 4px; background: linear-gradient(90deg, transparent, var(--pp-violet), var(--pp-lavender), var(--pp-sky), transparent); position: absolute; top: 0; inset-inline-start: -40%; animation: infiniteSlide 2s cubic-bezier(0.4, 0, 0.2, 1) infinite; }
+.progress-fill::after { content: ''; position: absolute; inset-inline-end: 10%; top: -3px; width: 8px; height: 8px; border-radius: 50%; background: var(--pp-sky); box-shadow: 0 0 8px rgba(90, 155, 213, 0.5), 0 0 16px rgba(90, 155, 213, 0.2); opacity: 0.9; }
+@keyframes infiniteSlide { 0% { inset-inline-start: -40%; } 100% { inset-inline-start: 100%; } }
+.progress-track.complete .progress-fill { width: 100%; inset-inline-start: 0; animation: none; background: linear-gradient(90deg, var(--pp-violet), var(--pp-lavender), var(--pp-sky)); transition: all 0.8s ease; }
 .progress-track.complete .progress-fill::after { display: none; }
 .progress-label-text { font-size: 12px; color: var(--pp-text-muted); font-family: 'DM Sans', sans-serif; letter-spacing: 0.3px; }
 .feature-cards { display: flex; gap: 16px; margin-top: 16px; opacity: 0; animation: fadeSlideUp 1s ease-out 2s forwards; }
@@ -98,7 +98,7 @@ html, body { overflow: hidden; background: var(--pp-bg); color: var(--pp-text); 
 .connector-lines { position: fixed; inset: 0; z-index: 2; pointer-events: none; overflow: hidden; }
 .connector { position: absolute; height: 1px; background: linear-gradient(90deg, transparent, rgba(139, 111, 192, 0.12), transparent); animation: connectorSweep 6s ease-in-out infinite; }
 @keyframes connectorSweep { 0%, 100% { transform: translateX(-100%); opacity: 0; } 20% { opacity: 1; } 80% { opacity: 1; } 100% { transform: translateX(100vw); opacity: 0; } }
-.scanline { position: fixed; left: 0; right: 0; height: 1px; background: linear-gradient(90deg, transparent 0%, var(--pp-lavender) 50%, transparent 100%); opacity: 0.06; z-index: 2; animation: scanDrop 8s linear infinite; pointer-events: none; }
+.scanline { position: fixed; inset-inline: 0; height: 1px; background: linear-gradient(90deg, transparent 0%, var(--pp-lavender) 50%, transparent 100%); opacity: 0.06; z-index: 2; animation: scanDrop 8s linear infinite; pointer-events: none; }
 @keyframes scanDrop { 0% { top: -2px; } 100% { top: 100%; } }
 .tip-area { text-align: center; margin-top: 12px; opacity: 0; animation: fadeSlideUp 1s ease-out 3s forwards; }
 .tip-label { font-size: 10px; letter-spacing: 2px; text-transform: uppercase; color: var(--pp-text-muted); margin-bottom: 8px; font-family: 'Outfit', sans-serif; }
@@ -106,7 +106,7 @@ html, body { overflow: hidden; background: var(--pp-bg); color: var(--pp-text); 
 @keyframes fadeSlideUp { from { opacity: 0; transform: translateY(16px); } to { opacity: 1; transform: translateY(0); } }
 .center-stage.complete .main-heading { animation: completePulse 2s ease-in-out infinite alternate; }
 @keyframes completePulse { 0% { filter: brightness(1); } 100% { filter: brightness(1.15); } }
-.input-banner { position: fixed; top: 24px; right: 24px; z-index: 100; display: flex; align-items: center; gap: 12px; background: linear-gradient(135deg, #FFF4D6 0%, #FFE9B3 100%); border: 1px solid #F5B800; color: #5C3D00; padding: 12px 14px 12px 22px; border-radius: 999px; font-family: 'Outfit', sans-serif; font-size: 14px; font-weight: 500; box-shadow: 0 4px 16px rgba(245, 184, 0, 0.25); max-width: min(360px, calc(100vw - 48px)); animation: bannerEnter 0.4s cubic-bezier(0.22, 1, 0.36, 1); }
+.input-banner { position: fixed; top: 24px; inset-inline-end: 24px; z-index: 100; display: flex; align-items: center; gap: 12px; background: linear-gradient(135deg, #FFF4D6 0%, #FFE9B3 100%); border: 1px solid #F5B800; color: #5C3D00; padding-block: 12px; padding-inline: 22px 14px; border-radius: 999px; font-family: 'Outfit', sans-serif; font-size: 14px; font-weight: 500; box-shadow: 0 4px 16px rgba(245, 184, 0, 0.25); max-width: min(360px, calc(100vw - 48px)); animation: bannerEnter 0.4s cubic-bezier(0.22, 1, 0.36, 1); }
 .input-banner[hidden] { display: none; }
 .input-banner-icon { font-size: 18px; animation: bannerPulse 1.5s ease-in-out infinite; flex-shrink: 0; }
 .input-banner-text { line-height: 1.4; flex: 1; min-width: 0; }
@@ -116,7 +116,7 @@ html, body { overflow: hidden; background: var(--pp-bg); color: var(--pp-text); 
 .input-banner-close:hover { background: rgba(92, 61, 0, 0.2); transform: scale(1.05); }
 @keyframes bannerPulse { 0%, 100% { transform: scale(1); } 50% { transform: scale(1.2); } }
 @keyframes bannerEnter { from { opacity: 0; transform: translateY(-12px); } to { opacity: 1; transform: translateY(0); } }
-@media (max-width: 600px) { .main-heading { font-size: 24px; } .progress-container { width: 260px; } .feature-cards { flex-direction: column; align-items: center; } .orbit-system { width: 180px; height: 180px; } .input-banner { top: 12px; right: 12px; padding: 10px 12px 10px 16px; font-size: 13px; max-width: calc(100vw - 24px); } }
+@media (max-width: 600px) { .main-heading { font-size: 24px; } .progress-container { width: 260px; } .feature-cards { flex-direction: column; align-items: center; } .orbit-system { width: 180px; height: 180px; } .input-banner { top: 12px; inset-inline-end: 12px; padding-block: 10px; padding-inline: 16px 12px; font-size: 13px; max-width: calc(100vw - 24px); } }
 `
 
 export default function Home() {
@@ -139,7 +139,7 @@ export default function Home() {
       const size = Math.random() * 3 + 1
       const colors = ['rgba(167,139,219,0.5)', 'rgba(128,136,217,0.5)', 'rgba(90,155,213,0.5)', 'rgba(139,111,192,0.5)']
       const color = colors[Math.floor(Math.random() * colors.length)]
-      p.style.cssText = `width:${size}px;height:${size}px;left:${Math.random() * 100}%;background:${color};box-shadow:0 0 ${size * 2}px ${color};animation-duration:${Math.random() * 15 + 12}s;animation-delay:${Math.random() * 10}s;`
+      p.style.cssText = `width:${size}px;height:${size}px;inset-inline-start:${Math.random() * 100}%;background:${color};box-shadow:0 0 ${size * 2}px ${color};animation-duration:${Math.random() * 15 + 12}s;animation-delay:${Math.random() * 10}s;`
       particlesEl.appendChild(p)
       timeouts.push(window.setTimeout(() => p.remove(), 30000))
     }

--- a/plugins/power-pages/skills/create-site/assets/vue/src/pages/Home.vue
+++ b/plugins/power-pages/skills/create-site/assets/vue/src/pages/Home.vue
@@ -89,7 +89,7 @@ onMounted(() => {
     const size = Math.random() * 3 + 1
     const colors = ['rgba(167,139,219,0.5)', 'rgba(128,136,217,0.5)', 'rgba(90,155,213,0.5)', 'rgba(139,111,192,0.5)']
     const color = colors[Math.floor(Math.random() * colors.length)]
-    p.style.cssText = `width:${size}px;height:${size}px;left:${Math.random() * 100}%;background:${color};box-shadow:0 0 ${size * 2}px ${color};animation-duration:${Math.random() * 15 + 12}s;animation-delay:${Math.random() * 10}s;`
+    p.style.cssText = `width:${size}px;height:${size}px;inset-inline-start:${Math.random() * 100}%;background:${color};box-shadow:0 0 ${size * 2}px ${color};animation-duration:${Math.random() * 15 + 12}s;animation-delay:${Math.random() * 10}s;`
     particlesEl.appendChild(p)
     timeouts.push(window.setTimeout(() => p.remove(), 30000))
   }
@@ -299,7 +299,7 @@ html, body { overflow: hidden; background: var(--pp-bg); color: var(--pp-text); 
 .loading-wrapper { position: fixed; inset: 0; display: flex; align-items: center; justify-content: center; background: var(--pp-bg); }
 .ambient { position: fixed; inset: 0; z-index: 0; overflow: hidden; }
 .ambient::before {
-  content: ''; position: absolute; width: 160%; height: 160%; top: -30%; left: -30%;
+  content: ''; position: absolute; width: 160%; height: 160%; top: -30%; inset-inline-start: -30%;
   background:
     radial-gradient(ellipse 600px 600px at 25% 30%, rgba(167, 139, 219, 0.12) 0%, transparent 70%),
     radial-gradient(ellipse 500px 500px at 75% 70%, rgba(90, 155, 213, 0.08) 0%, transparent 70%),
@@ -362,10 +362,10 @@ html, body { overflow: hidden; background: var(--pp-bg); color: var(--pp-text); 
 @keyframes spin { to { transform: rotate(360deg); } }
 .progress-container { width: 320px; opacity: 0; animation: fadeSlideUp 1s ease-out 1.5s forwards; display: flex; flex-direction: column; align-items: center; gap: 14px; }
 .progress-track { width: 100%; height: 3px; background: rgba(139, 111, 192, 0.1); border-radius: 4px; overflow: hidden; position: relative; }
-.progress-fill { height: 100%; width: 40%; border-radius: 4px; background: linear-gradient(90deg, transparent, var(--pp-violet), var(--pp-lavender), var(--pp-sky), transparent); position: absolute; top: 0; left: -40%; animation: infiniteSlide 2s cubic-bezier(0.4, 0, 0.2, 1) infinite; }
-.progress-fill::after { content: ''; position: absolute; right: 10%; top: -3px; width: 8px; height: 8px; border-radius: 50%; background: var(--pp-sky); box-shadow: 0 0 8px rgba(90, 155, 213, 0.5), 0 0 16px rgba(90, 155, 213, 0.2); opacity: 0.9; }
-@keyframes infiniteSlide { 0% { left: -40%; } 100% { left: 100%; } }
-.progress-track.complete .progress-fill { width: 100%; left: 0; animation: none; background: linear-gradient(90deg, var(--pp-violet), var(--pp-lavender), var(--pp-sky)); transition: all 0.8s ease; }
+.progress-fill { height: 100%; width: 40%; border-radius: 4px; background: linear-gradient(90deg, transparent, var(--pp-violet), var(--pp-lavender), var(--pp-sky), transparent); position: absolute; top: 0; inset-inline-start: -40%; animation: infiniteSlide 2s cubic-bezier(0.4, 0, 0.2, 1) infinite; }
+.progress-fill::after { content: ''; position: absolute; inset-inline-end: 10%; top: -3px; width: 8px; height: 8px; border-radius: 50%; background: var(--pp-sky); box-shadow: 0 0 8px rgba(90, 155, 213, 0.5), 0 0 16px rgba(90, 155, 213, 0.2); opacity: 0.9; }
+@keyframes infiniteSlide { 0% { inset-inline-start: -40%; } 100% { inset-inline-start: 100%; } }
+.progress-track.complete .progress-fill { width: 100%; inset-inline-start: 0; animation: none; background: linear-gradient(90deg, var(--pp-violet), var(--pp-lavender), var(--pp-sky)); transition: all 0.8s ease; }
 .progress-track.complete .progress-fill::after { display: none; }
 .progress-label-text { font-size: 12px; color: var(--pp-text-muted); font-family: 'DM Sans', sans-serif; letter-spacing: 0.3px; }
 .feature-cards { display: flex; gap: 16px; margin-top: 16px; opacity: 0; animation: fadeSlideUp 1s ease-out 2s forwards; }
@@ -377,7 +377,7 @@ html, body { overflow: hidden; background: var(--pp-bg); color: var(--pp-text); 
 .connector-lines { position: fixed; inset: 0; z-index: 2; pointer-events: none; overflow: hidden; }
 .connector { position: absolute; height: 1px; background: linear-gradient(90deg, transparent, rgba(139, 111, 192, 0.12), transparent); animation: connectorSweep 6s ease-in-out infinite; }
 @keyframes connectorSweep { 0%, 100% { transform: translateX(-100%); opacity: 0; } 20% { opacity: 1; } 80% { opacity: 1; } 100% { transform: translateX(100vw); opacity: 0; } }
-.scanline { position: fixed; left: 0; right: 0; height: 1px; background: linear-gradient(90deg, transparent 0%, var(--pp-lavender) 50%, transparent 100%); opacity: 0.06; z-index: 2; animation: scanDrop 8s linear infinite; pointer-events: none; }
+.scanline { position: fixed; inset-inline: 0; height: 1px; background: linear-gradient(90deg, transparent 0%, var(--pp-lavender) 50%, transparent 100%); opacity: 0.06; z-index: 2; animation: scanDrop 8s linear infinite; pointer-events: none; }
 @keyframes scanDrop { 0% { top: -2px; } 100% { top: 100%; } }
 .tip-area { text-align: center; margin-top: 12px; opacity: 0; animation: fadeSlideUp 1s ease-out 3s forwards; }
 .tip-label { font-size: 10px; letter-spacing: 2px; text-transform: uppercase; color: var(--pp-text-muted); margin-bottom: 8px; font-family: 'Outfit', sans-serif; }
@@ -385,7 +385,7 @@ html, body { overflow: hidden; background: var(--pp-bg); color: var(--pp-text); 
 @keyframes fadeSlideUp { from { opacity: 0; transform: translateY(16px); } to { opacity: 1; transform: translateY(0); } }
 .center-stage.complete .main-heading { animation: completePulse 2s ease-in-out infinite alternate; }
 @keyframes completePulse { 0% { filter: brightness(1); } 100% { filter: brightness(1.15); } }
-.input-banner { position: fixed; top: 24px; right: 24px; z-index: 100; display: flex; align-items: center; gap: 12px; background: linear-gradient(135deg, #FFF4D6 0%, #FFE9B3 100%); border: 1px solid #F5B800; color: #5C3D00; padding: 12px 14px 12px 22px; border-radius: 999px; font-family: 'Outfit', sans-serif; font-size: 14px; font-weight: 500; box-shadow: 0 4px 16px rgba(245, 184, 0, 0.25); max-width: min(360px, calc(100vw - 48px)); animation: bannerEnter 0.4s cubic-bezier(0.22, 1, 0.36, 1); }
+.input-banner { position: fixed; top: 24px; inset-inline-end: 24px; z-index: 100; display: flex; align-items: center; gap: 12px; background: linear-gradient(135deg, #FFF4D6 0%, #FFE9B3 100%); border: 1px solid #F5B800; color: #5C3D00; padding-block: 12px; padding-inline: 22px 14px; border-radius: 999px; font-family: 'Outfit', sans-serif; font-size: 14px; font-weight: 500; box-shadow: 0 4px 16px rgba(245, 184, 0, 0.25); max-width: min(360px, calc(100vw - 48px)); animation: bannerEnter 0.4s cubic-bezier(0.22, 1, 0.36, 1); }
 .input-banner[hidden] { display: none; }
 .input-banner-icon { font-size: 18px; animation: bannerPulse 1.5s ease-in-out infinite; flex-shrink: 0; }
 .input-banner-text { line-height: 1.4; flex: 1; min-width: 0; }
@@ -395,5 +395,5 @@ html, body { overflow: hidden; background: var(--pp-bg); color: var(--pp-text); 
 .input-banner-close:hover { background: rgba(92, 61, 0, 0.2); transform: scale(1.05); }
 @keyframes bannerPulse { 0%, 100% { transform: scale(1); } 50% { transform: scale(1.2); } }
 @keyframes bannerEnter { from { opacity: 0; transform: translateY(-12px); } to { opacity: 1; transform: translateY(0); } }
-@media (max-width: 600px) { .main-heading { font-size: 24px; } .progress-container { width: 260px; } .feature-cards { flex-direction: column; align-items: center; } .orbit-system { width: 180px; height: 180px; } .input-banner { top: 12px; right: 12px; padding: 10px 12px 10px 16px; font-size: 13px; max-width: calc(100vw - 24px); } }
+@media (max-width: 600px) { .main-heading { font-size: 24px; } .progress-container { width: 260px; } .feature-cards { flex-direction: column; align-items: center; } .orbit-system { width: 180px; height: 180px; } .input-banner { top: 12px; inset-inline-end: 12px; padding-block: 10px; padding-inline: 16px 12px; font-size: 13px; max-width: calc(100vw - 24px); } }
 </style>

--- a/plugins/power-pages/skills/create-site/references/design-aesthetics.md
+++ b/plugins/power-pages/skills/create-site/references/design-aesthetics.md
@@ -9,6 +9,13 @@ Design principles, typography, color, and motion guidance for Power Pages code s
 ### Typography
 Choose fonts that are beautiful, unique, and interesting. Load from Google Fonts.
 
+Typography must also support every configured writing script. Preserve the
+chosen brand character across script profiles, but do not force a Latin-only
+display font onto Arabic, Hebrew, Indic, CJK, or other scripts. Avoid fixed
+text heights, Latin-oriented letter spacing on cursive scripts, and hierarchy
+that depends on uppercase or italics. Use locale-appropriate quotation marks
+in translated content.
+
 **Never use:** Inter, Roboto, Open Sans, Lato, Arial, default system fonts
 
 **Recommended choices by mood:**
@@ -172,6 +179,13 @@ Refine the overall visual rhythm:
 - Use consistent spacing scale (e.g., 4, 8, 16, 24, 32, 48, 64, 96px)
 - Ensure visual hierarchy through size contrast (headings should be dramatically larger than body text)
 - Add container max-widths for readability (prose content at 65-75ch)
+- Use logical spacing, border, alignment, and inset properties so the same
+  design follows LTR and RTL without a second stylesheet
+- Test expanded and pseudo-opposite-direction content; buttons, tabs,
+  validation, and headings must wrap without clipping
+
+For complete mixed-content, asset, component, and exception rules, follow
+`${PLUGIN_ROOT}/references/bidirectional-design.md`.
 
 **Verify via `browser_snapshot`**
 

--- a/plugins/power-pages/skills/create-site/scripts/validate-site.js
+++ b/plugins/power-pages/skills/create-site/scripts/validate-site.js
@@ -10,6 +10,9 @@ const {
   detectFramework,
   detectSiteLanguage,
 } = require('../../../scripts/lib/localization-config');
+const {
+  auditBidirectionalReadiness,
+} = require('../../../scripts/lib/bidirectional-readiness');
 
 runValidation((cwd) => {
   const configPath = findPath(cwd, 'powerpages.config.json');
@@ -82,6 +85,17 @@ runValidation((cwd) => {
     } else if (!siteLanguage.valid) {
       errors.push(`Document language is invalid:\n  ${siteLanguage.conflicts.join('\n  ')}`);
     }
+  }
+
+  // 8. New sites must be structurally safe for either writing direction. The
+  // audit blocks only deterministic defects; geometry that may be intentionally
+  // physical remains a review finding for the create-site browser pass.
+  const bidiAudit = auditBidirectionalReadiness(projectRoot);
+  for (const finding of bidiAudit.findings.filter((item) => item.severity === 'error')) {
+    errors.push(
+      `Bidirectional readiness ${finding.file}:${finding.line} ` +
+      `[${finding.rule}]: ${finding.message}`
+    );
   }
 
   if (errors.length > 0) {

--- a/plugins/power-pages/skills/deploy-site/SKILL.md
+++ b/plugins/power-pages/skills/deploy-site/SKILL.md
@@ -205,7 +205,21 @@ Use `AskUserQuestion`:
 
 If `.powerpages-site` does **not** exist (first deployment), skip this step — there are no existing permissions to audit.
 
-### 4.3 Build the Site
+### 4.3 Validate Site Integrity
+
+Before building, run the shared lifecycle check:
+
+```bash
+node "${PLUGIN_ROOT}/scripts/validate-site-integrity.js" --projectRoot "<PROJECT_ROOT>"
+```
+
+This validates deterministic bidirectional rules for every code site and, when
+`.powerpages-localization.json` exists, resource parity, protected tokens, locale availability,
+runtime direction coordination, and localization structure. It also reports content-expansion
+and geometry findings for review. If validation fails, stop and remediate the reported source or
+resource defects before deployment. This is not a new approval gate.
+
+### 4.4 Build the Site
 
 Before uploading, ensure the site is built:
 
@@ -216,7 +230,7 @@ npm run build
 
 If the build fails, stop and help the user fix the build errors before retrying.
 
-### 4.4 Upload to Power Pages
+### 4.5 Upload to Power Pages
 
 Run the upload command:
 
@@ -448,7 +462,7 @@ If the user skips activation (or after activation completes), suggest:
 
 ### NEVER Use `pac pages upload`
 
-Always use `pac pages upload-code-site` — **never** use `pac pages upload`. The `pac pages upload` command is designed for portal-studio-style sites and will corrupt code site metadata if used on a code site project. This applies to every upload step in this skill (Phase 4.4, Phase 6.4, and troubleshooting retries).
+Always use `pac pages upload-code-site` — **never** use `pac pages upload`. The `pac pages upload` command is designed for portal-studio-style sites and will corrupt code site metadata if used on a code site project. This applies to every upload step in this skill (Phase 4.5, Phase 6.4, and troubleshooting retries).
 
 ### Throughout All Phases
 

--- a/plugins/power-pages/skills/integrate-webapi/SKILL.md
+++ b/plugins/power-pages/skills/integrate-webapi/SKILL.md
@@ -23,6 +23,7 @@ Integrate Power Pages Web API into a code site's frontend. This skill orchestrat
 - **Permissions require deployment**: The `.powerpages-site` folder must exist before table permissions and site settings can be configured. Integration code can be written without it, but permissions cannot.
 - **AI-only read mode is opt-in**: When invoked by another skill (e.g. `/add-ai-webapi`) with the `[AI-READ-ONLY]` sentinel in `$ARGUMENTS`, the flow produces read-only code and hardens the settings/permissions for AI summarization reads. See Phase 1.6 for the contract. Human invocations never trigger this mode.
 - **Use TaskCreate/TaskUpdate**: Track all progress throughout all phases — create the todo list upfront with all phases before starting any work.
+- **Preserve site integrity**: Before an agent changes mock-backed or data-driven UI, read `${PLUGIN_ROOT}/references/site-modification-integrity.md`; localize every new visible state when a manifest exists and keep the component bidirectional and expansion-safe.
 
 > **Prerequisites:**
 >

--- a/plugins/power-pages/skills/setup-auth/SKILL.md
+++ b/plugins/power-pages/skills/setup-auth/SKILL.md
@@ -32,6 +32,7 @@ Configure authentication (login/logout) and role-based authorization for a Power
 - **Client-side auth is UX only** — Power Pages authentication is server-side (session cookies). Client-side role checks control what users see, not what they can access. Server-side table permissions enforce actual security.
 - **Framework-appropriate patterns** — Every auth artifact (hooks, composables, services, directives, guards) must match the detected framework's idioms and conventions.
 - **Development parity** — Include mock data for local development so developers can test auth flows and role-based UI without deploying to Power Pages.
+- **Preserve site integrity** — Before changing navigation, auth pages, dialogs, or role-based UI, read `${PLUGIN_ROOT}/references/site-modification-integrity.md`. Synchronize all visible auth states across configured locale resources and keep them bidirectional and expansion-safe.
 
 **Initial request:** $ARGUMENTS
 


### PR DESCRIPTION
Makes bidirectional readiness and localization integrity foundational requirements for Power Pages code sites rather than behavior added only after an RTL locale is introduced.

This change adds shared LTR/RTL design guidance, script-aware direction resolution, deterministic bidirectional source auditing, and lifecycle validation that protects localized sites when later skills or agents modify visible SPA content.

## What changed

### Bidirectional design standard

- Added a shared bidirectional design standard for all Power Pages code sites.
- Requires direction-neutral CSS using logical properties instead of physical left/right assumptions.
- Defines handling for mixed-direction user content, machine-readable values, icons, images, typography, text expansion, focus order, gestures, charts, overlays, and other direction-sensitive components.
- Documents narrowly scoped `bidi-physical` exceptions for intentionally physical placement.
- Requires both `lang` and `dir` on the root document.
- Applies bidirectional readiness to single-language sites so future localization does not require a layout retrofit.

### Script-aware locale direction

- Resolves text direction from a locale's explicit or likely writing script instead of maintaining a language-only RTL allowlist.
- Uses locale maximization to identify the likely script when one is not explicitly provided.
- Correctly distinguishes locales that share a language but use different scripts, including:
  - `ku-Latn` and `ku-Arab`
  - `az-Latn` and `az-Arab`
  - `pa-Guru` and `pa-Arab`
  - `sd-Deva` and `sd-Arab`
- Exposes locale language, script, region, direction, and direction source as shared metadata.

### Deterministic bidirectional audit

- Added `audit-bidirectional-readiness.js` and a shared audit library.
- Scans generated SPA source for:
  - Physical margin, padding, border, and alignment properties
  - Unreviewed physical positioning
  - Visual-order reversal
  - Direction-sensitive transforms, gradients, clipping, and masks
  - Fixed text-container dimensions that may block content expansion
  - Unexpected invisible Unicode bidirectional controls
  - Invalid or unused physical-layout exceptions
- Separates blocking errors from findings that require visual review.
- Excludes generated output, dependencies, coverage, and other non-source directories.

### Localization readiness

- Extends `/add-localization` to classify configured locales as LTR-only, RTL-only, or mixed-direction.
- Requires a bidirectional-readiness review when the first opposite-direction locale is introduced.
- Keeps an opposite-direction locale unavailable when blocking layout issues remain.
- Preserves the localization work and resources while preventing incomplete locales from being exposed through selectors, automatic detection, navigation, alternate-language metadata, or production routes.
- Updates localization validation to enforce readiness state and locale-availability behavior.

### Site modification integrity

- Added a shared site-modification integrity contract for skills and agents that change visible SPA source.
- Requires new visible text to remain synchronized across configured locale resources.
- Preserves translation keys, protected interpolation tokens, unavailable-locale boundaries, direction-neutral layout, and content-expansion behavior.
- Added a centralized site-integrity validator that combines localization validation with the bidirectional source audit.
- Updated source-mutating skills and agents to follow the shared integrity contract.
- Updated the post-skill hook to run integrity validation after relevant source modifications.
- Updated `/deploy-site` to run the same validation as a final backstop for manual or out-of-band changes.

### Framework scaffolds

- Updated React, Vue, Angular, and Astro scaffold content to use direction-neutral layout patterns.
- Added semantic isolation for mixed-direction content.
- Updated create-site validation and design guidance to require bidirectional-safe generated output.

## Behavior and safety

- Single-language sites retain static root-document language and direction without introducing unnecessary localization infrastructure.
- Deterministic bidirectional errors block completion.
- Findings requiring visual judgment are reported for review rather than silently ignored.
- Opposite-direction locales with unresolved blocking issues remain unavailable.
- Existing localization resources and translations are preserved.
- Source-mutating skills cannot report successful completion when they leave the site's localization or bidirectional state invalid.
- Deployment repeats integrity validation so changes made outside a skill receive the same protection.

## Scope

This PR adds deterministic source-level auditing and lifecycle integrity enforcement.

It does not add full browser-rendered LTR/RTL component verification or runtime locale-switch transaction testing. Those capabilities are introduced in later stacked changes.

## Validation

Added or updated tests for:

- Explicit and likely writing-script direction resolution
- LTR and RTL variants of the same language
- Locale-direction classification
- Physical CSS detection and approved exceptions
- Visual-order and directional-geometry review findings
- Unicode bidirectional-control detection
- Localization readiness and unavailable-locale validation
- Site-integrity behavior for localized and single-language sites
- Post-skill integrity hook execution
- Source-mutating skill classification
- Create-site and add-localization validation
- React, Vue, Angular, and Astro scaffold behavior

```powershell
node --test plugins/power-pages/scripts/tests/localization-config.test.js
node --test plugins/power-pages/scripts/tests/bidirectional-readiness.test.js
node --test plugins/power-pages/scripts/tests/site-integrity.test.js
node --test plugins/power-pages/scripts/tests/validate-localization.test.js
node --test plugins/power-pages/scripts/tests/validate-site.test.js
node --test plugins/power-pages/scripts/tests/powerpages-hook-utils.test.js
node --test plugins/power-pages/scripts/tests/run-skill-posttool-validation.test.js
```
