### PR TITLE
fix(power-pages): restore the audit report placeholder check

### DIFF
--- a/plugins/power-pages/scripts/tests/validate-audit.test.js
+++ b/plugins/power-pages/scripts/tests/validate-audit.test.js
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+/**
+ * Tests for audit-permissions/scripts/validate-audit.js
+ *
+ * The validator's only job is to catch a report whose placeholders were never
+ * populated. It used to hardcode `__FINDINGS_DATA__` / `__INVENTORY_DATA__`, so
+ * when the template moved to the JSON-context tokens `__JSON_FINDINGS_DATA__` /
+ * `__JSON_INVENTORY_DATA__` the check silently stopped matching anything and an
+ * unpopulated report validated clean. These tests pin the placeholder grammar
+ * rather than specific key names so the same drift cannot recur.
+ */
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const { spawnSync } = require('child_process');
+
+const VALIDATOR = path.join(
+  __dirname,
+  '../../skills/audit-permissions/scripts/validate-audit.js'
+);
+const RENDERER = path.join(__dirname, '..', 'render-audit-report.js');
+const TEMPLATE = path.join(
+  __dirname,
+  '../../skills/audit-permissions/assets/audit-report.html'
+);
+
+// Mirrors PLACEHOLDER_RE in scripts/lib/render-template.js.
+const PLACEHOLDER_RE = /__(?:(?:HTML|ATTR|JSON|RAW)_)?[A-Z][A-Z0-9_]*__/g;
+
+function makeProject() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'validate-audit-'));
+  fs.writeFileSync(path.join(dir, 'powerpages.config.json'), '{}', 'utf8');
+  fs.mkdirSync(path.join(dir, 'docs'), { recursive: true });
+  return dir;
+}
+
+function writeReport(dir, html) {
+  fs.writeFileSync(path.join(dir, 'docs', 'permissions-audit.html'), html, 'utf8');
+}
+
+function runValidator(cwd) {
+  const result = spawnSync(process.execPath, [VALIDATOR], {
+    input: JSON.stringify({ cwd }),
+    encoding: 'utf8',
+    timeout: 5000,
+  });
+  return { code: result.status, stderr: result.stderr || '' };
+}
+
+test('validate-audit: exits 0 when no report was generated', () => {
+  assert.equal(runValidator(makeProject()).code, 0);
+});
+
+test('validate-audit: exits 0 for a report rendered by render-audit-report.js', () => {
+  const dir = makeProject();
+  const dataPath = path.join(dir, 'audit-data.json');
+  fs.writeFileSync(
+    dataPath,
+    JSON.stringify({
+      SITE_NAME: 'Contoso',
+      AUDIT_DESC: 'Security audit of table permissions',
+      SUMMARY: 'No critical findings.',
+      FINDINGS_DATA: [],
+      INVENTORY_DATA: [],
+    }),
+    'utf8'
+  );
+  const render = spawnSync(
+    process.execPath,
+    [RENDERER, '--output', path.join(dir, 'docs', 'permissions-audit.html'), '--data', dataPath],
+    { encoding: 'utf8', timeout: 5000 }
+  );
+  assert.equal(render.status, 0, render.stderr);
+
+  const result = runValidator(dir);
+  assert.equal(result.code, 0, result.stderr);
+});
+
+test('validate-audit: blocks the JSON-context tokens the template actually uses', () => {
+  const dir = makeProject();
+  writeReport(dir, 'const FINDINGS = __JSON_FINDINGS_DATA__;\nconst INVENTORY = __JSON_INVENTORY_DATA__;');
+  const result = runValidator(dir);
+  assert.equal(result.code, 2);
+  assert.match(result.stderr, /__JSON_FINDINGS_DATA__/);
+  assert.match(result.stderr, /__JSON_INVENTORY_DATA__/);
+});
+
+test('validate-audit: still blocks the legacy bare tokens', () => {
+  const dir = makeProject();
+  writeReport(dir, 'const FINDINGS = __FINDINGS_DATA__;');
+  assert.equal(runValidator(dir).code, 2);
+});
+
+test('validate-audit: blocks unreplaced text placeholders, not just the data ones', () => {
+  const dir = makeProject();
+  writeReport(dir, '<title>Permissions Audit — __SITE_NAME__</title>');
+  assert.equal(runValidator(dir).code, 2);
+});
+
+// The check is only safe to make grammar-wide if a correctly rendered report can never
+// contain a matching token. That holds while every placeholder in the template maps to a
+// key the renderer supplies, so assert that rather than assuming it.
+test('validate-audit: every template placeholder maps to a renderer-supplied key', () => {
+  const template = fs.readFileSync(TEMPLATE, 'utf8');
+  const supplied = ['SITE_NAME', 'AUDIT_DESC', 'SUMMARY', 'FINDINGS_DATA', 'INVENTORY_DATA', 'CSP_NONCE'];
+  const unsupported = [...new Set(template.match(PLACEHOLDER_RE) || [])].filter((token) => {
+    const key = token.replace(/^__(?:(?:HTML|ATTR|JSON|RAW)_)?/, '').replace(/__$/, '');
+    return !supplied.includes(key);
+  });
+  assert.deepEqual(unsupported, [], `Template placeholders with no renderer key: ${unsupported.join(', ')}`);
+});

