### PR TITLE
model-apps 2.6.1: refuse a per-table language instead of silently dropping it (#537)

### DIFF
--- a/plugins/model-apps/.claude-plugin/plugin.json
+++ b/plugins/model-apps/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "model-apps",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Build model-driven Power Apps end to end: /app-builder authors whole apps (tables, relationships, forms, views, charts, security roles, app + sitemap) from a natural-language intent, and /genpage builds generative pages with specialist agents for planning, entity creation, and parallel code generation. Requires PAC CLI > 2.10.0 and Azure CLI (`az`). See CHANGELOG.md for v1.x -> v2.x migration.",
   "author": {
     "name": "Microsoft",

--- a/plugins/model-apps/.plugin/plugin.json
+++ b/plugins/model-apps/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "model-apps",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Build model-driven Power Apps end to end: /app-builder authors whole apps (tables, relationships, forms, views, charts, security roles, app + sitemap) from a natural-language intent, and /genpage builds generative pages with specialist agents for planning, entity creation, and parallel code generation. Requires PAC CLI > 2.10.0 and Azure CLI (`az`). See CHANGELOG.md for v1.x -> v2.x migration.",
   "author": {
     "name": "Microsoft",

--- a/plugins/model-apps/CHANGELOG.md
+++ b/plugins/model-apps/CHANGELOG.md
@@ -5,7 +5,23 @@ All notable changes to the **model-apps** plugin.
 Entries are deliberately short: what changed and why it matters to you. The reasoning,
 evidence and trade-offs behind a change live in its PR, in `docs/`, or in the linked issue.
 
-## [Unreleased] — 2.6.0
+## [Unreleased] — 2.6.1
+
+### Fixed
+
+- **A per-table language is refused instead of silently ignored** ([#537]). `languageCode` and
+  `localizedLabels` on an **entity** or **column** used to validate clean and then be discarded, so
+  a spec asking for one table in a second language built successfully with the request dropped and
+  the table labelled in the organization's base language. Both keys are now rejected, naming the
+  spec-level `languageCode` — which is a single setting for the whole build. There is no per-table
+  language and no multi-language labelling; the schema doc now says so, and `references/localization.md`
+  states up front that it covers generative-page code, not Dataverse metadata labels.
+- **The invalid-`languageCode` error names a real LCID.** `"es-ES"` is the natural thing to write and
+  the old message ("must be a positive integer LCID") did not say what to write instead.
+
+[#537]: https://github.com/microsoft/power-platform-skills/issues/537
+
+## [2.6.0]
 
 Business process flows, plus an SDK uptake that changes how business rules fail on an environment
 that cannot host them.

--- a/plugins/model-apps/references/app-spec-schema.md
+++ b/plugins/model-apps/references/app-spec-schema.md
@@ -122,6 +122,19 @@ sample data (incl. multi-parent junction links + status reasons), and publish.
   Must be a positive integer LCID up to 65535 — `1031`, not `"de-DE"` and not `true`. An invalid
   value is rejected by validation, and a caller that bypasses validation gets a warning naming the
   discarded value rather than a silent fall-through.
+  **It is a single, SPEC-LEVEL setting — one language for the whole build.** There is no per-table
+  language and no multi-language labelling:
+  - `languageCode` applies to **every** artifact the build creates. You cannot author one table in
+    Spanish and another in English. The LCID is baked into the SDK at construction time, so a second
+    language would need a second build.
+  - A Dataverse label carries **one** translation here, not several. You cannot give a table both
+    `Customer` and `Cliente` — the SDK's label serializer emits a single `LocalizedLabel`.
+
+  Writing `languageCode` or `localizedLabels` on an **entity** or a **column** is therefore rejected
+  by validation ([#537](https://github.com/microsoft/power-platform-skills/issues/537)). It used to
+  validate clean and then be silently discarded, which produced a successful build with the request
+  dropped and the table labelled in the org's base language — so the key is now refused with a
+  message naming this spec-level field instead.
   **Emitted by `download-model-app.js` only if you pinned it yourself.** It is deliberately never
   read from Dataverse: an LCID copied out of the source org would be re-applied verbatim when the
   spec is rebuilt somewhere else, which is exactly how a spec starts failing in an org that lacks

--- a/plugins/model-apps/references/localization.md
+++ b/plugins/model-apps/references/localization.md
@@ -1,5 +1,12 @@
 # Localization Reference
 
+> **Scope: generative-page CODE only.** This file covers localizing the React/TypeScript a
+> generative page renders — translation dictionaries, RTL layout, and user-settings-driven
+> date/number/currency formatting. It does **not** cover Dataverse **metadata labels** (table,
+> column and choice display names). Those come from the App Spec's single, spec-level
+> `languageCode`; there is no per-table language and no multi-language labelling. See
+> `references/app-spec-schema.md` → `languageCode`.
+
 Read this only when the planner has detected multiple configured languages OR any
 non-English language via `pac model list-languages`. English-only environments
 should skip this entire file — the page-builder will write the page without any

--- a/plugins/model-apps/scripts/lib/app-spec.js
+++ b/plugins/model-apps/scripts/lib/app-spec.js
@@ -903,15 +903,21 @@ function validateAppSpec(spec, opts = {}) {
   if (spec.app && spec.app.headerNavigationRefresh !== undefined && typeof spec.app.headerNavigationRefresh !== 'boolean') {
     errors.push('app.headerNavigationRefresh must be a boolean');
   }
-  if (spec.languageCode !== undefined && normalizeLanguageCode(spec.languageCode) === null) {
-    errors.push('languageCode must be a positive integer LCID');
-  }
-  const entityNames = new Set();
-  const entityByLower = new Map(); // logical (lowercased schemaName) -> entity
   // Describe a rejected value for an error message WITHOUT being able to throw doing it.
   // `JSON.stringify` throws on a BigInt and on a getter that throws, which would turn a structured
   // validation error into a raw crash — the exact outcome this validator exists to prevent.
+  // Declared BEFORE the first check that quotes a value: it is a `const` arrow, so a use above this
+  // line is a temporal-dead-zone ReferenceError, not a hoisted call.
   const describeValue = (v) => { try { return JSON.stringify(v); } catch { return Object.prototype.toString.call(v); } };
+  if (spec.languageCode !== undefined && normalizeLanguageCode(spec.languageCode) === null) {
+    // Name a concrete LCID rather than only the rule. The most common wrong value is a BCP-47
+    // language TAG ('es-ES', 'de-DE') — the thing a person naturally writes — and "must be a
+    // positive integer LCID" is true but leaves that author with no idea what to type instead.
+    // LCID reference: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-lcid/
+    errors.push(`languageCode must be a positive integer LCID up to 65535 — a NUMBER such as 1033 (en-US) or 3082 (es-ES), not a language tag like "es-ES" (got ${describeValue(spec.languageCode)})`);
+  }
+  const entityNames = new Set();
+  const entityByLower = new Map(); // logical (lowercased schemaName) -> entity
   // A table reference an author writes becomes a Dataverse METADATA NAME, so it has to be a string
   // BEFORE it is compared. `String([["new_ticket"]])` is `"new_ticket"`, so a nested array passes an
   // entity-membership check and then throws a raw TypeError deep in the build, where the engine
@@ -923,6 +929,33 @@ function validateAppSpec(spec, opts = {}) {
     errors.push(`${where}: entity must be a table name (a string), got ${describeValue(value)}`);
     return true;
   };
+  // #537: `languageCode` and `localizedLabels` are meaningful ONLY at the top level of the spec.
+  // The authoring LCID is resolved once per build and baked into the SDK at CONSTRUCTION time, so
+  // there is no per-table language; and the SDK's label serializer emits a one-element
+  // `LocalizedLabels` array, so there is no multi-language label either.
+  //
+  // Neither key had a reader anywhere in the build and entities carry no unknown-key allow-list, so
+  // authoring one used to VALIDATE CLEAN and then be silently discarded — a successful build with
+  // the table labelled in the org's base language and nothing reporting the loss. That is the same
+  // class as the `newLook` round-trip loss (#514): an explicit instruction dropped in silence.
+  //
+  // Scoped to these two keys rather than a full entity/column allow-list on purpose. A strict
+  // allow-list would reject stray keys in specs that build correctly today, which is a breaking
+  // change this bug does not justify.
+  const LANGUAGE_ONLY_AT_SPEC_LEVEL = ['languageCode', 'localizedLabels'];
+  const rejectLanguageKeys = (obj, where) => {
+    if (!obj || typeof obj !== 'object') return;
+    for (const key of LANGUAGE_ONLY_AT_SPEC_LEVEL) {
+      if (obj[key] === undefined) continue;
+      errors.push(
+        `${where}: '${key}' is not supported here — the authoring language is a single, spec-level `
+        + 'setting. Move it to the top-level "languageCode" (an LCID number, e.g. 3082), which labels '
+        + 'EVERY artifact this build creates. Per-table languages and multi-language labels are not '
+        + `supported (got ${describeValue(obj[key])}).`
+      );
+    }
+  };
+
   for (const e of spec.entities || []) {
     if (!e.schemaName) {
       errors.push('entity.schemaName is required');
@@ -937,10 +970,12 @@ function validateAppSpec(spec, opts = {}) {
       errors.push(`entity ${e.schemaName}: quickCreate must be a boolean`);
     }
     validateDescription(e.description, `entity ${e.schemaName}`, errors);
+    rejectLanguageKeys(e, `entity ${e.schemaName}`);
     for (const c of e.columns || []) {
       if (!c.schemaName) {
         errors.push(`entity ${e.schemaName}: a column is missing schemaName`);
       }
+      rejectLanguageKeys(c, `entity ${e.schemaName}: column ${c.schemaName}`);
       validateDescription(c.description, `entity ${e.schemaName}: column ${c.schemaName}`, errors);
       // A Customer column is created through `createCustomerColumn`, whose payload is only
       // { Lookup, OneToManyRelationships } — the SDK has nowhere to put a description, so one

--- a/plugins/model-apps/scripts/tests/app-spec.test.js
+++ b/plugins/model-apps/scripts/tests/app-spec.test.js
@@ -1176,3 +1176,64 @@ test('the value describer cannot itself throw (BigInt / a throwing getter)', () 
     assert.strictEqual(res.ok, false, `${label} must still be rejected`);
   }
 });
+
+// --- #537: a per-entity / per-column language key is a SILENT DROP ------------------------------
+//
+// `languageCode` is resolved ONCE per build and baked into the SDK at construction, so there is no
+// per-table language and no multi-language label. The trap is not that limitation — it is that the
+// intuitive authorings for it used to VALIDATE CLEAN and then be dropped: `entities[].languageCode`
+// and `entities[].localizedLabels` have no reader anywhere in the build, and entities carry no
+// unknown-key allow-list, so the author got a successful build with the request silently discarded
+// and the table labelled in the org's base language. That is the same class as the `newLook`
+// round-trip loss (#514) — an explicit instruction lost with nothing reporting it.
+//
+// Scoped deliberately to the two keys authors actually reach for rather than a full entity
+// allow-list: a strict allow-list would reject stray keys in specs that build fine today, which is
+// a breaking change this bug does not justify.
+
+test('#537: a per-ENTITY languageCode is rejected, not silently dropped', () => {
+  const spec = cloneDesk();
+  spec.entities[0].languageCode = 3082;
+  const r = validateAppSpec(spec, { profile: 'plan' });
+  assert.strictEqual(r.ok, false, 'a per-entity languageCode must not validate clean');
+  const msg = (r.errors || []).join(' | ');
+  assert.match(msg, /languageCode/);
+  // The message must name the supported alternative, or it just moves the dead end earlier.
+  assert.match(msg, /spec-level|top-level/i, `error should point at the spec-level languageCode: ${msg}`);
+});
+
+test('#537: a per-ENTITY localizedLabels is rejected — multi-language labels are not supported', () => {
+  const spec = cloneDesk();
+  spec.entities[0].localizedLabels = { 1033: 'Customer', 3082: 'Cliente' };
+  const r = validateAppSpec(spec, { profile: 'plan' });
+  assert.strictEqual(r.ok, false);
+  assert.match((r.errors || []).join(' | '), /localizedLabels/);
+});
+
+test('#537: the same keys on a COLUMN are rejected too', () => {
+  for (const key of ['languageCode', 'localizedLabels']) {
+    const spec = cloneDesk();
+    spec.entities[0].columns[0][key] = key === 'languageCode' ? 3082 : { 1033: 'x' };
+    const r = validateAppSpec(spec, { profile: 'plan' });
+    assert.strictEqual(r.ok, false, `column ${key} must be rejected`);
+    assert.match((r.errors || []).join(' | '), new RegExp(key));
+  }
+});
+
+test('#537: the spec-level languageCode error names a concrete LCID, so a language TAG is actionable', () => {
+  const spec = cloneDesk();
+  spec.languageCode = 'es-ES';
+  const r = validateAppSpec(spec, { profile: 'plan' });
+  assert.strictEqual(r.ok, false);
+  const msg = (r.errors || []).join(' | ');
+  // Previously: "languageCode must be a positive integer LCID" — true, but it does not tell an
+  // author who wrote 'es-ES' what to write instead.
+  assert.match(msg, /3082|1033/, `error should show an example LCID: ${msg}`);
+});
+
+test('#537: the SUPPORTED spec-level languageCode still validates (no regression)', () => {
+  const spec = cloneDesk();
+  spec.languageCode = 3082;
+  const r = validateAppSpec(spec, { profile: 'plan' });
+  assert.strictEqual(r.ok, true, JSON.stringify(r.errors));
+});


### PR DESCRIPTION
Fixes #537 (the plugin half).

## The bug is the *silence*, not the limitation

`languageCode` is a single, **spec-level** authoring LCID. It is resolved once and baked into the
SDK at construction time, so there is no per-table language; and the SDK's label serializer emits a
one-element `LocalizedLabels` array, so there is no multi-language label either. Those limits are
reasonable and stay.

What was not reasonable is how they failed. Measured under **both** the `plan` and the strict
`deploy` profile, before this change:

```
entities[1].languageCode  = 3082                     ->  ok=true
entities[1].localizedLabels = {1033:.., 3082:..}     ->  ok=true
```

Both validated clean — and `e.languageCode` / `.localizedLabels` have **zero readers anywhere in
`scripts/lib`**. Entities carry no unknown-key allow-list (unlike `securityRoles`, `ai.appFeatures`,
`design` and `personas`, which all reject unknown keys precisely so a typo fails loudly), so the key
was accepted and dropped. The author asked for one table in Spanish, got a **successful build**, and
the table came out in the organization's base language with nothing reporting the loss. Same class
as the `newLook` round-trip loss (#514).

After:

```
entity new_cliente: 'languageCode' is not supported here — the authoring language is a single,
spec-level setting. Move it to the top-level "languageCode" (an LCID number, e.g. 3082), which
labels EVERY artifact this build creates. Per-table languages and multi-language labels are not
supported (got 3082).
```

## Scope, deliberately narrow

Rejection is scoped to **these two keys** on entities and columns, not a full allow-list. A strict
entity allow-list would reject stray keys in specs that build correctly today — a breaking change
this bug does not justify.

## Also

- **The invalid-`languageCode` message now names a real LCID.** A BCP-47 **tag** (`"es-ES"`) is the
  natural thing to write, and *"must be a positive integer LCID"* is true but tells that author
  nothing about what to type instead. It now reads `a NUMBER such as 1033 (en-US) or 3082 (es-ES)`.
- **Docs.** The schema doc now states the one-language-per-build limitation explicitly.
  `references/localization.md` now says up front that it covers generative-page **code**
  (translation dictionaries, RTL, user-settings formatting), **not** Dataverse metadata labels —
  that naming overlap is part of why the limitation was easy to misread as "localization is
  supported".

## A mistake worth recording

The first draft called `describeValue` **above its own `const` declaration** — a temporal-dead-zone
`ReferenceError`, not a hoisted call, and it would have crashed the validator on the exact input it
was added to describe. Caught before running; the helper now sits above its first use with a comment
saying why the order matters.

## Not in scope

The other half of #537 — actual multi-language labels — needs the **SDK** serializer to emit more
than one `LocalizedLabel`, plus a spec surface for it. That belongs upstream and #537 stays open for
it.

## Verification

| Gate | Result |
|---|---|
| Plugin suite | **2039/2039** (+5) |
| Eval tests | **159/159** |
| Repo validators | **7/7** |
| Mutants killed | **4/4** |
| Legacy manifest mirror | in sync |

Version bumped to **2.6.1**; `[Unreleased] — 2.6.0` also marked released, since 2.6.0 is on `main`.
