### PR TITLE
fix(mobile-apps): separate scaffold and generator validation

### DIFF
--- a/plugins/mobile-apps/.claude-plugin/plugin.json
+++ b/plugins/mobile-apps/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "mobile-app",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "description": "Build and deploy Power Apps code apps for mobile using Expo (React Native), with native device functionality and Power Platform connectors",
     "author": {
         "name": "Microsoft",

--- a/plugins/mobile-apps/.plugin/plugin.json
+++ b/plugins/mobile-apps/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "mobile-app",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "description": "Build and deploy Power Apps code apps for mobile using Expo (React Native), with native device functionality and Power Platform connectors",
     "author": {
         "name": "Microsoft",

--- a/plugins/mobile-apps/hooks/validate-protected-paths.js
+++ b/plugins/mobile-apps/hooks/validate-protected-paths.js
@@ -53,7 +53,8 @@ process.stdin.on('end', () => {
   const fp = toolInput.file_path || toolInput.filePath;
   if (typeof fp !== 'string') process.exit(0);
 
-  const hit = PROTECTED.find(({ rx }) => rx.test(fp));
+  const normalizedPath = fp.replace(/\\/g, '/');
+  const hit = PROTECTED.find(({ rx }) => rx.test(normalizedPath));
   if (!hit) process.exit(0);
 
   const rel = path.relative(process.cwd(), fp) || fp;

--- a/plugins/mobile-apps/scripts/prepare-mobile-template.js
+++ b/plugins/mobile-apps/scripts/prepare-mobile-template.js
@@ -560,6 +560,7 @@ function prepareMobileTemplate(options) {
   let removedPowerConfig;
   let removedLegacyFiles;
   let sharedFiles;
+  let writtenFiles;
   try {
     updateIdentity(projectRoot, options.displayName, options.slug);
     removedPowerConfig = removeEmptyPowerConfig(projectRoot);
@@ -567,6 +568,14 @@ function prepareMobileTemplate(options) {
     sharedFiles = copySharedFiles(projectRoot, samplesRoot);
     prepareRootLayout(projectRoot);
     assertNoDanglingLegacyImports(projectRoot);
+    writtenFiles = [...originalState.files]
+      .filter(([relativePath, snapshot]) => {
+        const filePath = path.join(projectRoot, relativePath);
+        if (!fs.existsSync(filePath)) return false;
+        return !snapshot.exists || !fs.readFileSync(filePath).equals(snapshot.content);
+      })
+      .map(([relativePath]) => relativePath)
+      .sort();
   } catch (error) {
     try {
       restorePreparationState(projectRoot, originalState);
@@ -578,6 +587,7 @@ function prepareMobileTemplate(options) {
 
   return {
     projectRoot,
+    writtenFiles,
     removedPowerConfig,
     removedLegacyFiles,
     copiedSharedFiles: sharedFiles.copied,

--- a/plugins/mobile-apps/scripts/tests/create-mobile-app-quality-contract.test.js
+++ b/plugins/mobile-apps/scripts/tests/create-mobile-app-quality-contract.test.js
@@ -45,3 +45,23 @@ test('Power Apps initialization directly invokes the CLI with approved values', 
   assert.match(initialize, /If a populated file remains, STOP/);
   assert.doesNotMatch(initialize, /spawnSync|node <<'NODE'/);
 });
+
+test('scaffold changed-file validation separates preparation and generator ownership', () => {
+  const preparation = skill.slice(
+    skill.indexOf('### Step 5 — Prepare existing template'),
+    skill.indexOf('### Step 6 — Initialize'),
+  );
+  const memory = skill.slice(
+    skill.indexOf('### Step 6.7 — Seed the memory bank'),
+    skill.indexOf('### Step 6.75 — Design system'),
+  );
+  const shared = fs.readFileSync(path.resolve(__dirname, '../../shared/shared-instructions.md'), 'utf8');
+
+  assert.match(preparation, /result\.writtenFiles/);
+  assert.match(preparation, /removedPowerConfig.*removedLegacyFiles/);
+  assert.match(preparation, /Do not rebuild this list from `git status`/);
+  assert.match(memory, /Step 5's `writtenFiles`.*`memory-bank\.md`/);
+  assert.match(memory, /read-only.*Step 6/);
+  assert.match(shared, /not modified afterward by the skill or its subagents/);
+  assert.match(shared, /Do not suppress a protected-path finding/);
+});

--- a/plugins/mobile-apps/scripts/tests/prepare-mobile-template.test.js
+++ b/plugins/mobile-apps/scripts/tests/prepare-mobile-template.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const assert = require('assert');
+const { spawnSync } = require('node:child_process');
 const fs = require('fs');
 const Module = require('module');
 const os = require('os');
@@ -83,9 +84,12 @@ test('preparation is idempotent and preserves generated and existing helper file
   fs.mkdirSync(path.dirname(existingHelperPath), { recursive: true });
   fs.writeFileSync(generatedPath, '// generated-owner sentinel\n');
   fs.writeFileSync(existingHelperPath, '// existing-helper sentinel\n');
+  fs.mkdirSync(path.join(projectRoot, 'src', 'hooks'), { recursive: true });
+  fs.writeFileSync(path.join(projectRoot, 'src', 'hooks', 'useContacts.ts'), '// legacy example\n');
   fs.writeFileSync(path.join(projectRoot, 'power.config.json'), '{"environmentId":""}\n');
   fs.writeFileSync(path.join(projectRoot, 'native-app-plan.md'), '# Approved plan\n');
 
+  const beforeFirstRun = fileSnapshot(projectRoot);
   const first = prepareMobileTemplate({
     workingDir: projectRoot,
     displayName: "R&D $& Inspector's Workspace",
@@ -93,6 +97,18 @@ test('preparation is idempotent and preserves generated and existing helper file
   });
 
   assert.strictEqual(first.removedPowerConfig, true);
+  const changedFiles = [...fileSnapshot(projectRoot)]
+    .filter(([relativePath, content]) => (
+      !beforeFirstRun.has(relativePath) || !content.equals(beforeFirstRun.get(relativePath))
+    ))
+    .map(([relativePath]) => relativePath.split(path.sep).join('/'))
+    .sort();
+  assert.deepStrictEqual(first.writtenFiles, changedFiles);
+  assert.ok(!first.writtenFiles.includes('power.config.json'));
+  assert.ok(!first.writtenFiles.includes('src/hooks/useContacts.ts'));
+  assert.ok(first.removedLegacyFiles.includes('src/hooks/useContacts.ts'));
+  assert.ok(!first.writtenFiles.includes('src/components/index.tsx'));
+  assert.ok(!first.writtenFiles.includes('src/generated/index.ts'));
   assert.deepStrictEqual(fs.readFileSync(generatedPath, 'utf8'), '// generated-owner sentinel\n');
   assert.deepStrictEqual(fs.readFileSync(existingHelperPath, 'utf8'), '// existing-helper sentinel\n');
   assert.deepStrictEqual(
@@ -129,7 +145,56 @@ test('preparation is idempotent and preserves generated and existing helper file
   });
   const afterSecondRun = fileSnapshot(projectRoot);
   assert.ok(second.preservedSharedFiles.length > 0);
+  assert.deepStrictEqual(second.writtenFiles, []);
   assertSnapshotsEqual(beforeSecondRun, afterSecondRun);
+});
+
+test('scaffold validation uses preparation writes, not later generator output', (t) => {
+  const projectRoot = copyTemplate();
+  t.after(() => fs.rmSync(projectRoot, { recursive: true, force: true }));
+  const configPath = path.join(projectRoot, 'power.config.json');
+  fs.writeFileSync(configPath, '{"environmentId":""}\n');
+  const options = { workingDir: projectRoot, displayName: 'Validation App', slug: 'validation-app' };
+  const prepared = prepareMobileTemplate(options);
+  assert.strictEqual(prepared.removedPowerConfig, true);
+
+  // Simulate init recreating the deleted placeholder and schema generation writing output.
+  const generatedConfig = '{"environmentId":"approved-environment","appDisplayName":"Validation App"}\n';
+  fs.writeFileSync(configPath, generatedConfig);
+  const generatedPath = path.join(projectRoot, 'src', 'generated', 'index.ts');
+  fs.mkdirSync(path.dirname(generatedPath), { recursive: true });
+  fs.writeFileSync(generatedPath, 'export {};\n');
+  const repeated = prepareMobileTemplate(options);
+  assert.strictEqual(repeated.removedPowerConfig, false);
+  assert.deepStrictEqual(repeated.writtenFiles, []);
+  assert.strictEqual(fs.readFileSync(configPath, 'utf8'), generatedConfig);
+  fs.writeFileSync(path.join(projectRoot, 'memory-bank.md'), '# Verified scaffold\n');
+
+  function validate(files) {
+    return spawnSync(process.execPath, [
+      path.join(pluginRoot, 'scripts', 'validate-mobile-files.js'),
+      '--project-root', projectRoot,
+      ...files.flatMap((file) => ['--file', file]),
+    ], {
+      cwd: projectRoot,
+      encoding: 'utf8',
+      env: { ...process.env, POWER_PLATFORM_SKILLS_TELEMETRY_MOBILE_APP_OPTOUT: '1' },
+    });
+  }
+
+  const manualFiles = [...prepared.writtenFiles, 'memory-bank.md'];
+  const valid = validate(manualFiles);
+  assert.strictEqual(valid.status, 0, valid.stderr);
+  for (const file of ['power.config.json', path.relative(projectRoot, generatedPath)]) {
+    const blocked = validate([file]);
+    assert.strictEqual(blocked.status, 2, blocked.stderr);
+    assert.match(blocked.stderr, /BLOCKED: protected path/);
+  }
+
+  fs.writeFileSync(configPath, '{"environmentId":"manual-edit"}\n');
+  const manualEdit = validate(['power.config.json']);
+  assert.strictEqual(manualEdit.status, 2, manualEdit.stderr);
+  assert.match(manualEdit.stderr, /owned by `npx power-apps init`/);
 });
 
 test('preparation round-trips JavaScript line terminators in app display names', () => {

--- a/plugins/mobile-apps/scripts/tests/validate-mobile-files-all-source.test.js
+++ b/plugins/mobile-apps/scripts/tests/validate-mobile-files-all-source.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const assert = require('assert');
+const { spawnSync } = require('node:child_process');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
@@ -11,6 +12,35 @@ const {
   main,
   parseArgs,
 } = require('../validate-mobile-files');
+
+test('protected paths remain blocked with POSIX and Windows path separators', () => {
+  for (const filePath of [
+    '/project/power.config.json',
+    'C:\\project\\power.config.json',
+    '/project/src/generated/services/ItemsService.ts',
+    'C:\\project\\src\\generated\\services\\ItemsService.ts',
+    '/project/vendor/package.tgz',
+    'C:\\project\\vendor\\package.tgz',
+  ]) {
+    const result = spawnSync(process.execPath, [
+      path.resolve(__dirname, '../../hooks/validate-protected-paths.js'),
+    ], {
+      encoding: 'utf8',
+      input: JSON.stringify({ tool_name: 'Write', tool_input: { file_path: filePath } }),
+    });
+    assert.strictEqual(result.status, 2, `${filePath}: ${result.stderr}`);
+    assert.match(result.stderr, /BLOCKED: protected path/);
+  }
+  for (const filePath of ['/project/src/items.ts', 'C:\\project\\src\\items.ts']) {
+    const result = spawnSync(process.execPath, [
+      path.resolve(__dirname, '../../hooks/validate-protected-paths.js'),
+    ], {
+      encoding: 'utf8',
+      input: JSON.stringify({ tool_name: 'Write', tool_input: { file_path: filePath } }),
+    });
+    assert.strictEqual(result.status, 0, result.stderr);
+  }
+});
 
 test('all-source flag is explicit and does not require individual files', () => {
   const parsed = parseArgs(['--project-root', '/tmp/project', '--all-source']);

--- a/plugins/mobile-apps/shared/shared-instructions.md
+++ b/plugins/mobile-apps/shared/shared-instructions.md
@@ -107,8 +107,8 @@ All non-Dataverse connectors require a connection ID or connection reference bef
 
 Plugin-level hooks also run during unrelated plugin workflows, so every mutating mobile skill owns its validation:
 
-1. Track every file written by the skill or its subagents. Exclude untouched output from trusted generators such as `npx power-apps init` and `npx power-apps add-data-source`.
-2. Before returning success, pass each changed file explicitly:
+1. Track changed files by writer: the skill/subagents and preparation helpers versus trusted generators. Use a helper's returned `writtenFiles` when available; track removals separately, not as files to validate. Output from `npx power-apps init` or `npx power-apps add-data-source` is excluded only when produced by that command and not modified afterward by the skill or its subagents. Newly generated does not mean manually written.
+2. Before returning success, pass each existing skill/helper-owned changed file explicitly:
 
    ```bash
    node "${PLUGIN_ROOT}/scripts/validate-mobile-files.js" \
@@ -118,6 +118,14 @@ Plugin-level hooks also run during unrelated plugin workflows, so every mutating
    ```
 
 3. On exit `2`, repair every finding and rerun. Exit `0` is required before `DONE`.
+
+`--file` runs write-safety checks, not a read-only audit of generator output. For CLI-owned
+`power.config.json` and `src/generated/`, perform the owning phase's read-only identity,
+schema/service and TypeScript checks instead. Do not suppress a protected-path finding
+by excluding a file that was manually edited; stop and recover through its owning command
+under the existing approval/resume rules. Never infer ownership from the path alone or a
+whole-worktree diff. If the manual target list is empty, record that fact; do not invoke
+the validator with no files or add generated files to make a nonempty list.
 
 Never pass a directory or the whole project. Files with common text extensions (see `scripts/lib/mobile-validator-manifest.js`) receive content-based checks; other files receive path-safety-only checks. This gate remains required after a successful typecheck.
 ### MUST (required before acting)

--- a/plugins/mobile-apps/skills/create-mobile-app/SKILL.md
+++ b/plugins/mobile-apps/skills/create-mobile-app/SKILL.md
@@ -919,6 +919,13 @@ process.stdout.write(`${JSON.stringify(result)}\n`);
 NODE
 ```
 
+Capture `result.writtenFiles` as the exact project-relative preparation validation targets.
+This list contains only files created or changed by this preparation call, excluding unchanged
+preserved files and deletions. Keep `removedPowerConfig` and `removedLegacyFiles` as removal
+outcomes, not `--file` targets: Step 6 can recreate the same config path with a different owner.
+Union targets across any preparation reruns rather than replacing earlier pending changes.
+Do not rebuild this list from `git status` or a directory scan after initialization.
+
 The script is the only owner of Step 5 mutations. It updates identity, removes
 only recognized legacy example hooks/query-client files, copies shared helpers
 only when missing, verifies that TypeScript inherits the host configuration,
@@ -1050,6 +1057,8 @@ environment instead of overwriting it or running `init` again.
 Verify `power.config.json` exists and both its `environmentId` and
 `appDisplayName` match the approved Step 2/Step 4 values. If initialization
 fails, report the exact error and STOP.
+Record the successful CLI command as the config's writer. These checks are read-only;
+do not add this CLI-generated file to Step 5's manual validation targets or hand-edit it.
 
 ### Step 6.5 — Verify dependencies
 
@@ -1095,6 +1104,12 @@ cp "${PLUGIN_ROOT}/shared/memory-bank.md" "<working_dir>/memory-bank.md"
 ```
 
 Fill in the Project facts and Power Platform context sections from Steps 2 and 4. From here on, every step appends to the relevant section of `<working_dir>/memory-bank.md` immediately after success — not at the end. This is what enables Step 0's resume on a future run.
+
+Before leaving this step, run the shared changed-file gate on Step 5's `writtenFiles`, `memory-bank.md`,
+and any other pending skill/subagent-authored files or scaffold repairs, using an exact `--file`
+argument for each. Exclude files verified as CLI-generated and not manually modified afterward;
+`power.config.json` is covered by the read-only identity checks in Step 6, not this write gate.
+The successful TypeScript check does not replace either validation.
 
 Immediately after creating `memory-bank.md`, flush any queued planner concerns from `DEFERRED_CONCERNS[]` into `## Concerns` (append-only). This flush is unconditional: if the queue is non-empty, write it now before continuing to Step 6.75.
 


### PR DESCRIPTION
## What was the issue?

During app creation, the scaffold TypeScript check passed and the workflow seeded the memory bank. It then included `power.config.json`, created by `npx power-apps init`, in the manual changed-file validation command.

`validate-mobile-files.js --file ...` treats each supplied file as a write by the agent. The protected-path guard therefore correctly rejected the CLI-owned configuration. The workflow had to remove that file from the target list and retry.

**The bug is incorrect validation-target ownership, not a TypeScript failure or a reason to relax the protected-file guard.**

## Why could this happen on main?

- The shared instructions already said to exclude untouched trusted-generator output, but the scaffold did not provide an exact preparation-owned changed-file list.
- Preparation returned copied/preserved helper lists and removal outcomes, leaving the foreground to assemble the full validation target list.
- There is also a delete/recreate boundary: preparation can remove an empty `power.config.json` placeholder, then `init` creates a new file at the same path. A path appearing in the workflow or worktree diff does not identify who wrote its current contents.

This ambiguity causes avoidable validation failures. Simply excluding every protected filename would be unsafe because that could conceal an actual manual edit.

## What changes in this PR?

1. **Return exact preparation targets.** `prepareMobileTemplate` now returns sorted, project-relative `writtenFiles`, derived from its existing before/after snapshots. The list includes created or content-changed files, not unchanged files or deletions. Idempotent reruns return an empty list.
2. **Use the right targets at the scaffold gate.** The creation skill retains these targets across preparation reruns and validates them together with the memory bank and other pending authored changes. Removal outcomes remain separate; the target list must not be rebuilt from a directory scan or `git status` after initialization.
3. **Verify generator output separately.** Initialization still checks the generated configuration against the approved environment and app display name. Generated schema/service and TypeScript checks remain required in their owning phases.
4. **Keep manual edits blocked.** Generator output is excluded only when its command provenance is known and it has not been manually modified afterward. A real manual edit to a protected file must be surfaced and recovered through its owning command under the existing approval rules, not hidden by exclusion.
5. **Handle Windows paths consistently.** The new protection regression exposed an existing separator bug: backslash paths did not match the protected-path expressions. The guard now normalizes separators before matching, retaining protection on both path styles.

Both mobile plugin manifests move to `0.3.1`. No app-template, dependency, hook-registration, or UX-redesign changes are included.

## Before and after

| Case | Before | After |
| --- | --- | --- |
| CLI generates configuration after preparation | Foreground can accidentally include it in the manual-write gate, producing a protected-path rejection and retry | Exact preparation targets remain separate; CLI configuration receives read-only identity verification |
| Agent manually changes a protected file | Must be rejected, not silently excluded | Still rejected; guidance explicitly forbids excluding it to hide the violation |
| Preparation removes a placeholder or runs again without content changes | Removal/preserved-file lists do not fully identify the write-validation targets | Deletions are separate and a no-change rerun returns an empty `writtenFiles` list |
| Protected path uses Windows separators | Backslash paths could be accepted | Protected paths are rejected consistently |

## How was it validated?

- **31 targeted tests passed on Node 20.20.2 and Node 22.23.2**, with no skips.
- Executable regression uses actual template preparation and the validation dispatcher, with simulated CLI-generated configuration/schema files: the correct authored-file list passes, while explicitly supplied protected paths and a manual configuration edit remain blocked.
- Coverage includes exact changed-file tracking, preserved helpers/configuration, deleted placeholders/legacy files, idempotent reruns, and POSIX/Windows protected and ordinary paths.
- Plugin names, metadata mirrors, skill descriptions, keyword case, secure process execution, and `git diff --check` passed.
- Tests simulate the CLI output boundary; this PR does not claim a live Dataverse run, Windows-host execution, or a full agent-driven app-generation test.