--- a/plugins/power-pages/skills/audit-permissions/scripts/validate-audit.js
+++ b/plugins/power-pages/skills/audit-permissions/scripts/validate-audit.js
@@ -7,6 +7,12 @@ const fs = require('fs');
 const path = require('path');
 const { approve, block, runValidation, findPath, findProjectRoot } = require('../../../scripts/lib/validation-helpers');
 
+// Mirrors PLACEHOLDER_RE in scripts/lib/render-template.js. Matching the grammar rather
+// than specific token names keeps this check working when a template renames a key or
+// adds a context prefix, which is how `__FINDINGS_DATA__` -> `__JSON_FINDINGS_DATA__`
+// silently disabled it before.
+const PLACEHOLDER_RE = /__(?:(?:HTML|ATTR|JSON|RAW)_)?[A-Z][A-Z0-9_]*__/g;
+
 runValidation((cwd) => {
   const projectRoot = findProjectRoot(cwd);
   if (!projectRoot) approve(); // Not a Power Pages project — not an audit session
@@ -15,8 +21,9 @@ runValidation((cwd) => {
   const docsReport = path.join(projectRoot, 'docs', 'permissions-audit.html');
   if (fs.existsSync(docsReport)) {
     const content = fs.readFileSync(docsReport, 'utf8');
-    if (content.includes('__FINDINGS_DATA__') || content.includes('__INVENTORY_DATA__')) {
-      block('Audit report has unreplaced placeholders — data was not populated.');
+    const unreplaced = [...new Set(content.match(PLACEHOLDER_RE) || [])];
+    if (unreplaced.length > 0) {
+      block(`Audit report has unreplaced placeholders (${unreplaced.join(', ')}) — data was not populated.`);
     }
     approve();
   }


### PR DESCRIPTION
## Problem

`plugins/power-pages/skills/audit-permissions/scripts/validate-audit.js` is a `PostToolUse(Skill)` hook whose only job is to catch a permissions audit report that was written without its data being populated. It does that by looking for leftover template placeholders.

#389 moved `audit-report.html` to the context-aware placeholders introduced by that PR:

```diff
-const FINDINGS = __FINDINGS_DATA__;
+const FINDINGS = __JSON_FINDINGS_DATA__;
-const INVENTORY = __INVENTORY_DATA__;
+const INVENTORY = __JSON_INVENTORY_DATA__;
```

The validator was not updated and still tests for the old names:

```js
if (content.includes('__FINDINGS_DATA__') || content.includes('__INVENTORY_DATA__')) {
```

This is not a partial match, it is no match at all. `__FINDINGS_DATA__` is **not** a substring of `__JSON_FINDINGS_DATA__`, because the leading `__` is broken by the `JSON` prefix. Both `includes()` calls are now permanently false, so a report full of unreplaced placeholders is approved rather than blocked. The guard has been silently inert since #389.

Nothing else regressed in that PR: `render-audit-report.js` and `render-template.js` handle the new tokens correctly. Only this check drifted.

## Fix

Match the placeholder **grammar** rather than specific key names, mirroring `PLACEHOLDER_RE` in `scripts/lib/render-template.js`:

```js
const PLACEHOLDER_RE = /__(?:(?:HTML|ATTR|JSON|RAW)_)?[A-Z][A-Z0-9_]*__/g;
```

Consequences:

- Renaming a key or adding a context prefix cannot silently disable the check again, which is the actual failure mode here.
- `__SITE_NAME__`, `__AUDIT_DESC__` and `__SUMMARY__` are now covered too. They never were.
- The block message names the placeholders that were left, so the failure is actionable.

Widening the match is only safe while a correctly rendered report can never contain a matching token. That holds because every placeholder in the template maps to a key `render-audit-report.js` supplies (`SITE_NAME`, `AUDIT_DESC`, `SUMMARY`, `FINDINGS_DATA`, `INVENTORY_DATA`, plus the auto-injected `CSP_NONCE`). Rather than assume that invariant, the new test asserts it, so adding an unsupported placeholder to the template fails CI instead of causing a spurious block.

## Tests

Adds `plugins/power-pages/scripts/tests/validate-audit.test.js`, picked up automatically by the existing `node --test` run in `power-pages-script-tests.yml`.

| Case | Expected |
| --- | --- |
| No report generated | approve |
| Report rendered through `render-audit-report.js` | approve |
| `__JSON_FINDINGS_DATA__` / `__JSON_INVENTORY_DATA__` left in | block, naming both |
| Legacy `__FINDINGS_DATA__` left in | block |
| `__SITE_NAME__` left in | block |
| Every template placeholder maps to a renderer key | invariant holds |

2 of the 6 cases fail against the current validator and pass with this change, so the test reproduces the defect rather than just describing it.

`cd plugins/power-pages/scripts/tests && node --test` — 1441 passing, 0 failing.
