### PR TITLE
Bump canvas-apps plugin version to 3.0.4

### DIFF
--- a/plugins/canvas-apps/.claude-plugin/plugin.json
+++ b/plugins/canvas-apps/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "canvas-apps",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "Build Power Apps Canvas Apps using the Canvas Authoring MCP server.",
   "author": {
     "name": "Microsoft",

--- a/plugins/canvas-apps/.plugin/plugin.json
+++ b/plugins/canvas-apps/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "canvas-apps",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "Build Power Apps Canvas Apps using the Canvas Authoring MCP server.",
   "author": {
     "name": "Microsoft",


### PR DESCRIPTION
Bumps both Canvas Apps plugin manifests from 3.0.3 to 3.0.4 so clients can discover the package update merged in #511. Validated legacy compatibility, plugin names, and skill descriptions.