### PR TITLE
fix(model-apps): reject unknown entities[] keys instead of silently dropping them

### DIFF
--- a/plugins/model-apps/.claude-plugin/plugin.json
+++ b/plugins/model-apps/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "model-apps",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Build model-driven Power Apps end to end: /app-builder authors whole apps (tables, relationships, forms, views, charts, security roles, app + sitemap) from a natural-language intent, and /genpage builds generative pages with specialist agents for planning, entity creation, and parallel code generation. Requires PAC CLI > 2.10.0 and Azure CLI (`az`). See CHANGELOG.md for v1.x -> v2.x migration.",
   "author": {
     "name": "Microsoft",

--- a/plugins/model-apps/.plugin/plugin.json
+++ b/plugins/model-apps/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "model-apps",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Build model-driven Power Apps end to end: /app-builder authors whole apps (tables, relationships, forms, views, charts, security roles, app + sitemap) from a natural-language intent, and /genpage builds generative pages with specialist agents for planning, entity creation, and parallel code generation. Requires PAC CLI > 2.10.0 and Azure CLI (`az`). See CHANGELOG.md for v1.x -> v2.x migration.",
   "author": {
     "name": "Microsoft",

--- a/plugins/model-apps/AGENTS.md
+++ b/plugins/model-apps/AGENTS.md
@@ -198,6 +198,16 @@ the pipeline and delegates each script's **behavioral spec** to the entries belo
   language disagrees with the SDK performing it (`ARTIFACT_LANGUAGE_MISMATCH`, for registrations
   marked `languageSensitive` — App, Form, Dashboard). Passing nothing preserves the SDK's own 1033
   default exactly, so the option is opt-in rather than a silent re-labelling.
+  **One language per BUILD, and there is no per-table override.** Because the LCID is resolved once
+  and is a construction-time SDK option, a second language would need a second SDK instance — and
+  multi-language labelling is blocked a layer lower anyway, since the SDK's label serializer emits a
+  one-element `LocalizedLabels` array by design. `entities[].languageCode` and
+  `entities[].localizedLabels` are therefore **rejected by validation**
+  ([#537](https://github.com/microsoft/power-platform-skills/issues/537)) rather than accepted and
+  dropped: `entities[]` had no allow-list, so both validated clean and were silently ignored, and an
+  author asking for one table in a second language got a successful build with the request gone. Any
+  unknown table key now fails the same way (see `ENTITY_KEYS`, `scripts/lib/app-spec.js`). Note that
+  `references/localization.md` is about generated **page** code, not Dataverse labels.
   Note the SDK deliberately does **not** language-parameterize BusinessRule: its mapper's language
   parameter is the *environment base* language, a different concept.
   Guarded by `scripts/tests/lcid-real-bundle.test.js`, which drives the REAL vendored bundle — a mock

--- a/plugins/model-apps/CHANGELOG.md
+++ b/plugins/model-apps/CHANGELOG.md
@@ -5,7 +5,28 @@ All notable changes to the **model-apps** plugin.
 Entries are deliberately short: what changed and why it matters to you. The reasoning,
 evidence and trade-offs behind a change live in its PR, in `docs/`, or in the linked issue.
 
-## [Unreleased] — 2.6.0
+## [Unreleased] — 2.6.1
+
+### Fixed
+
+- **A table key the build cannot honour now fails instead of being dropped** ([#537]). `entities[]`
+  was the one authorable block with no allow-list, so `entities[].languageCode` and
+  `entities[].localizedLabels` — the two natural ways to ask for a per-table or multi-language
+  label — validated clean and were then silently ignored. Asking for one table in Spanish produced a
+  successful build with the request gone and nothing reporting the loss. Unknown table keys (a
+  misspelled `pluralname`, too) are now rejected, and the error names what to write instead: the
+  authoring language is **build-wide**, set by the spec-level `languageCode`. Multi-language labels
+  remain unsupported — the SDK's serializer emits one label per name by design. The same check runs
+  on the `/genpage` provisioning input, which is the other entry point that accepts tables; it still
+  accepts every App Spec table key, so entities copied from an `app-spec.json` keep validating.
+- **The `languageCode` error now says what to write.** It named the mistake but not the fix; it now
+  gives a concrete LCID (`1033`) and rejects a language tag explicitly. A tag is deliberately not
+  accepted as an alias: `es-ES` is 3082 or 1034 depending on sort order, and guessing wrong would
+  not fail — it would build every label in the wrong language.
+
+[#537]: https://github.com/microsoft/power-platform-skills/issues/537
+
+## [2.6.0]
 
 Business process flows, plus an SDK uptake that changes how business rules fail on an environment
 that cannot host them.

--- a/plugins/model-apps/CHANGELOG.md
+++ b/plugins/model-apps/CHANGELOG.md
@@ -23,6 +23,12 @@ evidence and trade-offs behind a change live in its PR, in `docs/`, or in the li
   gives a concrete LCID (`1033`) and rejects a language tag explicitly. A tag is deliberately not
   accepted as an alias: `es-ES` is 3082 or 1034 depending on sort order, and guessing wrong would
   not fail — it would build every label in the wrong language.
+- **A non-string `entities[].schemaName` is an error, not a crash.** The check only tested
+  truthiness, so `"schemaName": 42` (or `{}`, `[]`, `true`) passed it and the next line called
+  `.toLowerCase()` on the value — `validateAppSpec` threw a raw `TypeError` and the caller lost
+  every problem found so far, not just that one. Found while reproducing the review comment on the
+  message above; pre-existing rather than introduced here, but on the same line and the same class
+  of "a validator must return problems, not throw them".
 
 [#537]: https://github.com/microsoft/power-platform-skills/issues/537
 

--- a/plugins/model-apps/references/app-spec-schema.md
+++ b/plugins/model-apps/references/app-spec-schema.md
@@ -122,6 +122,12 @@ sample data (incl. multi-parent junction links + status reasons), and publish.
   Must be a positive integer LCID up to 65535 — `1031`, not `"de-DE"` and not `true`. An invalid
   value is rejected by validation, and a caller that bypasses validation gets a warning naming the
   discarded value rather than a silent fall-through.
+  **It is build-wide.** One LCID is resolved and applied to every table, column, choice, status
+  value, relationship and alternate key in the spec. There is **no per-table language**: an
+  `entities[].languageCode` or `entities[].localizedLabels` is **rejected**
+  ([#537](https://github.com/microsoft/power-platform-skills/issues/537)), because the
+  build cannot honour either — the SDK takes the language as a construction-time option and its
+  label serializer emits one label per name by design. Multi-language labelling is not supported.
   **Emitted by `download-model-app.js` only if you pinned it yourself.** It is deliberately never
   read from Dataverse: an LCID copied out of the source org would be re-applied verbatim when the
   spec is rebuilt somewhere else, which is exactly how a spec starts failing in an org that lacks
@@ -247,6 +253,11 @@ it exists is accepted by validation, builds green, and does not change the deplo
   ]
 }
 ```
+- **Unknown table keys are REJECTED, not ignored**
+  ([#537](https://github.com/microsoft/power-platform-skills/issues/537)). A table accepts exactly the keys above
+  plus `statusReasons` / `alternateKeys`. Anything else — a misspelled `pluralname`, or a
+  `languageCode` / `localizedLabels` asking for a per-table or second language — fails validation
+  naming the alternative, rather than validating clean and being dropped from the build.
 - **Column `type`:** `Text · Memo · Choice · MultiChoice · Boolean · Money · DateTime ·
   Integer · BigInt · Decimal · Double · File · Image · AutoNumber · Customer`.
   **Lookups are NOT columns** — declare a `OneToMany` relationship instead.

--- a/plugins/model-apps/references/localization.md
+++ b/plugins/model-apps/references/localization.md
@@ -1,5 +1,11 @@
 # Localization Reference
 
+> **Scope: generated PAGE code, not Dataverse metadata.** This file covers translating the React
+> pages `/genpage` writes — translation dictionaries, RTL, and user-settings-driven number/date
+> formatting. It does **not** cover Dataverse table, column or choice **labels**. Those are written
+> in a single build-wide authoring language set by the spec-level `languageCode`; there is no
+> per-table language and no multi-language labelling (see `app-spec-schema.md` → `languageCode`).
+
 Read this only when the planner has detected multiple configured languages OR any
 non-English language via `pac model list-languages`. English-only environments
 should skip this entire file — the page-builder will write the page without any

--- a/plugins/model-apps/scripts/lib/app-spec.js
+++ b/plugins/model-apps/scripts/lib/app-spec.js
@@ -588,6 +588,19 @@ function describeSpecValue(v) {
   try { return Object.prototype.toString.call(v); } catch { return '<unprintable>'; }
 }
 
+// The single wording for a rejected LCID, shared by every entry point that accepts one.
+//
+// It is a function rather than a constant because the offending value is quoted back: the most
+// common wrong input is a BCP-47 language TAG ("es-ES", "de-DE") — the thing a person naturally
+// writes — and "must be a positive integer LCID" is true but leaves that author with nothing to act
+// on. Shared for the same reason `ENTITY_KEYS` is: two entry points that disagree about what a bad
+// LCID *is* teach the author two different rules for one field.
+// LCID reference: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-lcid/
+function invalidLanguageCodeMessage(value) {
+  return `languageCode must be a positive integer LCID up to ${MAX_LCID} — e.g. 1033 (en-US) or 1031 (de-DE), `
+    + `not a language tag like "de-DE" (got ${describeSpecValue(value)})`;
+}
+
 // Normalize a page's implementation source into a discriminated shape:
 //   { kind: 'tsx', codeFile } | { kind: 'intent' } | null
 // A legacy top-level `codeFile` (schemaVersion < 2) is treated as an implemented tsx page. `null`
@@ -962,7 +975,7 @@ function validateAppSpec(spec, opts = {}) {
     // wrong guess would not fail — it would build every label in the wrong language, which is the
     // same silent-corruption class this validator exists to prevent. Naming the LCID is safe;
     // inferring one is not.
-    errors.push(`languageCode must be a positive integer LCID up to ${MAX_LCID} — e.g. 1033 (en-US) or 1031 (de-DE), not a language tag like "de-DE" (got ${describeSpecValue(spec.languageCode)})`);
+    errors.push(invalidLanguageCodeMessage(spec.languageCode));
   }
   const entityNames = new Set();
   const entityByLower = new Map(); // logical (lowercased schemaName) -> entity
@@ -991,6 +1004,16 @@ function validateAppSpec(spec, opts = {}) {
     // caller can pass a Proxy whose `ownKeys` trap throws, and this validator's contract is to
     // RETURN problems, not to throw them.
     if (e && typeof e === 'object' && !Array.isArray(e)) {
+      // The label is resolved BEFORE `schemaName` is validated, and reading it can itself fail (a
+      // getter that throws). Without a fallback a malformed entity reported `entity undefined:
+      // unknown key ...` next to the real `entity.schemaName is required` — two errors for one
+      // problem, one of them naming a table that does not exist.
+      let label;
+      try {
+        label = typeof e.schemaName === 'string' && e.schemaName.trim() ? `entity ${e.schemaName}` : 'an entity with no schemaName';
+      } catch {
+        label = 'an entity whose schemaName could not be read';
+      }
       let keys;
       try {
         keys = Object.keys(e);
@@ -1000,7 +1023,7 @@ function validateAppSpec(spec, opts = {}) {
       }
       for (const k of keys || []) {
         if (ENTITY_KEYS.has(k)) continue;
-        errors.push(`entity ${e.schemaName}: unknown key '${k}'${ENTITY_KEY_HINTS[k] || ''} (allowed: ${[...ENTITY_KEYS].join(', ')})`);
+        errors.push(`${label}: unknown key '${k}'${ENTITY_KEY_HINTS[k] || ''} (allowed: ${[...ENTITY_KEYS].join(', ')})`);
       }
     }
     if (!e.schemaName) {
@@ -2273,6 +2296,7 @@ module.exports = {
   canonicalPersonaName,
   VALIDATION_PROFILES,
   ENTITY_KEYS,
+  invalidLanguageCodeMessage,
   ENTITY_KEY_HINTS,
   DIRECT_ENTRY_BEHAVIORS,
   COLUMN_VISUALIZATIONS,

--- a/plugins/model-apps/scripts/lib/app-spec.js
+++ b/plugins/model-apps/scripts/lib/app-spec.js
@@ -1026,11 +1026,34 @@ function validateAppSpec(spec, opts = {}) {
         errors.push(`${label}: unknown key '${k}'${ENTITY_KEY_HINTS[k] || ''} (allowed: ${[...ENTITY_KEYS].join(', ')})`);
       }
     }
-    if (!e.schemaName) {
-      errors.push('entity.schemaName is required');
+    // `schemaName` must be a non-empty STRING, and the check says so rather than only testing
+    // truthiness. `!e.schemaName` let `42`, `{}` and `[]` through, and the very next line called
+    // `.toLowerCase()` on them — so a spec carrying `"schemaName": 42` CRASHED the validator with a
+    // raw TypeError instead of being told what was wrong. That is the one outcome this function must
+    // never produce: its whole contract is to turn bad input into structured errors, and a caller
+    // that gets a TypeError loses every finding collected so far, not just this one. Reachable from
+    // any hand- or model-authored JSON file, which is how every spec arrives.
+    //
+    // The read itself is wrapped only because it is cheap to do so. A getter or Proxy trap that
+    // throws is NOT comprehensively defended against in this validator — several later passes
+    // interpolate `e.schemaName` directly — and no attempt is made to pretend otherwise; that shape
+    // cannot come from `JSON.parse`, only from a programmatic caller.
+    let schemaNameValue;
+    let schemaNameReadable = true;
+    try { schemaNameValue = e.schemaName; } catch { schemaNameReadable = false; }
+    if (!schemaNameReadable) {
+      errors.push('entity.schemaName could not be read');
+    } else if (typeof schemaNameValue !== 'string' || !schemaNameValue.trim()) {
+      // `undefined`/`null`/`""` keep the original wording: it is the overwhelmingly common case and
+      // "is required" is the right thing to say about an absent value. A present-but-wrong value
+      // gets its own message, quoting what was found, because "required" would be actively
+      // misleading to someone who did supply one.
+      errors.push(schemaNameValue === undefined || schemaNameValue === null || schemaNameValue === ''
+        ? 'entity.schemaName is required'
+        : `entity.schemaName must be a non-empty string (got ${describeSpecValue(schemaNameValue)})`);
     } else {
-      entityNames.add(e.schemaName);
-      entityByLower.set(e.schemaName.toLowerCase(), e);
+      entityNames.add(schemaNameValue);
+      entityByLower.set(schemaNameValue.toLowerCase(), e);
     }
     if (!e.primaryAttribute || !e.primaryAttribute.schemaName) {
       errors.push(`entity ${e.schemaName}: primaryAttribute.schemaName required`);

--- a/plugins/model-apps/scripts/lib/app-spec.js
+++ b/plugins/model-apps/scripts/lib/app-spec.js
@@ -493,6 +493,43 @@ const BPF_STEP_KEYS = new Set(['name', 'field', 'required']);
 const BPF_MAX_STAGES = 30;
 const BPF_MAX_STEPS = 30;
 
+// The keys an `entities[]` table may carry. Everything else is REJECTED rather than dropped.
+//
+// Entities were the one authorable block with NO allow-list, and the gap was not theoretical: the
+// two most natural ways to ask for a second language — `entities[].languageCode` and
+// `entities[].localizedLabels` — both validated clean and were then silently ignored, so an author
+// asking for one table in Spanish got a SUCCESSFUL build with the request dropped and nothing
+// reporting the loss (#537). Neither key is read anywhere in scripts/ or scripts/lib/.
+//
+// They cannot be honoured today, which is precisely why they must fail loudly rather than validate
+// clean. The authoring language is BUILD-WIDE: provisionDataModel resolves ONE LCID and passes it to
+// every createTable / createColumn / createGlobalOptionSet / insertStatusValue / createRelationship /
+// createAlternateKey call, and the SDK takes it as a CONSTRUCTION-TIME option (the App/Form/Dashboard
+// adapters bake it in), so a per-table language would need a second SDK instance. Multi-language
+// labelling is blocked a layer lower still — the SDK's label serializer emits a ONE-element
+// LocalizedLabels array by design, and pushing an artifact read under a different LCID throws
+// ARTIFACT_LANGUAGE_MISMATCH.
+//
+// This list is the set the build actually READS. Adding a key here without a reader would re-open
+// the very silent-drop hole it exists to close.
+const ENTITY_KEYS = new Set([
+  'schemaName', 'displayName', 'pluralName', 'description', 'primaryAttribute', 'columns',
+  'hasNotes', 'quickCreate', 'existing', 'enrichDefaultViews',
+  'vectorIcon', 'iconDescription', 'icon',
+  'statusReasons', 'alternateKeys',
+]);
+
+// What to write INSTEAD, for the keys an author is most likely to reach for. A bare "unknown key"
+// names the mistake but not the fix, and for these two the fix is not guessable from the schema.
+//
+// Prototype-less on purpose: the lookup key comes from the SPEC, so a table carrying `constructor`
+// or `toString` would otherwise inherit a value from Object.prototype and splice
+// "function Object() { [native code] }" into the error message.
+const ENTITY_KEY_HINTS = Object.assign(Object.create(null), {
+  languageCode: ' — the authoring language is build-wide, not per-table: set the spec-level `languageCode`, which applies to every table',
+  localizedLabels: ' — multi-language labels are not supported: the build writes ONE label per name, in the spec-level `languageCode` language',
+});
+
 // The column logical names an entity legitimately exposes to a rule / process step: its declared
 // columns, its primary name column, and any lookup a relationship creates ON it (a lookup is a real
 // column on the referencing table, just declared elsewhere in the spec).
@@ -537,6 +574,18 @@ function normalizeLanguageCode(value) {
   if (typeof value === 'number') return Number.isInteger(value) ? ok(value) : null;
   if (typeof value === 'string' && /^\d+$/.test(value.trim())) return ok(Number(value.trim()));
   return null;
+}
+
+// Describe a rejected value for an error message WITHOUT being able to throw doing it.
+// `JSON.stringify` throws on a BigInt and on a getter that throws, which would turn a structured
+// validation error into a raw crash — the exact outcome this validator exists to prevent.
+// The FALLBACK is guarded too: `Object.prototype.toString` itself throws on a revoked Proxy, so an
+// unguarded fallback would reintroduce the crash it exists to avoid.
+// Module-level so checks that run BEFORE validateAppSpec's local helpers are initialised can use it
+// too (a `const` arrow declared later in the function is in the temporal dead zone until then).
+function describeSpecValue(v) {
+  try { return JSON.stringify(v); } catch { /* fall through */ }
+  try { return Object.prototype.toString.call(v); } catch { return '<unprintable>'; }
 }
 
 // Normalize a page's implementation source into a discriminated shape:
@@ -904,14 +953,22 @@ function validateAppSpec(spec, opts = {}) {
     errors.push('app.headerNavigationRefresh must be a boolean');
   }
   if (spec.languageCode !== undefined && normalizeLanguageCode(spec.languageCode) === null) {
-    errors.push('languageCode must be a positive integer LCID');
+    // Keep the leading clause stable — the CLI flag and two test suites match on it. The appended
+    // guidance exists because the bare message named the mistake without naming the fix, and a
+    // language TAG is the most likely thing an author reaches for.
+    //
+    // A tag is NOT accepted as an alias, deliberately: the mapping is genuinely ambiguous where it
+    // matters (es-ES is 3082 with the international sort and 1034 with the traditional one), and a
+    // wrong guess would not fail — it would build every label in the wrong language, which is the
+    // same silent-corruption class this validator exists to prevent. Naming the LCID is safe;
+    // inferring one is not.
+    errors.push(`languageCode must be a positive integer LCID up to ${MAX_LCID} — e.g. 1033 (en-US) or 1031 (de-DE), not a language tag like "de-DE" (got ${describeSpecValue(spec.languageCode)})`);
   }
   const entityNames = new Set();
   const entityByLower = new Map(); // logical (lowercased schemaName) -> entity
   // Describe a rejected value for an error message WITHOUT being able to throw doing it.
-  // `JSON.stringify` throws on a BigInt and on a getter that throws, which would turn a structured
-  // validation error into a raw crash — the exact outcome this validator exists to prevent.
-  const describeValue = (v) => { try { return JSON.stringify(v); } catch { return Object.prototype.toString.call(v); } };
+  // See describeSpecValue above for why a bare JSON.stringify is unsafe here.
+  const describeValue = describeSpecValue;
   // A table reference an author writes becomes a Dataverse METADATA NAME, so it has to be a string
   // BEFORE it is compared. `String([["new_ticket"]])` is `"new_ticket"`, so a nested array passes an
   // entity-membership check and then throws a raw TypeError deep in the build, where the engine
@@ -924,6 +981,28 @@ function validateAppSpec(spec, opts = {}) {
     return true;
   };
   for (const e of spec.entities || []) {
+    // Reject unknown keys (#537). A key with no reader is otherwise accepted and dropped, so an
+    // explicit authoring instruction disappears into a successful build.
+    //
+    // Guarded to plain objects: a malformed entity already fails the schemaName check below, and
+    // `Object.keys('x')` would turn one bad value into a bogus "unknown key '0'".
+    //
+    // The enumeration itself is guarded because the object comes from the CALLER: a programmatic
+    // caller can pass a Proxy whose `ownKeys` trap throws, and this validator's contract is to
+    // RETURN problems, not to throw them.
+    if (e && typeof e === 'object' && !Array.isArray(e)) {
+      let keys;
+      try {
+        keys = Object.keys(e);
+      } catch {
+        keys = null;
+        errors.push('an entity could not be inspected: enumerating its keys threw');
+      }
+      for (const k of keys || []) {
+        if (ENTITY_KEYS.has(k)) continue;
+        errors.push(`entity ${e.schemaName}: unknown key '${k}'${ENTITY_KEY_HINTS[k] || ''} (allowed: ${[...ENTITY_KEYS].join(', ')})`);
+      }
+    }
     if (!e.schemaName) {
       errors.push('entity.schemaName is required');
     } else {
@@ -2193,6 +2272,8 @@ module.exports = {
   SDK_ROLE_MARKER,
   canonicalPersonaName,
   VALIDATION_PROFILES,
+  ENTITY_KEYS,
+  ENTITY_KEY_HINTS,
   DIRECT_ENTRY_BEHAVIORS,
   COLUMN_VISUALIZATIONS,
   INTEGER_FORMATS,

--- a/plugins/model-apps/scripts/lib/provision-input.js
+++ b/plugins/model-apps/scripts/lib/provision-input.js
@@ -5,7 +5,7 @@
 // App-Spec subset: { solution, entities, relationships, globalChoices?, sampleData? }.
 // Entities carry FULL schema names (e.g. cr_candidate), not bare suffixes.
 
-const { TYPE_MAP, normalizeLanguageCode } = require('./app-spec.js');
+const { TYPE_MAP, normalizeLanguageCode, ENTITY_KEYS, ENTITY_KEY_HINTS } = require('./app-spec.js');
 
 // Validates provision-entities input. Returns { ok, errors }.
 function validateProvisionInput(input) {
@@ -73,6 +73,35 @@ function validateProvisionInput(input) {
 
     if (publisherPrefix && !e.schemaName.toLowerCase().startsWith(`${publisherPrefix}_`)) {
       errors.push(`entity '${e.schemaName}': schemaName must start with the solution publisher prefix '${publisherPrefix}_'`);
+    }
+
+    // Reject unknown table keys here too (#537). This is a SECOND entry point that accepts entities
+    // (the /genpage provisioning CLI), so validating only in validateAppSpec left the silent drop
+    // fully reproducible through a documented path: `languageCode`, `localizedLabels` and a
+    // misspelled `pluralname` all returned ok:true and were dropped before any SDK write.
+    //
+    // It shares ENTITY_KEYS with the App Spec deliberately, for the same reason normalizeLanguageCode
+    // is shared: two entry points that disagree about what a table key IS would be worse than either
+    // rule alone. This input is documented as "App Spec format", so entities copied out of an
+    // app-spec.json must keep validating.
+    //
+    // That means the 5 keys this narrower path does not consume — vectorIcon, iconDescription, icon,
+    // existing, enrichDefaultViews — are ACCEPTED and ignored here (it provisions the data model
+    // only; it writes no icons and enriches no views). That is a known subset boundary, not the
+    // unknown-key hole #537 is about, and rejecting them would break the copy-paste compatibility
+    // the format promises.
+    // Enumeration is guarded for the same reason as validateAppSpec's: the object comes from the
+    // caller, and a validator's contract is to RETURN problems rather than throw them.
+    let entityKeys;
+    try {
+      entityKeys = Object.keys(e);
+    } catch {
+      entityKeys = null;
+      errors.push(`entity '${e.schemaName}': could not be inspected — enumerating its keys threw`);
+    }
+    for (const k of entityKeys || []) {
+      if (ENTITY_KEYS.has(k)) continue;
+      errors.push(`entity '${e.schemaName}': unknown key '${k}'${ENTITY_KEY_HINTS[k] || ''} (allowed: ${[...ENTITY_KEYS].join(', ')})`);
     }
 
     entityByLower.set(e.schemaName.toLowerCase(), e);

--- a/plugins/model-apps/scripts/lib/provision-input.js
+++ b/plugins/model-apps/scripts/lib/provision-input.js
@@ -5,7 +5,7 @@
 // App-Spec subset: { solution, entities, relationships, globalChoices?, sampleData? }.
 // Entities carry FULL schema names (e.g. cr_candidate), not bare suffixes.
 
-const { TYPE_MAP, normalizeLanguageCode, ENTITY_KEYS, ENTITY_KEY_HINTS } = require('./app-spec.js');
+const { TYPE_MAP, normalizeLanguageCode, ENTITY_KEYS, ENTITY_KEY_HINTS, invalidLanguageCodeMessage } = require('./app-spec.js');
 
 // Validates provision-entities input. Returns { ok, errors }.
 function validateProvisionInput(input) {
@@ -35,7 +35,10 @@ function validateProvisionInput(input) {
   // The other two entry points hard-error on the identical string; this gate keeps all three consistent
   // and runs before any SDK write.
   if (input.languageCode !== undefined && normalizeLanguageCode(input.languageCode) === null) {
-    errors.push('languageCode must be a positive integer LCID');
+    // Shares the App Spec validator's wording — the entity-key rule is already shared between these
+    // two entry points, and the same bad value must not produce a helpful error on one path and a
+    // terse one on the other.
+    errors.push(invalidLanguageCodeMessage(input.languageCode));
   }
 
   // Entities validation

--- a/plugins/model-apps/scripts/tests/app-spec-keys.test.js
+++ b/plugins/model-apps/scripts/tests/app-spec-keys.test.js
@@ -321,3 +321,29 @@ test('#537: exotic values become validation errors, not raw crashes', () => {
   assert.strictEqual(r2.ok, false);
   assert.ok(r2.errors.some((e) => /could not be inspected/.test(e)), JSON.stringify(r2.errors));
 });
+
+// --- review follow-ups on the #537 entity-key allow-list ----------------------------------------
+
+test('#537 review: an unknown key on an entity with NO schemaName does not say "entity undefined"', () => {
+  // The unknown-key message interpolates the entity's schemaName, which is validated AFTERWARDS. A
+  // malformed entity therefore produced `entity undefined: unknown key ...` alongside the real
+  // `entity.schemaName is required` — two errors for one problem, one of them naming a table that
+  // does not exist. The label must degrade to something stable instead.
+  const r = validateAppSpec({
+    solution: { uniqueName: 'S', displayName: 'S', publisherPrefix: 'new' },
+    app: { name: 'A', description: '' },
+    entities: [{ languageCode: 3082, primaryAttribute: { schemaName: 'new_n', displayName: 'N' } }],
+    appShell: { areas: [] },
+  }, { profile: 'plan' });
+  const msg = (r.errors || []).join(' | ');
+  assert.match(msg, /unknown key 'languageCode'/, 'the unknown key must still be reported');
+  assert.doesNotMatch(msg, /entity undefined/, `no "entity undefined" label: ${msg}`);
+});
+
+// PRE-EXISTING, deliberately NOT fixed here: `validateAppSpec` still THROWS instead of returning
+// errors when an entity's `schemaName` is a non-string or a getter that throws. Verified against
+// `origin/main`, which fails identically — `e.schemaName.toLowerCase is not a function` and the
+// getter's own error — so it is not a regression from the allow-list change. The entity loop reads
+// `e.schemaName` at 19 further sites this PR does not touch; fixing it properly means resolving the
+// name ONCE into a local and threading it through, which is its own change with its own tests.
+// The label guard above covers the case the review actually raised: a MISSING schemaName.

--- a/plugins/model-apps/scripts/tests/app-spec-keys.test.js
+++ b/plugins/model-apps/scripts/tests/app-spec-keys.test.js
@@ -340,10 +340,48 @@ test('#537 review: an unknown key on an entity with NO schemaName does not say "
   assert.doesNotMatch(msg, /entity undefined/, `no "entity undefined" label: ${msg}`);
 });
 
-// PRE-EXISTING, deliberately NOT fixed here: `validateAppSpec` still THROWS instead of returning
-// errors when an entity's `schemaName` is a non-string or a getter that throws. Verified against
-// `origin/main`, which fails identically — `e.schemaName.toLowerCase is not a function` and the
-// getter's own error — so it is not a regression from the allow-list change. The entity loop reads
-// `e.schemaName` at 19 further sites this PR does not touch; fixing it properly means resolving the
-// name ONCE into a local and threading it through, which is its own change with its own tests.
-// The label guard above covers the case the review actually raised: a MISSING schemaName.
+test('#537 review follow-up: a NON-STRING schemaName is an error, not a crash', () => {
+  // Found while reproducing the review comment above. `!e.schemaName` only tested truthiness, so
+  // `42`, `{}`, `[]` and `true` passed it and the very next line called `.toLowerCase()` on them —
+  // `validateAppSpec` THREW a raw TypeError instead of returning findings. That is the one outcome
+  // this function must never produce: the caller loses every problem collected so far, not just
+  // this one. Reachable from any hand- or model-authored JSON file, which is how specs arrive.
+  //
+  // Verified against `origin/main` before the fix: it threw for every non-string below.
+  const spec = (schemaName) => ({
+    solution: { uniqueName: 'S', displayName: 'S', publisherPrefix: 'new' },
+    app: { name: 'A', description: '' },
+    entities: [{ ...(schemaName === undefined ? {} : { schemaName }), displayName: 'T', primaryAttribute: { schemaName: 'new_n', displayName: 'N' }, columns: [] }],
+    appShell: { areas: [] },
+  });
+
+  for (const bad of [42, {}, [], true, '   ']) {
+    let r;
+    assert.doesNotThrow(() => { r = validateAppSpec(spec(bad), { profile: 'plan' }); },
+      `a schemaName of ${JSON.stringify(bad)} must be REPORTED, not thrown`);
+    assert.strictEqual(r.ok, false);
+    assert.ok((r.errors || []).some((e) => /schemaName must be a non-empty string/.test(e)),
+      `${JSON.stringify(bad)} -> ${JSON.stringify(r.errors)}`);
+  }
+
+  // An ABSENT value keeps the original wording — it is the common case, and "is required" is the
+  // right thing to say about a value nobody supplied. Saying "must be a non-empty string" to
+  // someone who wrote nothing would be worse, not better.
+  for (const absent of [undefined, null, '']) {
+    const r = validateAppSpec(spec(absent), { profile: 'plan' });
+    assert.ok((r.errors || []).some((e) => /^entity\.schemaName is required$/.test(e)),
+      `${JSON.stringify(absent)} -> ${JSON.stringify(r.errors)}`);
+  }
+
+  // Counterfactual: a valid name still validates clean, so the tightening did not simply reject
+  // everything.
+  assert.strictEqual(validateAppSpec(spec('new_ticket'), { profile: 'plan' }).ok, true);
+});
+
+// STILL NOT FIXED, and deliberately so: `validateAppSpec` throws if reading `e.schemaName` ITSELF
+// throws — a getter or a Proxy trap. The read at the schemaName check is wrapped, but ~19 later
+// sites interpolate `e.schemaName` directly and any one of them re-triggers the trap, so a guard
+// only at the first site would buy nothing while implying the case was handled. Fixing it properly
+// means resolving the name ONCE into a local and threading it through every site, which is its own
+// change with its own tests. Unlike the non-string case above, this shape cannot come from
+// `JSON.parse` — only a programmatic caller can build it — so it is not on any real input path.

--- a/plugins/model-apps/scripts/tests/app-spec-keys.test.js
+++ b/plugins/model-apps/scripts/tests/app-spec-keys.test.js
@@ -196,3 +196,128 @@ test('app.newLook must be a boolean', () => {
   // Absent is fine — the new look is opt-in.
   assert.strictEqual(validateAppSpec(base(), { profile: 'plan' }).ok, true);
 });
+
+// ---------------------------------------------------------------------------------------------
+// #537 — entities[] had no allow-list, so a key with no reader validated clean and was dropped.
+//
+// The two that motivated this are `languageCode` and `localizedLabels`: the natural ways to ask for
+// a per-table or multi-language label. Both were accepted and silently ignored, so an author asking
+// for one table in Spanish got a SUCCESSFUL build with the request gone. These pin the loud failure
+// AND the alternative each error names, because an error that does not say what to write instead
+// just moves the dead end.
+// ---------------------------------------------------------------------------------------------
+
+test('#537: entities[].languageCode is rejected and names the spec-level languageCode', () => {
+  for (const profile of ['plan', 'deploy']) {
+    const s = base();
+    s.entities[0].languageCode = 3082;
+    const r = validateAppSpec(s, { profile });
+    const hit = (r.errors || []).find((e) => /unknown key 'languageCode'/.test(e));
+    assert.ok(hit, `${profile}: ` + JSON.stringify(r.errors));
+    // Naming the supported alternative is the point of the error, not a nicety.
+    assert.match(hit, /spec-level `languageCode`/);
+    assert.match(hit, /build-wide, not per-table/);
+  }
+});
+
+test('#537: entities[].localizedLabels is rejected and says multi-language is unsupported', () => {
+  for (const profile of ['plan', 'deploy']) {
+    const s = base();
+    s.entities[0].localizedLabels = { 3082: 'Cliente', 1033: 'Customer' };
+    const r = validateAppSpec(s, { profile });
+    const hit = (r.errors || []).find((e) => /unknown key 'localizedLabels'/.test(e));
+    assert.ok(hit, `${profile}: ` + JSON.stringify(r.errors));
+    assert.match(hit, /multi-language labels are not supported/);
+  }
+});
+
+test('#537: a misspelled entity key fails loudly instead of being dropped', () => {
+  const s = base();
+  s.entities[0].pluralname = 'Orders'; // real key is `pluralName`
+  const r = validateAppSpec(s, { profile: 'plan' });
+  const hit = (r.errors || []).find((e) => /unknown key 'pluralname'/.test(e));
+  assert.ok(hit, JSON.stringify(r.errors));
+  assert.match(hit, /allowed: .*pluralName/); // the allowed list is what makes the typo obvious
+});
+
+// The counterpart that matters most: an allow-list that is too NARROW silently breaks valid specs,
+// which is a worse failure than the one being fixed. Every key the build reads must still validate.
+test('#537: every supported entity key still validates clean', () => {
+  const s = base();
+  s.webResources = [
+    { name: 'contoso_i', displayName: 'I', type: 'svg', content: '<svg/>' },
+    { name: 'contoso_p', displayName: 'P', type: 'png', contentBase64: 'AA==' },
+  ];
+  Object.assign(s.entities[0], {
+    displayName: 'Order', pluralName: 'Orders', description: 'An order.',
+    hasNotes: true, quickCreate: true, existing: false, enrichDefaultViews: true,
+    vectorIcon: 'contoso_i', iconDescription: 'a box', icon: 'contoso_p',
+    statusReasons: [], alternateKeys: [],
+  });
+  const r = validateAppSpec(s, { profile: 'plan' });
+  assert.strictEqual(r.ok, true, JSON.stringify(r.errors));
+});
+
+// A malformed entity must not be re-described as a key problem: Object.keys('x') is ['0'], which
+// would report a bogus "unknown key '0'" on top of the real shape error.
+test('#537: a non-object entity does not produce a bogus index key error', () => {
+  const s = base();
+  s.entities.push('contoso_ghost');
+  const r = validateAppSpec(s, { profile: 'plan' });
+  assert.ok(!(r.errors || []).some((e) => /unknown key '\d+'/.test(e)), JSON.stringify(r.errors));
+});
+
+// The bare "must be a positive integer LCID" named the mistake but not the fix, and a language TAG
+// is the likeliest thing an author writes. A tag is deliberately NOT accepted as an alias: es-ES is
+// 3082 (international sort) or 1034 (traditional), and guessing wrong would not fail — it would
+// build every label in the wrong language.
+test('#537: the languageCode error names an LCID and rejects a language tag', () => {
+  const s = base();
+  s.languageCode = 'es-ES';
+  const r = validateAppSpec(s, { profile: 'plan' });
+  const hit = (r.errors || []).find((e) => /languageCode must be a positive integer LCID/.test(e));
+  assert.ok(hit, JSON.stringify(r.errors));
+  assert.match(hit, /1033 \(en-US\)/);      // a concrete value to copy
+  assert.match(hit, /not a language tag/);
+  assert.match(hit, /"es-ES"/);              // echoes what was actually written
+
+  // The supported spelling still passes, in both profiles.
+  for (const profile of ['plan', 'deploy']) {
+    const ok = base();
+    ok.languageCode = 3082;
+    assert.strictEqual(validateAppSpec(ok, { profile }).ok, true, JSON.stringify(validateAppSpec(ok, { profile }).errors));
+  }
+});
+
+// The hint lookup is keyed by a name that comes from the SPEC, so an inherited Object.prototype
+// member must not become part of the message. Before the map was made prototype-less, a table with
+// a `constructor` key reported: unknown key 'constructor'function Object() { [native code] }
+test('#537: an entity key that collides with Object.prototype does not leak a native function', () => {
+  const s = base();
+  s.entities[0].constructor = 1;
+  s.entities[0].toString = 2;
+  const r = validateAppSpec(s, { profile: 'plan' });
+  const hits = (r.errors || []).filter((e) => /unknown key/.test(e));
+  assert.strictEqual(hits.length, 2, JSON.stringify(r.errors));
+  for (const h of hits) assert.ok(!/native code/.test(h), h);
+});
+
+// A validator's contract is to RETURN problems, not throw them. Both of these threw before the
+// guards went in: Object.prototype.toString throws on a revoked Proxy, and an entity Proxy whose
+// ownKeys trap throws escaped straight through the new key loop.
+test('#537: exotic values become validation errors, not raw crashes', () => {
+  const revoked = Proxy.revocable({}, {});
+  revoked.revoke();
+
+  const s = base();
+  s.languageCode = revoked.proxy;
+  const r = validateAppSpec(s, { profile: 'plan' });
+  assert.strictEqual(r.ok, false);
+  assert.ok(r.errors.some((e) => /languageCode must be a positive integer LCID/.test(e)), JSON.stringify(r.errors));
+
+  const s2 = base();
+  s2.entities.push(new Proxy({ schemaName: 'contoso_ghost' }, { ownKeys() { throw new Error('trap'); } }));
+  const r2 = validateAppSpec(s2, { profile: 'plan' });
+  assert.strictEqual(r2.ok, false);
+  assert.ok(r2.errors.some((e) => /could not be inspected/.test(e)), JSON.stringify(r2.errors));
+});

--- a/plugins/model-apps/scripts/tests/provision-input.test.js
+++ b/plugins/model-apps/scripts/tests/provision-input.test.js
@@ -159,3 +159,19 @@ test('#537: provision input still accepts every App Spec table key', () => {
   }));
   assert.strictEqual(r.ok, true, JSON.stringify(r.errors));
 });
+
+test('#537 review: provision-input reports the SAME invalid-LCID message as the App Spec validator', () => {
+  // The entity-key rule is already shared between these two entry points; the top-level LCID message
+  // was not, so the same bad value produced a helpful error on one path and a terse one on the other.
+  const { validateProvisionInput } = require('../lib/provision-input.js');
+  const r = validateProvisionInput({
+    solution: { uniqueName: 'S', displayName: 'S', publisherPrefix: 'new' },
+    entities: [{ schemaName: 'new_t', displayName: 'T', pluralName: 'Ts', primaryAttribute: { schemaName: 'new_n', displayName: 'N' }, columns: [] }],
+    relationships: [],
+    languageCode: 'es-ES',
+  });
+  assert.strictEqual(r.ok, false);
+  const msg = (r.errors || []).join(' | ');
+  assert.match(msg, /1033|1031/, `should name a concrete LCID: ${msg}`);
+  assert.match(msg, /language tag/, `should name the language-tag mistake: ${msg}`);
+});

--- a/plugins/model-apps/scripts/tests/provision-input.test.js
+++ b/plugins/model-apps/scripts/tests/provision-input.test.js
@@ -108,3 +108,54 @@ test('languageCode in the provision input is validated, not silently discarded (
   // Absent stays valid — the field is optional and the org default is the normal case.
   assert.ok(!(validateProvisionInput(base).errors || []).some((e) => /languageCode/.test(e)));
 });
+
+// ---------------------------------------------------------------------------------------------
+// #537 — this CLI is the SECOND entry point that accepts entities (the /genpage provisioning
+// path). Validating only in validateAppSpec left the silent drop fully reproducible here: an
+// entity-level languageCode returned ok:true and the table was then created with the org default.
+// ---------------------------------------------------------------------------------------------
+
+function provisionBase(entityExtra) {
+  return {
+    solution: { uniqueName: 'Default', publisherPrefix: 'cr' },
+    entities: [Object.assign({
+      schemaName: 'cr_candidate', displayName: 'Candidate',
+      primaryAttribute: { schemaName: 'cr_name' }, columns: [],
+    }, entityExtra)],
+    relationships: [],
+  };
+}
+
+test('#537: provision input rejects entities[].languageCode and names the alternative', () => {
+  const r = validateProvisionInput(provisionBase({ languageCode: 3082 }));
+  assert.strictEqual(r.ok, false);
+  const hit = r.errors.find((e) => /unknown key 'languageCode'/.test(e));
+  assert.ok(hit, JSON.stringify(r.errors));
+  assert.match(hit, /spec-level `languageCode`/);
+});
+
+test('#537: provision input rejects entities[].localizedLabels', () => {
+  const r = validateProvisionInput(provisionBase({ localizedLabels: { 3082: 'Cliente' } }));
+  assert.strictEqual(r.ok, false);
+  assert.ok(r.errors.some((e) => /unknown key 'localizedLabels'/.test(e)), JSON.stringify(r.errors));
+});
+
+test('#537: provision input rejects a misspelled entity key', () => {
+  const r = validateProvisionInput(provisionBase({ pluralname: 'Candidates' }));
+  assert.strictEqual(r.ok, false);
+  assert.ok(r.errors.some((e) => /unknown key 'pluralname'/.test(e)), JSON.stringify(r.errors));
+});
+
+// The input is documented as "App Spec format", so entities copied out of an app-spec.json must
+// still validate — including the keys this narrower path does not itself consume (icons, existing,
+// enrichDefaultViews). Rejecting those would break the compatibility the format promises; they are
+// a known subset boundary, not the unknown-key hole.
+test('#537: provision input still accepts every App Spec table key', () => {
+  const r = validateProvisionInput(provisionBase({
+    pluralName: 'Candidates', description: 'A candidate.', hasNotes: true, quickCreate: true,
+    existing: true, enrichDefaultViews: true,
+    vectorIcon: 'cr_icon', iconDescription: 'a badge', icon: 'cr_iconpng',
+    statusReasons: [], alternateKeys: [],
+  }));
+  assert.strictEqual(r.ok, true, JSON.stringify(r.errors));
+});


### PR DESCRIPTION
## What

`entities[]` was the one authorable block in the App Spec with **no unknown-key allow-list** — unlike `securityRoles`, `ai.appFeatures`, `design`, `personas` and the BPF blocks, which all reject unknown keys precisely so a typo fails loudly.

So the two most natural ways to ask for a second language — `entities[].languageCode` and `entities[].localizedLabels` — **validated clean and were then silently ignored**. An author asking for one table in Spanish got a *successful* build with the request dropped and nothing reporting the loss.

Fixes #537 (part **a**).

| authoring | before | after |
|---|---|---|
| `entities[].languageCode = 3082` | `ok: true`, silently ignored | rejected, names the spec-level `languageCode` |
| `entities[].localizedLabels = {…}` | `ok: true`, silently ignored | rejected, says multi-language is unsupported |
| `entities[].pluralname` (typo) | `ok: true`, silently ignored | rejected, lists the allowed keys |
| `languageCode: 'es-ES'` | *"must be a positive integer LCID"* | …now also names `1033` and rejects a tag explicitly |

## Why these can't just be implemented

Neither key can be honoured today, which is exactly why they must fail loudly rather than validate clean:

- The authoring language is **build-wide** — `provisionDataModel` resolves **one** LCID and passes it to every `createTable` / `createColumn` / `createGlobalOptionSet` / `insertStatusValue` / `createRelationship` / `createAlternateKey` call, and the SDK takes it as a **construction-time** option, so a per-table language would need a second SDK instance.
- Multi-language labelling is blocked a layer lower: the SDK's label serializer emits a **one-element** `LocalizedLabels` array by design, and pushing an artifact read under a different LCID throws `ARTIFACT_LANGUAGE_MISMATCH`.

Part **(b)** of the issue (real multi-language labels) is SDK work and is deliberately **not** in this PR.

## The main risk, and how it was managed

**An allow-list that is too narrow silently breaks valid specs — a worse failure than the bug being fixed.** The 15 keys are the set the build actually *reads*, verified three independent ways:

1. every entity-key read across `scripts/` and `scripts/lib/`;
2. the documented `entities[]` surface in `references/app-spec-schema.md`;
3. every spec fixture in the repo (`evals/model-apps/**`) plus a sweep of all fenced doc examples.

The severe failure mode would be breaking the **download → build round trip**. That is pinned by existing coverage: `hydrate-spec.test.js` hydrates a spec and asserts `validateAppSpec(...).ok === true`, and the download side emits only `schemaName`/`displayName`/`description`/`primaryAttribute`/`columns`/`existing` — all allow-listed.

## Found in review (three additional fixes)

- **The same silent drop was still fully reproducible** through the `/genpage` provisioning CLI — a second entry point that accepts entities and ran no unknown-key check (`ok: true` for all three cases above). It now shares **one** `ENTITY_KEYS` definition with the App Spec, for the same reason `normalizeLanguageCode` is shared: two entry points disagreeing about what a table key *is* would be worse than either rule alone. It still accepts every App Spec table key — including the five it does not itself consume (`vectorIcon`, `iconDescription`, `icon`, `existing`, `enrichDefaultViews`) — so entities copied out of an `app-spec.json` keep validating.
- **`.claude-plugin/plugin.json` is a required mirror** of `.plugin/plugin.json`. Bumping only one fails `validate-legacy-compatibility.js` and the required metadata workflow — this would have shipped a red CI.
- **Validation could crash instead of returning errors.** `Object.prototype.toString` throws on a revoked `Proxy`, and an entity `Proxy` whose `ownKeys` trap throws escaped the new key loop. Both now produce structured validation errors, restoring the "return problems, never throw" contract.

## Deliberate non-change

A BCP-47 tag is **not** accepted as an alias for an LCID. The mapping is genuinely ambiguous where it matters — `es-ES` is **3082** (international sort) or **1034** (traditional) — and a wrong guess would not fail: it would build every label in the wrong language, which is the same silent-corruption class this validator exists to prevent. Naming the LCID in the error is safe; inferring one is not.

## Testing

- **2046 pass, 0 fail** (`node scripts/run-tests.js`); baseline was 2034.
- **Red-green verified**: the behaviour tests fail against `origin/main`'s `app-spec.js`. The two guard tests (over-narrow allow-list; no bogus `unknown key '0'` on a malformed entity) pass in both states *by design* — they guard the fix, not the bug.
- `validate-legacy-compatibility.js` passes.

## Docs

`CHANGELOG.md` (2.6.1), both plugin manifests, `AGENTS.md`, and `references/app-spec-schema.md`. Also a scope note at the top of `references/localization.md`, which the issue calls out: it covers generated **page** code, not Dataverse metadata labels, and the naming overlap makes it easy to read the plugin as having table-label localization it does not have.
