### PR TITLE
model-apps 2.7.1: authored page keys, in-tag comments, value-less view operators, a lint CLI, and the session-start hook warning

### DIFF
--- a/.github/workflows/validate-repository-metadata.yml
+++ b/.github/workflows/validate-repository-metadata.yml
@@ -32,6 +32,15 @@ jobs:
             - name: validate-telemetry-ikeys
               run: node scripts/validate-telemetry-ikeys.js
 
+            # A hooks.json key the host does not recognise fails nothing — it just
+            # prints "unknown key ... ignored" in every user's terminal at every
+            # session start, so no test and no reviewer catches it.
+            - name: test-hooks-manifests-validator
+              run: node --test scripts/tests/validate-hooks-manifests.test.js
+
+            - name: validate-hooks-manifests
+              run: node scripts/validate-hooks-manifests.js
+
             - name: test-secure-process-execution-validator
               run: node --test scripts/tests/validate-secure-process-execution.test.js
 

--- a/plugins/mobile-apps/.claude-plugin/plugin.json
+++ b/plugins/mobile-apps/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "mobile-app",
-    "version": "0.3.1",
+    "version": "0.3.2",
     "description": "Build and deploy Power Apps code apps for mobile using Expo (React Native), with native device functionality and Power Platform connectors",
     "author": {
         "name": "Microsoft",

--- a/plugins/mobile-apps/.plugin/plugin.json
+++ b/plugins/mobile-apps/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "mobile-app",
-    "version": "0.3.1",
+    "version": "0.3.2",
     "description": "Build and deploy Power Apps code apps for mobile using Expo (React Native), with native device functionality and Power Platform connectors",
     "author": {
         "name": "Microsoft",

--- a/plugins/mobile-apps/hooks/README.md
+++ b/plugins/mobile-apps/hooks/README.md
@@ -1,0 +1,15 @@
+# mobile-apps hooks
+
+What `hooks.json` wires up, and why.
+
+Telemetry-only start hooks. They never validate, mutate, or block tool calls. File validation stays
+owned by each workflow through `scripts/validate-mobile-files.js`.
+
+This prose lived in a `_comment` key inside `hooks.json` itself. Claude Code validates that file
+against a closed schema and prints `mobile-apps: hooks.json: unknown key "_comment" ignored` at
+**every session start**, which reads as a plugin misconfiguration to the user (#555, #558). The
+documentation belongs here instead; `scripts/validate-hooks-manifests.js` keeps it from drifting
+back.
+
+Telemetry is fail-closed and honours the `POWER_PLATFORM_SKILLS_TELEMETRY_MOBILE_APP_OPTOUT`
+environment variable, which disables transmission for automation and CI.

--- a/plugins/mobile-apps/hooks/hooks.json
+++ b/plugins/mobile-apps/hooks/hooks.json
@@ -1,5 +1,4 @@
 {
-  "_comment": "Telemetry-only start hooks. They never validate, mutate, or block tool calls. File validation stays owned by each workflow through scripts/validate-mobile-files.js.",
   "hooks": {
     "PreToolUse": [
       {

--- a/plugins/model-apps/.claude-plugin/plugin.json
+++ b/plugins/model-apps/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "model-apps",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "Build model-driven Power Apps end to end: /app-builder authors whole apps (tables, relationships, forms, views, charts, security roles, app + sitemap) from a natural-language intent, and /genpage builds generative pages with specialist agents for planning, entity creation, and parallel code generation. Requires PAC CLI > 2.10.0 and Azure CLI (`az`). See CHANGELOG.md for v1.x -> v2.x migration.",
   "author": {
     "name": "Microsoft",

--- a/plugins/model-apps/.plugin/plugin.json
+++ b/plugins/model-apps/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "model-apps",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "Build model-driven Power Apps end to end: /app-builder authors whole apps (tables, relationships, forms, views, charts, security roles, app + sitemap) from a natural-language intent, and /genpage builds generative pages with specialist agents for planning, entity creation, and parallel code generation. Requires PAC CLI > 2.10.0 and Azure CLI (`az`). See CHANGELOG.md for v1.x -> v2.x migration.",
   "author": {
     "name": "Microsoft",

--- a/plugins/model-apps/AGENTS.md
+++ b/plugins/model-apps/AGENTS.md
@@ -99,6 +99,14 @@ the pipeline and delegates each script's **behavioral spec** to the entries belo
 - **`scripts/lib/spec-lint.js`** — pure App Spec guardrail (`lintAppSpec → { ok, errors,
   warnings }`): errors block the plan gate (e.g. the relationship-name-vs-lookup-name
   collision Dataverse rejects), warnings teach.
+- **`scripts/lint-app-spec.js`** — the CLI surface for both gates, for a headless author or a CI
+  job (#560). Runs the same three steps every deploying CLI runs on load — `migrateAppSpec` →
+  `validateAppSpec` → `lintAppSpec` — and exits non-zero on errors (`--strict` also fails on
+  warnings). Prefer it over calling the library through `node -e`: linting the file **as written**
+  rather than the migrated shape is what let a spec pass the lint and then fail the build (#545).
+  `--profile` defaults to **`plan`**, not `deploy`, because the authoring flow runs this while pages
+  are still intents and jobs still lack privileges — a deploy default rejects a normal
+  work-in-progress spec. Gate a final, deployable spec with `--profile deploy`.
 - **`scripts/build-model-app.js` → `scripts/lib/sdk-build.js`** — the deterministic, **idempotent**
   build engine, run after approval. Runs in two engine invocations (staged flow): (1) `--stage data
   --apply` materializes tables + columns + relationships (solution·data-model only; sample-data

--- a/plugins/model-apps/AGENTS.md
+++ b/plugins/model-apps/AGENTS.md
@@ -100,13 +100,13 @@ the pipeline and delegates each script's **behavioral spec** to the entries belo
   warnings }`): errors block the plan gate (e.g. the relationship-name-vs-lookup-name
   collision Dataverse rejects), warnings teach.
 - **`scripts/lint-app-spec.js`** — the CLI surface for both gates, for a headless author or a CI
-  job (#560). Runs the same three steps every deploying CLI runs on load — `migrateAppSpec` →
-  `validateAppSpec` → `lintAppSpec` — and exits non-zero on errors (`--strict` also fails on
+  job (#560). Runs `migrateAppSpec` → `validateAppSpec` (what the build runs on load) → `lintAppSpec`
+  (guardrails the builder does **not** run), and exits non-zero on errors (`--strict` also fails on
   warnings). Prefer it over calling the library through `node -e`: linting the file **as written**
   rather than the migrated shape is what let a spec pass the lint and then fail the build (#545).
   `--profile` defaults to **`plan`**, not `deploy`, because the authoring flow runs this while pages
-  are still intents and jobs still lack privileges — a deploy default rejects a normal
-  work-in-progress spec. Gate a final, deployable spec with `--profile deploy`.
+  are still intents — a deploy default rejects a normal work-in-progress spec. `plan` relaxes only
+  that rule. Gate a final, deployable spec with `--profile deploy`.
 - **`scripts/build-model-app.js` → `scripts/lib/sdk-build.js`** — the deterministic, **idempotent**
   build engine, run after approval. Runs in two engine invocations (staged flow): (1) `--stage data
   --apply` materializes tables + columns + relationships (solution·data-model only; sample-data

--- a/plugins/model-apps/CHANGELOG.md
+++ b/plugins/model-apps/CHANGELOG.md
@@ -5,7 +5,47 @@ All notable changes to the **model-apps** plugin.
 Entries are deliberately short: what changed and why it matters to you. The reasoning,
 evidence and trade-offs behind a change live in its PR, in `docs/`, or in the linked issue.
 
-## [Unreleased] — 2.7.0
+## [Unreleased] — 2.7.1
+
+Three defects an author hits before reaching an environment, and a session-start warning.
+
+### Added
+
+- **`scripts/lint-app-spec.js` — lint and validate a spec without touching an environment** ([#560]).
+  `validateAppSpec` (the gate `--apply` enforces) and `lintAppSpec` (the authoring guardrails) were
+  library exports with no entry point, so a headless author or a CI job had to reach in with
+  `node -e`. The CLI runs the same three steps every deploying CLI runs on load — migrate →
+  validate → lint — tags each finding `schema:` or `lint:`, and exits non-zero on errors.
+  `--profile` defaults to `plan` (pages may still be intents, jobs may still lack privileges), so
+  gate a final, deployable spec with `--profile deploy`. `--strict` also fails on warnings;
+  `--json` emits the report.
+
+### Fixed
+
+- **A spec that declares `schemaVersion` per page but not at the top level no longer breaks every
+  page reference** ([#545]). Migration mints a stable key per page, and it did so *unconditionally* —
+  overwriting hand-authored keys with a slug of the page name. The references hold keys, not names,
+  so nothing rewrote them and validation reported one "not a known page key" / "unknown page" error
+  per page, none of which named the cause. Authored keys now survive migration; a key is minted only
+  for a page that has none, and every authored key is reserved first so a minted one cannot steal it.
+- **`eq-businessid` / `ne-businessid` are accepted in a view filter** ([#546]). Both are value-less
+  FetchXML operators — the business-unit equivalents of `eq-userid` / `ne-userid` — and the lint
+  demanded a value they must not carry. The operator list is now the documented value-less set,
+  which also adds `eq-userlanguage`, the user-hierarchy operators, and the relative fiscal-period
+  ones.
+- **No more `hooks.json: unknown key "_comment" ignored` at every session start** ([#555], [#558],
+  affects `model-apps` and `mobile-apps`). The hooks manifest is validated against a closed schema,
+  so the documentation key it carried was reported as a misconfiguration on every launch. The prose
+  moved to `hooks/README.md`, and a repo-wide CI check now fails any manifest with an unrecognised
+  top-level key — the symptom is otherwise invisible to both tests and review.
+
+[#545]: https://github.com/microsoft/power-platform-skills/issues/545
+[#546]: https://github.com/microsoft/power-platform-skills/issues/546
+[#555]: https://github.com/microsoft/power-platform-skills/issues/555
+[#558]: https://github.com/microsoft/power-platform-skills/issues/558
+[#560]: https://github.com/microsoft/power-platform-skills/issues/560
+
+## [2.7.0]
 
 Multi-language Dataverse labels, granting access on roles this spec does not own, and the
 app-builder defects found while rebuilding a real app into a second environment.

--- a/plugins/model-apps/CHANGELOG.md
+++ b/plugins/model-apps/CHANGELOG.md
@@ -28,6 +28,13 @@ Three defects an author hits before reaching an environment, and a session-start
   so nothing rewrote them and validation reported one "not a known page key" / "unknown page" error
   per page, none of which named the cause. Authored keys now survive migration; a key is minted only
   for a page that has none, and every authored key is reserved first so a minted one cannot steal it.
+- **A `//` or `/* */` comment inside a JSX opening tag no longer makes a valid page look truncated**
+  ([#542]). `jsxTag` mode had no comment handling, so an apostrophe in the comment prose was read as
+  an attribute-value quote — and that scanner does not stop at a newline, because a JSX attribute
+  value legitimately may span lines. It ran to end of file, blanking the real `export default` and
+  miscounting every bracket after it, so `promote-intent-pages` rejected a complete page as
+  truncated. Promotion is transactional, so one such page blocked the whole batch. Block comments
+  had the same defect, which the report did not cover.
 - **`eq-businessid` / `ne-businessid` are accepted in a view filter** ([#546]). Both are value-less
   FetchXML operators — the business-unit equivalents of `eq-userid` / `ne-userid` — and the lint
   demanded a value they must not carry. The operator list is now the documented value-less set,
@@ -39,6 +46,7 @@ Three defects an author hits before reaching an environment, and a session-start
   moved to `hooks/README.md`, and a repo-wide CI check now fails any manifest with an unrecognised
   top-level key — the symptom is otherwise invisible to both tests and review.
 
+[#542]: https://github.com/microsoft/power-platform-skills/issues/542
 [#545]: https://github.com/microsoft/power-platform-skills/issues/545
 [#546]: https://github.com/microsoft/power-platform-skills/issues/546
 [#555]: https://github.com/microsoft/power-platform-skills/issues/555

--- a/plugins/model-apps/CHANGELOG.md
+++ b/plugins/model-apps/CHANGELOG.md
@@ -14,11 +14,10 @@ Three defects an author hits before reaching an environment, and a session-start
 - **`scripts/lint-app-spec.js` — lint and validate a spec without touching an environment** ([#560]).
   `validateAppSpec` (the gate `--apply` enforces) and `lintAppSpec` (the authoring guardrails) were
   library exports with no entry point, so a headless author or a CI job had to reach in with
-  `node -e`. The CLI runs the same three steps every deploying CLI runs on load — migrate →
-  validate → lint — tags each finding `schema:` or `lint:`, and exits non-zero on errors.
-  `--profile` defaults to `plan` (pages may still be intents, jobs may still lack privileges), so
-  gate a final, deployable spec with `--profile deploy`. `--strict` also fails on warnings;
-  `--json` emits the report.
+  `node -e`. The CLI runs migrate → validate → lint, tags each finding `schema:` or `lint:`, and
+  exits non-zero on errors. `--profile` defaults to `plan` (pages may still be intents), so gate a
+  final, deployable spec with `--profile deploy`. `--strict` also fails on warnings; `--json`
+  emits the report.
 
 ### Fixed
 

--- a/plugins/model-apps/hooks/README.md
+++ b/plugins/model-apps/hooks/README.md
@@ -1,0 +1,35 @@
+# model-apps hooks
+
+What `hooks.json` wires up, and why.
+
+This prose lived in a `_comment` key inside `hooks.json` itself. Claude Code validates that file
+against a closed schema and prints `model-apps: hooks.json: unknown key "_comment" ignored` at
+**every session start**, which reads as a plugin misconfiguration to the user (#555, #558). The
+documentation belongs here instead; `scripts/validate-hooks-manifests.js` keeps it from drifting
+back.
+
+## PreToolUse
+
+| Matcher | Hook | Behaviour |
+| --- | --- | --- |
+| `Write\|Edit\|MultiEdit` | `validate-write-safety.js` | **Flags** (non-blocking, exit 1) a write outside the cwd, and only during an active model-apps authoring session — that is, when a `genpage-plan.md`, `app-spec.json`, or `model-app-plan.md` marker exists at or under the cwd, which covers both `/genpage` and `/app-builder`. |
+| `Skill\|skill` | `run-skill-pretool-telemetry.js` | Emits the `skill_started` usage event. Ships disabled until an instrumentation key is provisioned. |
+
+## PostToolUse
+
+| Matcher | Hook | Behaviour |
+| --- | --- | --- |
+| `Skill\|skill` | `run-skill-posttool-validation.js` | Runs the invoked skill's own `scripts/validate*.js`, if it has one. |
+| `Write\|Edit\|MultiEdit` | `validate-icon-imports.js` | On every code write, validates `@fluentui/react-icons` imports against `references/verified-icons.txt`. |
+
+## UserPromptSubmit
+
+`run-user-prompt-telemetry.js` emits `skill_started` for `/model-apps:<skill>` slash commands.
+Tracked skills are derived from `skills/*/SKILL.md`, so a new skill is picked up automatically.
+
+## Notes
+
+- All telemetry is fail-closed and default-off in `ikey.json`; a missing executable, a timeout, or an
+  unparseable response resolves to "no event" rather than throwing into the hook it runs inside.
+- Run the host from the target project folder, or pass that folder as the cwd — the write-safety
+  session markers are resolved relative to it.

--- a/plugins/model-apps/hooks/hooks.json
+++ b/plugins/model-apps/hooks/hooks.json
@@ -1,5 +1,4 @@
 {
-  "_comment": "PreToolUse: write-safety FLAGS (non-blocking, exit 1) Write/Edit/MultiEdit outside the cwd only during an active model-apps authoring session (a genpage-plan.md, app-spec.json, or model-app-plan.md marker at/under cwd — covering both /genpage and /app-builder); skill-pretool-telemetry emits skill_started usage telemetry (ships disabled until provisioned). PostToolUse: per-skill validator + on every code write validate @fluentui/react-icons imports against references/verified-icons.txt. UserPromptSubmit: emit skill_started for /model-apps:<skill> slash commands. Tracked skills are derived from skills/*/SKILL.md, so a new skill is picked up automatically. All telemetry is fail-closed and default-off in ikey.json. Run the host from the target project folder (or pass it as cwd).",
   "hooks": {
     "PreToolUse": [
       {

--- a/plugins/model-apps/references/authoring-flow.md
+++ b/plugins/model-apps/references/authoring-flow.md
@@ -633,11 +633,12 @@ node "${PLUGIN_ROOT}/scripts/lint-app-spec.js" --spec @<abs-path-to-app-spec.jso
 
 Replace `<abs-path-to-app-spec.json>` with the actual absolute path to
 `<working-dir>/app-spec.json`. Pass an absolute path so it resolves regardless of cwd.
-The CLI runs the same three steps a deploying CLI runs on load — migrate → `validateAppSpec`
-→ `lintAppSpec` — and exits non-zero on errors. It validates under the `plan` profile, which
-allows pages that are still intents (they are generated in Phase 1.5, after this gate). Errors
-are tagged `schema:` (the hard gate) or `lint:` (authoring guardrails); fix the `schema:` ones
-first, because lint advice on a spec that fails the gate is advice on a spec that cannot build.
+The CLI runs migration and `validateAppSpec` — the gates the build itself runs on load — plus
+the `lintAppSpec` authoring guardrails, which the builder does **not** run. It exits non-zero on
+errors. It validates under the `plan` profile, which allows pages that are still intents (they
+are generated in Phase 1.5, after this gate); `plan` relaxes only that rule. Errors are tagged
+`schema:` (the hard gate) or `lint:` (authoring guardrails); fix the `schema:` ones first,
+because lint advice on a spec that fails the gate is advice on a spec that cannot build.
 
 **Interpret the result:**
 

--- a/plugins/model-apps/references/authoring-flow.md
+++ b/plugins/model-apps/references/authoring-flow.md
@@ -387,7 +387,7 @@ relationship-name-vs-lookup-name collision Dataverse rejects) **before** the use
 on top of a broken model, the most expensive point to unwind:
 
 ```bash
-node -e "const{lintAppSpec}=require('${PLUGIN_ROOT}/scripts/lib/spec-lint.js');const s=require('<abs-path-to-app-spec.json>');const r=lintAppSpec(s);console.log(JSON.stringify(r,null,2));"
+node "${PLUGIN_ROOT}/scripts/lint-app-spec.js" --spec @<abs-path-to-app-spec.json> --json
 ```
 
 On a data-model-only spec the linter surfaces **only** data-model findings (the forms/views/app checks
@@ -628,12 +628,16 @@ spec — the data model was already gated by the early lint at the end of Level 
 validating the artifacts/sample-data/app layered on top):
 
 ```bash
-node -e "const{lintAppSpec}=require('${PLUGIN_ROOT}/scripts/lib/spec-lint.js');const s=require('<abs-path-to-app-spec.json>');const r=lintAppSpec(s);console.log(JSON.stringify(r,null,2));"
+node "${PLUGIN_ROOT}/scripts/lint-app-spec.js" --spec @<abs-path-to-app-spec.json> --json
 ```
 
 Replace `<abs-path-to-app-spec.json>` with the actual absolute path to
-`<working-dir>/app-spec.json`. Use `require()` with an absolute path so Node
-resolves it regardless of cwd.
+`<working-dir>/app-spec.json`. Pass an absolute path so it resolves regardless of cwd.
+The CLI runs the same three steps a deploying CLI runs on load — migrate → `validateAppSpec`
+→ `lintAppSpec` — and exits non-zero on errors. It validates under the `plan` profile, which
+allows pages that are still intents (they are generated in Phase 1.5, after this gate). Errors
+are tagged `schema:` (the hard gate) or `lint:` (authoring guardrails); fix the `schema:` ones
+first, because lint advice on a spec that fails the gate is advice on a spec that cannot build.
 
 **Interpret the result:**
 

--- a/plugins/model-apps/scripts/lib/app-spec.js
+++ b/plugins/model-apps/scripts/lib/app-spec.js
@@ -2777,7 +2777,12 @@ function migrateAppSpec(spec) {
   // defensively — but do NOT rewrite the value, or validateAppSpec would see a repaired spec and
   // report nothing. The shape error stays for the gate to find.
   const arr = (v) => (Array.isArray(v) ? v : []);
-  const authoredKey = (p) => (typeof p.key === 'string' && p.key.trim() ? p.key : '');
+  // A key the author actually wrote AND that is usable as an identifier. A present-but-malformed
+  // `key` (42, null, "", "   ") is deliberately NOT usable: it is neither reserved nor used to
+  // resolve a reference, but it is still preserved on the page (see pass 1) so validateAppSpec
+  // reports the author's real mistake instead of this pass papering over it.
+  const usableKey = (p) => (typeof p.key === 'string' && p.key.trim() ? p.key : '');
+  const authoredKeys = new Set();
   // Pass 0: RESERVE every hand-authored key before minting anything.
   //
   // A spec can declare `schemaVersion: 2` on each PAGE — with hand-authored stable keys and
@@ -2789,40 +2794,51 @@ function migrateAppSpec(spec) {
   // earlier page from stealing a key that a later page authored. See #545.
   for (const p of arr(out.pages)) {
     if (!p || typeof p !== 'object') continue;
-    const k = authoredKey(p);
-    if (k) used.add(k);
+    const k = usableKey(p);
+    if (k) { used.add(k); authoredKeys.add(k); }
   }
   // Pass 1: mint keys for KEYLESS pages only, and wrap legacy codeFile→source. nameToKey is fully
   // populated after this loop so the rewrite pass below needs only a single scan (no forward-ref gaps).
   for (const p of arr(out.pages)) {
     if (!p || typeof p !== 'object') continue;
     // An authored key is kept verbatim — including a malformed one. validateAppSpec then reports it
-    // by name ("key 'X' has an invalid key grammar"), which the author can act on; replacing it with
-    // a slug here would resurrect the dangling-reference failure above with no message at all.
-    let key = authoredKey(p);
+    // by name ("key 'X' has an invalid key grammar", or "needs a stable key" for a non-string),
+    // which the author can act on; replacing it with a slug here would either resurrect the
+    // dangling-reference failure above or silently repair a typo the author needs to see. A key is
+    // minted ONLY when the page carries no `key` property at all.
+    let key = usableKey(p);
     if (!key) {
-      key = slugify(p.name);
-      let n = 1;
-      while (used.has(key)) { n += 1; key = `${slugify(p.name)}-${n}`; }
-      used.add(key);
+      const declared = Object.prototype.hasOwnProperty.call(p, 'key') && p.key !== undefined;
+      if (declared) {
+        key = p.key; // present but malformed — hand it to validation unchanged
+      } else {
+        key = slugify(p.name);
+        let n = 1;
+        while (used.has(key)) { n += 1; key = `${slugify(p.name)}-${n}`; }
+        used.add(key);
+      }
     }
     p.key = key;
-    nameToKey.set(p.name, key);
+    // Only a usable key can stand in for this page in a reference. Registering a malformed one
+    // would rewrite a legacy name-ref to `42` or `""` and bury the real error under a second one.
+    if (typeof key === 'string' && key.trim()) nameToKey.set(p.name, key);
     if (!p.source && typeof p.codeFile === 'string') { p.source = { kind: 'tsx', codeFile: p.codeFile }; delete p.codeFile; }
   }
   // Pass 2: rewrite name-refs to keys exactly once. Because nameToKey is complete, forward refs
   // (a page referencing a later-declared page) resolve correctly without a repeated second pass.
   //
-  // An exact KEY match wins over a name match. Once authored keys survive migration (pass 0), a
-  // reference can legitimately already BE a key — and a spec may contain a page whose authored key
-  // equals a DIFFERENT page's name (key 'orders' on "All Orders", plus a page actually named
-  // "orders"). Rewriting unconditionally would silently retarget that reference to the other page
-  // and still validate, because the substituted value is itself a valid key. Resolving key-first
-  // makes the author's own identifier authoritative; a name-ref, which only legacy specs use, is
-  // still rewritten because it cannot collide with a key it does not match.
-  // `used` now holds every FINAL page key — authored ones reserved in pass 0, minted ones added in
-  // pass 1 — so it is the authoritative "is this string a page key?" test for the rewrite below.
-  const rewrite = (ref) => (used.has(ref) ? ref : (nameToKey.has(ref) ? nameToKey.get(ref) : ref));
+  // An exact AUTHORED-key match wins over a name match. Once authored keys survive migration
+  // (pass 0), a reference can legitimately already BE a key — and a spec may contain a page whose
+  // authored key equals a DIFFERENT page's name (key 'orders' on "All Orders", plus a page actually
+  // named "orders"). Rewriting unconditionally would silently retarget that reference to the other
+  // page and still validate, because the substituted value is itself a valid key.
+  //
+  // The test is `authoredKeys`, NOT every final key: a MINTED key is derived from a name, so it can
+  // collide with a different page's name by construction (pages "All Orders" and "all-orders" mint
+  // 'all-orders' and 'all-orders-2'). Treating a minted key as authoritative would leave a legacy
+  // name-ref to the second page pointing at the first. A legacy spec has no authored keys at all,
+  // so it keeps exactly its previous name-first behaviour.
+  const rewrite = (ref) => (authoredKeys.has(ref) ? ref : (nameToKey.has(ref) ? nameToKey.get(ref) : ref));
   for (const p of arr(out.pages)) {
     if (!p || typeof p !== 'object') continue;
     for (const nav of arr(p.navigatesTo)) { if (nav && typeof nav.targetKey === 'string') nav.targetKey = rewrite(nav.targetKey); }

--- a/plugins/model-apps/scripts/lib/app-spec.js
+++ b/plugins/model-apps/scripts/lib/app-spec.js
@@ -2777,29 +2777,61 @@ function migrateAppSpec(spec) {
   // defensively — but do NOT rewrite the value, or validateAppSpec would see a repaired spec and
   // report nothing. The shape error stays for the gate to find.
   const arr = (v) => (Array.isArray(v) ? v : []);
-  // Pass 1: mint every key and wrap legacy codeFile→source. nameToKey is fully populated
-  // after this loop so the rewrite pass below needs only a single scan (no forward-ref gaps).
+  const authoredKey = (p) => (typeof p.key === 'string' && p.key.trim() ? p.key : '');
+  // Pass 0: RESERVE every hand-authored key before minting anything.
+  //
+  // A spec can declare `schemaVersion: 2` on each PAGE — with hand-authored stable keys and
+  // key-based `navigatesTo`/appShell refs — while omitting the TOP-LEVEL `schemaVersion`, which is
+  // precisely what routes it here. Minting `slugify(name)` over an authored key silently re-keys
+  // the page, and because the refs hold KEYS (not names) pass 2 never rewrites them, so every
+  // reference dangles and validation reports one "not a known page key" / "unknown page" error per
+  // page — none of them naming the real cause. Reserving first also stops a key minted for an
+  // earlier page from stealing a key that a later page authored. See #545.
   for (const p of arr(out.pages)) {
     if (!p || typeof p !== 'object') continue;
-    let key = slugify(p.name);
-    let n = 1;
-    while (used.has(key)) { n += 1; key = `${slugify(p.name)}-${n}`; }
-    used.add(key);
+    const k = authoredKey(p);
+    if (k) used.add(k);
+  }
+  // Pass 1: mint keys for KEYLESS pages only, and wrap legacy codeFile→source. nameToKey is fully
+  // populated after this loop so the rewrite pass below needs only a single scan (no forward-ref gaps).
+  for (const p of arr(out.pages)) {
+    if (!p || typeof p !== 'object') continue;
+    // An authored key is kept verbatim — including a malformed one. validateAppSpec then reports it
+    // by name ("key 'X' has an invalid key grammar"), which the author can act on; replacing it with
+    // a slug here would resurrect the dangling-reference failure above with no message at all.
+    let key = authoredKey(p);
+    if (!key) {
+      key = slugify(p.name);
+      let n = 1;
+      while (used.has(key)) { n += 1; key = `${slugify(p.name)}-${n}`; }
+      used.add(key);
+    }
     p.key = key;
     nameToKey.set(p.name, key);
     if (!p.source && typeof p.codeFile === 'string') { p.source = { kind: 'tsx', codeFile: p.codeFile }; delete p.codeFile; }
   }
   // Pass 2: rewrite name-refs to keys exactly once. Because nameToKey is complete, forward refs
   // (a page referencing a later-declared page) resolve correctly without a repeated second pass.
+  //
+  // An exact KEY match wins over a name match. Once authored keys survive migration (pass 0), a
+  // reference can legitimately already BE a key — and a spec may contain a page whose authored key
+  // equals a DIFFERENT page's name (key 'orders' on "All Orders", plus a page actually named
+  // "orders"). Rewriting unconditionally would silently retarget that reference to the other page
+  // and still validate, because the substituted value is itself a valid key. Resolving key-first
+  // makes the author's own identifier authoritative; a name-ref, which only legacy specs use, is
+  // still rewritten because it cannot collide with a key it does not match.
+  // `used` now holds every FINAL page key — authored ones reserved in pass 0, minted ones added in
+  // pass 1 — so it is the authoritative "is this string a page key?" test for the rewrite below.
+  const rewrite = (ref) => (used.has(ref) ? ref : (nameToKey.has(ref) ? nameToKey.get(ref) : ref));
   for (const p of arr(out.pages)) {
     if (!p || typeof p !== 'object') continue;
-    for (const nav of arr(p.navigatesTo)) { if (nav && nameToKey.has(nav.targetKey)) nav.targetKey = nameToKey.get(nav.targetKey); }
+    for (const nav of arr(p.navigatesTo)) { if (nav && typeof nav.targetKey === 'string') nav.targetKey = rewrite(nav.targetKey); }
   }
   for (const a of arr(out.appShell && out.appShell.areas)) {
     if (!a || typeof a !== 'object') continue;
     for (const g of arr(a.groups)) {
       if (!g || typeof g !== 'object') continue;
-      for (const sa of arr(g.subAreas)) { if (sa && sa.page && nameToKey.has(sa.page)) sa.page = nameToKey.get(sa.page); }
+      for (const sa of arr(g.subAreas)) { if (sa && typeof sa.page === 'string') sa.page = rewrite(sa.page); }
     }
   }
   return out;

--- a/plugins/model-apps/scripts/lib/source-literals.js
+++ b/plugins/model-apps/scripts/lib/source-literals.js
@@ -282,6 +282,28 @@ function blankLiterals(code) {
     }
 
     if (mode === 'jsxTag') {
+      // Comments come FIRST. A `//` or `/* */` comment between attributes is valid TSX, and a
+      // generator naturally emits one to explain an attribute. Without this branch the attribute-
+      // value case below sees an apostrophe in the comment prose ("Griffel's") and treats it as a
+      // quote — and that scanner deliberately does NOT stop at a newline, because a JSX attribute
+      // value may legitimately span lines, so it ran to EOF. The real `export default` was blanked
+      // and every bracket after it miscounted, which is the false-positive direction this file's
+      // header calls the worse one: a complete page refused as truncated. #542.
+      //
+      // `/` in a tag is otherwise only the start of `/>`, and `n` distinguishes all three cases.
+      if (c === '/' && n === '/') {
+        const end = src.indexOf('\n', i);
+        blank(i, end === -1 ? src.length : end);
+        i = end === -1 ? src.length : end;
+        continue;
+      }
+      if (c === '/' && n === '*') {
+        const end = src.indexOf('*/', i + 2);
+        const stop = end === -1 ? src.length : end + 2;
+        blank(i, stop);
+        i = stop;
+        continue;
+      }
       if (c === '"' || c === "'") {                 // attribute value
         let j = i + 1;
         while (j < src.length && src[j] !== c) j += 1;

--- a/plugins/model-apps/scripts/lib/source-literals.js
+++ b/plugins/model-apps/scripts/lib/source-literals.js
@@ -311,6 +311,26 @@ function blankLiterals(code) {
         i = Math.min(j + 1, src.length);
         continue;
       }
+      // A template literal inside a tag can only be part of an explicit TYPE ARGUMENT, e.g.
+      //   <Link<`https://${string}`> to={u} />
+      // and its content is data, not code. Consuming it as one unit here is what keeps the `//`
+      // in a template-literal *type* from being mistaken for the comment branch above — which
+      // would blank to end of line and reject a valid module, and could also hide a genuinely
+      // malformed expression that follows on the same line. Mirrors the `code`-mode scanner:
+      // `${...}` interpolations are blanked with the rest rather than tracked.
+      if (c === '`') {
+        let j = i + 1;
+        let d = 0;
+        for (; j < src.length; j += 1) {
+          if (src[j] === '\\') { j += 1; continue; }
+          if (src[j] === '{' && src[j - 1] === '$') d += 1;
+          else if (src[j] === '}' && d > 0) d -= 1;
+          else if (src[j] === '`' && d === 0) break;
+        }
+        blank(i + 1, j);
+        i = Math.min(j + 1, src.length);
+        continue;
+      }
       if (c === '{') { enterJsxExpr('jsxTag'); i += 1; continue; }
       if (c === '/' && n === '>') {                 // self-closing: no text run follows
         mode = jsxDepth > 0 ? 'jsxText' : 'code';

--- a/plugins/model-apps/scripts/lib/spec-lint.js
+++ b/plugins/model-apps/scripts/lib/spec-lint.js
@@ -9,9 +9,24 @@ const { resolveSurfaces, unresolvedSurfaceMessage } = require('./surface-resolve
 const CHOICE_OPTION_WARN = 12;
 const SEQNUM_RE = /\{SEQNUM(:\d+)?\}/i;
 // FetchXML operators that take no <value> (so a filter may omit value/values).
-const NO_VALUE_OPS = new Set(['null', 'not-null', 'eq-userid', 'ne-userid', 'eq-useroruserteams', 'eq-userteams',
+//
+// The list is the documented value-less ConditionOperator set, NOT a curated subset: an operator
+// missing here makes the lint demand a value the operator must not carry and reject a correct spec
+// (#546 — `eq-businessid` / `ne-businessid`, the business-unit equivalents of `eq-userid` /
+// `ne-userid`, which are the natural way to express "rows owned by my business unit"). The reverse
+// error matters too, so do not add a value-TAKING operator here: that would silently stop the lint
+// catching a missing value and push the failure to the platform at build time.
+// https://learn.microsoft.com/en-us/power-apps/developer/data-platform/fetchxml/reference/operators
+const NO_VALUE_OPS = new Set(['null', 'not-null',
+  // current-user / current-business-unit context
+  'eq-userid', 'ne-userid', 'eq-useroruserteams', 'eq-userteams', 'eq-useroruserhierarchy',
+  'eq-useroruserhierarchyandteams', 'eq-businessid', 'ne-businessid', 'eq-userlanguage',
+  // relative date
   'today', 'yesterday', 'tomorrow', 'this-week', 'last-week', 'next-week', 'this-month', 'last-month', 'next-month',
-  'this-year', 'last-year', 'next-year', 'this-fiscal-year', 'last-seven-days', 'next-seven-days']);
+  'this-year', 'last-year', 'next-year', 'last-seven-days', 'next-seven-days',
+  // relative fiscal period
+  'this-fiscal-year', 'last-fiscal-year', 'next-fiscal-year',
+  'this-fiscal-period', 'last-fiscal-period', 'next-fiscal-period']);
 
 function lintAppSpec(spec) {
   const errors = [];

--- a/plugins/model-apps/scripts/lint-app-spec.js
+++ b/plugins/model-apps/scripts/lint-app-spec.js
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+'use strict';
+// lint-app-spec: validate and lint an App Spec WITHOUT touching an environment.
+//
+// WHY this exists (#560): `validateAppSpec` (the hard schema/deploy gate) and `lintAppSpec` (the
+// authoring guardrails) were library exports with no entry point, and `build-model-app.js` has no
+// lint-only flag. A headless author — a CI job, or an agent authoring a spec outside the interactive
+// skill flow — had to reach in with `node -e "require('./lib/spec-lint.js')..."`, which is both
+// undiscoverable and easy to get wrong (it is the MIGRATED spec that must be validated, not the
+// file as written; see below).
+//
+// This runs the same three steps, in the same order, that every deploying CLI runs on load:
+//   1. migrateAppSpec  — upgrade a legacy spec to schemaVersion 2 (mints page keys, rewrites
+//                        name-refs). Skipping it lints a shape the build never sees.
+//   2. validateAppSpec — the hard gate. Its errors are what `--apply` refuses on.
+//   3. lintAppSpec     — advisory guardrails: errors AND warnings.
+//
+// Exit codes: 0 when there are no errors from either step (warnings alone do not fail, so a CI job
+// can gate on correctness without being blocked by advice), 1 otherwise. `--strict` also fails on
+// warnings, for a pipeline that wants them treated as errors.
+//
+// `--profile` selects validateAppSpec's strictness and DEFAULTS TO `plan`, not `deploy`. The deploy
+// profile requires every generative page to be implemented and every persona job to carry
+// privileges — state a spec legitimately lacks while it is still being authored, which is exactly
+// when the authoring flow runs this. Pass `--profile deploy` to gate a final, deployable spec.
+//
+// Usage:
+//   node lint-app-spec.js --spec @<app-folder>/app-spec.json
+//                         [--profile design|plan|deploy|structural] [--strict] [--json]
+
+const { parseArgs, readJsonArg, emitResult } = require('./lib/dataverse-auth.js');
+const { validateAppSpec, migrateAppSpec, VALIDATION_PROFILES } = require('./lib/app-spec.js');
+const { lintAppSpec } = require('./lib/spec-lint.js');
+
+const USAGE = 'Usage: node lint-app-spec.js --spec @<path-to-app-spec.json> [--profile design|plan|deploy|structural] [--strict] [--json]';
+
+// Pure core: spec in, report out. Exported so tests can assert the contract without spawning a
+// process or writing fixture files to disk.
+//
+// `profile` selects how strict `validateAppSpec` is. It matters more than it looks: the DEPLOY
+// profile requires every generative page to be implemented (`source.kind: 'tsx'` with a codeFile)
+// and every persona job to carry privileges — both of which are deliberately absent while a spec is
+// still being authored. Defaulting to deploy made this CLI reject a perfectly normal work-in-
+// progress spec at the two gates the authoring flow actually runs it at, so the default is `plan`,
+// the same profile the builder's own dry run uses. A caller checking a FINAL, deployable spec
+// (a CI gate before `--apply`) should pass `--profile deploy` explicitly.
+function lintSpec(rawSpec, opts) {
+  const profile = (opts && opts.profile) || 'plan';
+  if (!VALIDATION_PROFILES.includes(profile)) {
+    return { ok: false, profile, errors: [`unknown profile '${profile}' (valid: ${VALIDATION_PROFILES.join(', ')})`], warnings: [] };
+  }
+  const spec = migrateAppSpec(rawSpec);
+
+  // validateAppSpec is the gate `--apply` enforces, so its findings are reported FIRST and tagged
+  // as such: an author who fixes lint advice while a schema error stands has fixed nothing.
+  const validation = validateAppSpec(spec, { profile });
+  const validationErrors = (validation && validation.errors) || [];
+  // validateAppSpec also emits non-blocking advisories the build narrates (e.g. a Customer-column
+  // description Dataverse will not store). Dropping them here would make this CLI quieter than the
+  // build it stands in for, and would let `--strict` pass on a spec the build warns about.
+  const validationWarnings = (validation && validation.warnings) || [];
+
+  // A spec that fails the schema gate can put lintAppSpec in front of shapes it never expects
+  // (a null entity, a string where a list belongs). The lint already guards its own collections,
+  // but it is downstream advice either way — keep a crash from masking the real, already-known
+  // schema errors. The crash is REPORTED, not swallowed, so a genuine lint defect still surfaces.
+  let lint = { ok: true, errors: [], warnings: [] };
+  try {
+    lint = lintAppSpec(spec) || lint;
+  } catch (err) {
+    lint = { ok: false, errors: [`lint could not run on this spec: ${err.message}`], warnings: [] };
+  }
+
+  const errors = [
+    ...validationErrors.map((e) => `schema: ${e}`),
+    ...((lint.errors || []).map((e) => `lint: ${e}`)),
+  ];
+  const warnings = [
+    ...validationWarnings.map((w) => `schema: ${w}`),
+    ...((lint.warnings || []).map((w) => `lint: ${w}`)),
+  ];
+
+  return { ok: errors.length === 0, profile, errors, warnings, schemaVersion: spec && spec.schemaVersion };
+}
+
+function main() {
+  const { flags } = parseArgs(process.argv.slice(2));
+  const specArg = flags.spec;
+  if (!specArg) return emitResult(false, new Error(USAGE));
+
+  // parseArgs yields `true` for a bare `--flag` and a string for `--flag=value`, so accept both.
+  const isOn = (v) => v === true || v === 'true';
+
+  let rawSpec;
+  try {
+    rawSpec = readJsonArg(typeof specArg === 'string' && !specArg.startsWith('@') ? '@' + specArg : specArg);
+  } catch (err) {
+    // A spec that is not readable/parseable is the single most common "why did nothing happen"
+    // failure, so name the file and the parser's own message rather than a generic gate error.
+    return emitResult(false, new Error(`could not read spec ${specArg}: ${err.message}`));
+  }
+
+  const report = lintSpec(rawSpec, { profile: typeof flags.profile === 'string' ? flags.profile : undefined });
+  const strict = isOn(flags.strict);
+  const failed = !report.ok || (strict && report.warnings.length > 0);
+
+  if (isOn(flags.json)) {
+    // Deliberately NOT emitResult: its structured-failure branch reports
+    // "Operation completed with N error(s)" off `payload.errors`, which for a warnings-only
+    // `--strict` failure prints "0 error(s)" next to a non-zero exit — and the payload's own `ok`
+    // must describe the COMMAND's outcome, not just whether errors were found.
+    process.stdout.write(JSON.stringify({ ...report, ok: !failed }) + '\n');
+    if (failed) {
+      process.stderr.write(
+        report.errors.length > 0
+          ? `app spec has ${report.errors.length} error(s); see stdout JSON\n`
+          : `app spec has ${report.warnings.length} warning(s) and --strict was set; see stdout JSON\n`
+      );
+    }
+    process.exit(failed ? 1 : 0);
+  }
+
+  for (const e of report.errors) process.stderr.write(`ERROR  ${e}\n`);
+  for (const w of report.warnings) process.stderr.write(`WARN   ${w}\n`);
+  process.stdout.write(
+    `${failed ? 'FAIL' : 'OK'} [profile: ${report.profile}] — ${report.errors.length} error(s), ${report.warnings.length} warning(s)` +
+      `${strict && report.errors.length === 0 && report.warnings.length > 0 ? ' (failed by --strict)' : ''}\n`
+  );
+  process.exit(failed ? 1 : 0);
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { lintSpec };

--- a/plugins/model-apps/scripts/lint-app-spec.js
+++ b/plugins/model-apps/scripts/lint-app-spec.js
@@ -9,20 +9,25 @@
 // undiscoverable and easy to get wrong (it is the MIGRATED spec that must be validated, not the
 // file as written; see below).
 //
-// This runs the same three steps, in the same order, that every deploying CLI runs on load:
+// This runs the gates a build runs on load, plus the authoring guardrails:
 //   1. migrateAppSpec  — upgrade a legacy spec to schemaVersion 2 (mints page keys, rewrites
 //                        name-refs). Skipping it lints a shape the build never sees.
 //   2. validateAppSpec — the hard gate. Its errors are what `--apply` refuses on.
-//   3. lintAppSpec     — advisory guardrails: errors AND warnings.
+//   3. lintAppSpec     — advisory guardrails: errors AND warnings. NOTE: `build-model-app.js` does
+//                        NOT run this; it migrates and validates only. The `lint:` findings here
+//                        are therefore ADDITIONAL to what the builder reports, which is the point —
+//                        the skill's plan gate is where they are meant to be caught.
 //
 // Exit codes: 0 when there are no errors from either step (warnings alone do not fail, so a CI job
 // can gate on correctness without being blocked by advice), 1 otherwise. `--strict` also fails on
 // warnings, for a pipeline that wants them treated as errors.
 //
 // `--profile` selects validateAppSpec's strictness and DEFAULTS TO `plan`, not `deploy`. The deploy
-// profile requires every generative page to be implemented and every persona job to carry
-// privileges — state a spec legitimately lacks while it is still being authored, which is exactly
-// when the authoring flow runs this. Pass `--profile deploy` to gate a final, deployable spec.
+// profile requires every generative page to be IMPLEMENTED (`source.kind: 'tsx'` with a codeFile),
+// which a spec legitimately lacks until generate-pages runs — and that is exactly when the
+// authoring flow invokes this. `plan` relaxes only that; it does NOT relax any other rule (a
+// persona job still requires `privileges[]` under every profile). Pass `--profile deploy` to gate
+// a final, deployable spec.
 //
 // Usage:
 //   node lint-app-spec.js --spec @<app-folder>/app-spec.json
@@ -38,11 +43,12 @@ const USAGE = 'Usage: node lint-app-spec.js --spec @<path-to-app-spec.json> [--p
 // process or writing fixture files to disk.
 //
 // `profile` selects how strict `validateAppSpec` is. It matters more than it looks: the DEPLOY
-// profile requires every generative page to be implemented (`source.kind: 'tsx'` with a codeFile)
-// and every persona job to carry privileges — both of which are deliberately absent while a spec is
-// still being authored. Defaulting to deploy made this CLI reject a perfectly normal work-in-
-// progress spec at the two gates the authoring flow actually runs it at, so the default is `plan`,
-// the same profile the builder's own dry run uses. A caller checking a FINAL, deployable spec
+// profile requires every generative page to be implemented (`source.kind: 'tsx'` with a codeFile),
+// which is deliberately not true while pages are still intents. Defaulting to deploy made this CLI
+// reject a perfectly normal work-in-progress spec at the two gates the authoring flow actually runs
+// it at, so the default is `plan`, the same profile the builder's own dry run uses. `plan` relaxes
+// ONLY that rule — a persona job still requires `privileges[]` under every profile. A caller
+// checking a FINAL, deployable spec
 // (a CI gate before `--apply`) should pass `--profile deploy` explicitly.
 function lintSpec(rawSpec, opts) {
   const profile = (opts && opts.profile) || 'plan';
@@ -85,22 +91,30 @@ function lintSpec(rawSpec, opts) {
 
 function main() {
   const { flags } = parseArgs(process.argv.slice(2));
-  const specArg = flags.spec;
-  if (!specArg) return emitResult(false, new Error(USAGE));
 
-  // parseArgs yields `true` for a bare `--flag` and a string for `--flag=value`, so accept both.
+  // parseArgs yields `true` for a bare `--flag` and a string for `--flag=value` / `--flag value`.
+  // For a VALUE-taking flag, that bare `true` is a usage error and must be rejected rather than
+  // coerced: a bare `--profile` silently falling back to the default would skip a `deploy` gate a
+  // CI job believed it had requested, and a bare `--spec` would reach readJsonArg and surface as
+  // "spec is not an object" — a gate report about a file the caller never named.
   const isOn = (v) => v === true || v === 'true';
+  const specArg = flags.spec;
+  if (specArg === undefined) return emitResult(false, new Error(USAGE));
+  if (typeof specArg !== 'string') return emitResult(false, new Error(`--spec needs a path\n${USAGE}`));
+  if (flags.profile !== undefined && typeof flags.profile !== 'string') {
+    return emitResult(false, new Error(`--profile needs one of: ${VALIDATION_PROFILES.join(', ')}\n${USAGE}`));
+  }
 
   let rawSpec;
   try {
-    rawSpec = readJsonArg(typeof specArg === 'string' && !specArg.startsWith('@') ? '@' + specArg : specArg);
+    rawSpec = readJsonArg(specArg.startsWith('@') ? specArg : '@' + specArg);
   } catch (err) {
     // A spec that is not readable/parseable is the single most common "why did nothing happen"
     // failure, so name the file and the parser's own message rather than a generic gate error.
     return emitResult(false, new Error(`could not read spec ${specArg}: ${err.message}`));
   }
 
-  const report = lintSpec(rawSpec, { profile: typeof flags.profile === 'string' ? flags.profile : undefined });
+  const report = lintSpec(rawSpec, { profile: flags.profile });
   const strict = isOn(flags.strict);
   const failed = !report.ok || (strict && report.warnings.length > 0);
 

--- a/plugins/model-apps/scripts/tests/app-spec-migrate.test.js
+++ b/plugins/model-apps/scripts/tests/app-spec-migrate.test.js
@@ -140,6 +140,41 @@ test('#545: an authored key that equals another page\'s name is not retargeted b
   assert.strictEqual(m.appShell.areas[0].groups[0].subAreas[0].page, 'orders');
 });
 
+// Review finding. The key-first rewrite must key off AUTHORED keys, not every final key. A MINTED
+// key is derived from a name, so it collides with a different page's name by construction: pages
+// "All Orders" and "all-orders" mint 'all-orders' and 'all-orders-2'. Treating a minted key as
+// authoritative left a legacy name-ref to the SECOND page pointing at the first.
+test('#545: a legacy name-ref is still resolved by name when the match is a MINTED key', () => {
+  const legacy = {
+    solution: { uniqueName: 'c', publisherPrefix: 'c' }, app: { name: 'C' }, entities: [],
+    pages: [
+      { name: 'All Orders', codeFile: 'a.tsx' },
+      { name: 'all-orders', codeFile: 'b.tsx', navigatesTo: [{ targetKey: 'all-orders' }] },
+    ],
+  };
+  const m = migrateAppSpec(legacy);
+  assert.deepStrictEqual(m.pages.map((p) => p.key), ['all-orders', 'all-orders-2']);
+  assert.strictEqual(m.pages[1].navigatesTo[0].targetKey, 'all-orders-2',
+    'the name-ref names the SECOND page; a minted key must not capture it');
+});
+
+// Review finding. A key the author WROTE but got wrong must reach validation unchanged. Minting
+// over it silently repairs a typo the author needs to see — and contradicts the preservation this
+// pass documents. Only a page with no `key` property at all gets one minted.
+test('#545: a present-but-malformed key is preserved verbatim for validation to name', () => {
+  for (const key of [42, '', '   ', null]) {
+    const s = { solution: { uniqueName: 'c', publisherPrefix: 'c' }, app: { name: 'C' }, entities: [], pages: [{ key, name: 'Orders', source: { kind: 'intent' } }] };
+    const m = migrateAppSpec(s);
+    assert.deepStrictEqual(m.pages[0].key, key, `key ${JSON.stringify(key)} must survive migration`);
+    const r = validateAppSpec(m, { profile: 'plan' });
+    assert.ok(r.errors.some((e) => /stable key|invalid key grammar/.test(e)),
+      `validation must name the key problem for ${JSON.stringify(key)}: ${JSON.stringify(r.errors)}`);
+  }
+  // ...while a page with NO key property still gets one minted, as before.
+  const s = { solution: { uniqueName: 'c', publisherPrefix: 'c' }, app: { name: 'C' }, entities: [], pages: [{ name: 'Orders', source: { kind: 'intent' } }] };
+  assert.strictEqual(migrateAppSpec(s).pages[0].key, 'orders');
+});
+
 // IMPORTANT #2 regression: a navigatesTo name-ref whose target name collides with a minted key
 // for a DIFFERENT page must resolve to the correct (first) page and not be double-rewritten.
 //

--- a/plugins/model-apps/scripts/tests/app-spec-migrate.test.js
+++ b/plugins/model-apps/scripts/tests/app-spec-migrate.test.js
@@ -63,6 +63,83 @@ test('mints a fallback key for a page with a blank name', () => {
   assert.strictEqual(migrateAppSpec(legacy).pages[0].key, 'page');
 });
 
+// #545 Case 1 regression. A spec may declare schemaVersion 2 on each PAGE (and carry hand-authored
+// stable keys and key-based refs) while omitting the TOP-LEVEL schemaVersion. Migration then runs,
+// and pass 1 used to mint `p.key = slugify(p.name)` UNCONDITIONALLY — overwriting the author's keys.
+// The refs are keys, not names, so pass 2 left them pointing at the now-discarded keys, and
+// validateAppSpec reported one "not a known page key" / "unknown page" error per page, none of
+// which named the real cause. Adding the top-level schemaVersion "fixed" it only because that made
+// migration a no-op. An authored key must survive migration.
+test('#545: preserves hand-authored page keys when only the top-level schemaVersion is missing', () => {
+  const authored = {
+    solution: { uniqueName: 'c', publisherPrefix: 'c' }, app: { name: 'C' },
+    entities: [{ schemaName: 'c_order', primaryAttribute: { schemaName: 'c_name' }, columns: [] }],
+    pages: [
+      // Keys deliberately DIFFER from slugify(name), which is what makes the clobber observable.
+      { schemaVersion: 2, key: 'orders', name: 'All Open Orders', source: { kind: 'tsx', codeFile: 'orders.tsx' }, navigatesTo: [{ targetKey: 'order-card' }] },
+      { schemaVersion: 2, key: 'order-card', name: 'Order Details View', source: { kind: 'tsx', codeFile: 'card.tsx' } },
+    ],
+    appShell: { areas: [{ label: 'Main', groups: [{ label: 'Main', subAreas: [{ title: 'Orders', page: 'orders' }, { title: 'Card', page: 'order-card' }] }] }] },
+  };
+  const m = migrateAppSpec(authored);
+  assert.strictEqual(m.schemaVersion, 2);
+  assert.strictEqual(m.pages[0].key, 'orders', 'authored key survives migration (not re-slugged from the name)');
+  assert.strictEqual(m.pages[1].key, 'order-card');
+  assert.strictEqual(m.pages[0].navigatesTo[0].targetKey, 'order-card', 'key-based navigatesTo still resolves');
+  assert.deepStrictEqual(m.appShell.areas[0].groups[0].subAreas.map((s) => s.page), ['orders', 'order-card']);
+  const r = validateAppSpec(m);
+  assert.strictEqual(r.ok, true, JSON.stringify(r.errors));
+});
+
+// Mixed spec: some pages carry an authored key, others do not. Every authored key must be RESERVED
+// before any key is minted, or a minted slug can collide with an authored key declared later and
+// silently steal it.
+test('#545: mints only for keyless pages, and never mints over a later authored key', () => {
+  const authored = {
+    solution: { uniqueName: 'c', publisherPrefix: 'c' }, app: { name: 'C' }, entities: [],
+    pages: [
+      { name: 'Orders', source: { kind: 'intent' } },                          // keyless -> slug would be 'orders'
+      { key: 'orders', name: 'Legacy Orders', source: { kind: 'intent' } },     // authored 'orders' declared LATER
+    ],
+  };
+  const m = migrateAppSpec(authored);
+  assert.strictEqual(m.pages[1].key, 'orders', 'the authored key wins');
+  assert.strictEqual(m.pages[0].key, 'orders-2', 'the minted key yields to the reserved authored key');
+});
+
+// An authored key that violates the key grammar must NOT be silently replaced: validateAppSpec
+// reports it by name, which is a message the author can act on. Silently re-slugging it would
+// resurrect the same dangling-reference failure this fix exists to remove.
+test('#545: a malformed authored key is preserved so validation can name it', () => {
+  const authored = {
+    solution: { uniqueName: 'c', publisherPrefix: 'c' }, app: { name: 'C' }, entities: [],
+    pages: [{ key: 'Not A Slug', name: 'Orders', source: { kind: 'intent' } }],
+  };
+  const m = migrateAppSpec(authored);
+  assert.strictEqual(m.pages[0].key, 'Not A Slug');
+  const r = validateAppSpec(m);
+  assert.strictEqual(r.ok, false);
+  assert.ok(r.errors.some((e) => e.includes('Not A Slug') && e.includes('invalid key grammar')), JSON.stringify(r.errors));
+});
+
+// Review finding on the #545 fix. Once authored keys survive migration, a reference can legitimately
+// already BE a key — and a spec may hold a page whose authored key equals a DIFFERENT page's name.
+// Rewriting name-first silently retargets the reference to the other page AND still validates,
+// because the substituted value is itself a valid key. An exact key match must win.
+test('#545: an authored key that equals another page\'s name is not retargeted by the name rewrite', () => {
+  const authored = {
+    solution: { uniqueName: 'c', publisherPrefix: 'c' }, app: { name: 'C' }, entities: [],
+    pages: [
+      { key: 'orders', name: 'All Orders', source: { kind: 'intent' }, navigatesTo: [{ targetKey: 'orders' }] },
+      { key: 'report', name: 'orders', source: { kind: 'intent' } },
+    ],
+    appShell: { areas: [{ label: 'M', groups: [{ label: 'M', subAreas: [{ title: 'O', page: 'orders' }] }] }] },
+  };
+  const m = migrateAppSpec(authored);
+  assert.strictEqual(m.pages[0].navigatesTo[0].targetKey, 'orders', "the key ref stays on the page that OWNS the key, not the page NAMED 'orders'");
+  assert.strictEqual(m.appShell.areas[0].groups[0].subAreas[0].page, 'orders');
+});
+
 // IMPORTANT #2 regression: a navigatesTo name-ref whose target name collides with a minted key
 // for a DIFFERENT page must resolve to the correct (first) page and not be double-rewritten.
 //

--- a/plugins/model-apps/scripts/tests/lint-app-spec.test.js
+++ b/plugins/model-apps/scripts/tests/lint-app-spec.test.js
@@ -198,3 +198,32 @@ test('CLI with no --spec prints usage', () => {
   assert.strictEqual(out.code, 1);
   assert.match(out.stderr, /Usage: node lint-app-spec\.js/);
 });
+
+// Review finding. parseArgs turns a bare `--flag` into `true`. For a VALUE-taking flag that is a
+// usage error, not a default: a bare `--profile` silently falling back to `plan` would skip a
+// `deploy` gate a CI job believed it had requested, and a bare `--spec` would reach readJsonArg and
+// report "spec is not an object" — a gate verdict about a file the caller never named.
+test('CLI rejects a value-taking flag given with no value', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'lint-app-spec-'));
+  const file = path.join(dir, 'app-spec.json');
+  fs.writeFileSync(file, JSON.stringify(good()));
+  try {
+    for (const [args, expected] of [
+      [[CLI, '--spec'], /--spec needs a path/],
+      [[CLI, '--spec', '@' + file, '--profile'], /--profile needs one of: design, plan, deploy, structural/],
+    ]) {
+      let out;
+      try {
+        execFileSync(process.execPath, args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+        out = { code: 0, stderr: '' };
+      } catch (err) {
+        out = { code: err.status, stderr: String(err.stderr || '') };
+      }
+      assert.strictEqual(out.code, 1, `expected a usage failure for ${args.slice(1).join(' ')}`);
+      assert.match(out.stderr, expected);
+      assert.doesNotMatch(out.stderr, /spec is not an object/, 'a usage error must not surface as a gate verdict');
+    }
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/plugins/model-apps/scripts/tests/lint-app-spec.test.js
+++ b/plugins/model-apps/scripts/tests/lint-app-spec.test.js
@@ -1,0 +1,200 @@
+// #560: lint-app-spec.js is the CLI surface for the two gates that previously had none.
+// The contract that matters is that it runs the SAME three steps a deploying CLI runs on load
+// (migrate -> validate -> lint) — linting the file as written instead of the migrated shape is
+// exactly the mistake the `node -e` workaround invited.
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+
+const { lintSpec } = require('../lint-app-spec.js');
+
+const CLI = path.join(__dirname, '..', 'lint-app-spec.js');
+
+const good = () => ({
+  solution: { uniqueName: 'c', publisherPrefix: 'c' },
+  app: { name: 'C' },
+  entities: [{ schemaName: 'c_order', displayName: 'Order', pluralName: 'Orders', primaryAttribute: { schemaName: 'c_name', displayName: 'Name' }, columns: [] }],
+  forms: [], views: [], charts: [],
+});
+
+test('a clean spec reports ok with no errors', () => {
+  const r = lintSpec(good());
+  assert.strictEqual(r.ok, true, JSON.stringify(r.errors));
+  assert.deepStrictEqual(r.errors, []);
+  assert.strictEqual(r.profile, 'plan', 'the default profile is plan, not deploy');
+});
+
+// Review finding. validateAppSpec defaults to the DEPLOY profile, which requires every generative
+// page to be implemented and every persona job to carry privileges. Both are deliberately absent
+// while a spec is being authored — which is exactly when the documented gates run this CLI — so a
+// deploy default rejected normal work-in-progress specs and would have broken the authoring flow.
+test('the default profile accepts a work-in-progress spec that the deploy profile rejects', () => {
+  const s = good();
+  s.pages = [{ key: 'ov', name: 'Overview', purpose: 'overview', source: { kind: 'intent' } }];
+  s.appShell = { areas: [{ label: 'M', groups: [{ label: 'M', subAreas: [{ title: 'Overview', page: 'ov' }] }] }] };
+
+  const dflt = lintSpec(s);
+  assert.strictEqual(dflt.ok, true, `an intent page must pass the default gate: ${JSON.stringify(dflt.errors)}`);
+
+  const deploy = lintSpec(s, { profile: 'deploy' });
+  assert.strictEqual(deploy.ok, false, 'deploy still requires the page to be implemented');
+  assert.ok(deploy.errors.some((e) => /must be implemented/.test(e)), JSON.stringify(deploy.errors));
+});
+
+test('an unknown profile is rejected by name rather than silently falling back', () => {
+  const r = lintSpec(good(), { profile: 'nope' });
+  assert.strictEqual(r.ok, false);
+  assert.ok(r.errors.some((e) => /unknown profile 'nope'/.test(e)), JSON.stringify(r.errors));
+});
+
+// Review finding. validateAppSpec emits non-blocking advisories of its own, which the build narrates.
+// Reporting only lint warnings made this CLI quieter than the build it stands in for.
+test('warnings from BOTH gates are reported, each tagged with its source', () => {
+  const s = good();
+  // Two pre-existing (pageId-bearing) pages sharing a name is a validateAppSpec WARNING.
+  s.pages = [
+    { key: 'a', name: 'Overview', pageId: 'p1', source: { kind: 'tsx', codeFile: 'a.tsx' } },
+    { key: 'b', name: 'overview', pageId: 'p2', source: { kind: 'tsx', codeFile: 'b.tsx' } },
+  ];
+  s.appShell = { areas: [{ label: 'M', groups: [{ label: 'M', subAreas: [{ title: 'A', page: 'a' }, { title: 'B', page: 'b' }] }] }] };
+  const r = lintSpec(s);
+  assert.ok(r.warnings.some((w) => w.startsWith('schema: ')), `expected a schema-tagged warning: ${JSON.stringify(r.warnings)}`);
+});
+
+test('schema (validateAppSpec) findings are reported and tagged "schema:"', () => {
+  const s = good();
+  delete s.solution;
+  const r = lintSpec(s);
+  assert.strictEqual(r.ok, false);
+  assert.ok(r.errors.some((e) => e.startsWith('schema: ')), JSON.stringify(r.errors));
+});
+
+test('lint (lintAppSpec) findings are reported and tagged "lint:"', () => {
+  const s = good();
+  // A view filter with a value-taking operator and no value is a lint error, not a schema error.
+  s.views = [{ entity: 'c_order', name: 'Mine', columns: ['c_name'], filters: [{ attr: 'c_name', op: 'eq' }] }];
+  const r = lintSpec(s);
+  assert.strictEqual(r.ok, false);
+  assert.ok(r.errors.some((e) => e.startsWith('lint: ')), JSON.stringify(r.errors));
+});
+
+// The load-bearing behaviour: the spec is MIGRATED before either gate sees it. A legacy spec with
+// name-based refs is valid only after migration, so linting the raw file would report false errors.
+test('the spec is migrated before validation (a legacy spec is not reported as broken)', () => {
+  const legacy = {
+    ...good(),
+    pages: [{ name: 'Sales Overview', codeFile: 'sales.tsx' }],
+    appShell: { areas: [{ label: 'Main', groups: [{ label: 'Main', subAreas: [{ title: 'Sales Overview', page: 'Sales Overview' }] }] }] },
+  };
+  const r = lintSpec(legacy);
+  assert.strictEqual(r.schemaVersion, 2, 'migration ran');
+  assert.strictEqual(r.ok, true, JSON.stringify(r.errors));
+});
+
+test('warnings alone do not fail (so CI can gate on correctness, not advice)', () => {
+  const s = good();
+  // "Active <Plural>" collides with the stock default view — a documented WARNING.
+  s.views = [{ entity: 'c_order', name: 'Active Orders', columns: ['c_name'], activeOnly: true }];
+  const r = lintSpec(s);
+  assert.strictEqual(r.ok, true, JSON.stringify(r.errors));
+  assert.ok(r.warnings.length > 0, 'expected the stock-default-view warning');
+  assert.ok(r.warnings.every((w) => /^(schema|lint): /.test(w)), `every warning is source-tagged: ${JSON.stringify(r.warnings)}`);
+});
+
+function runCli(spec, extraArgs) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'lint-app-spec-'));
+  const file = path.join(dir, 'app-spec.json');
+  fs.writeFileSync(file, JSON.stringify(spec));
+  try {
+    const stdout = execFileSync(process.execPath, [CLI, '--spec', '@' + file, ...(extraArgs || [])], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+    return { code: 0, stdout };
+  } catch (err) {
+    return { code: err.status, stdout: String(err.stdout || ''), stderr: String(err.stderr || '') };
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test('CLI exits 0 on a clean spec and 1 when a gate fails', () => {
+  const ok = runCli(good());
+  assert.strictEqual(ok.code, 0, ok.stdout + (ok.stderr || ''));
+  assert.match(ok.stdout, /^OK \[profile: plan\] — 0 error\(s\)/m);
+
+  const bad = good();
+  delete bad.solution;
+  const fail = runCli(bad);
+  assert.strictEqual(fail.code, 1);
+  assert.match(fail.stderr, /ERROR {2}schema: /);
+});
+
+test('CLI --profile deploy is available for gating a final, deployable spec', () => {
+  const s = good();
+  s.pages = [{ key: 'ov', name: 'Overview', purpose: 'overview', source: { kind: 'intent' } }];
+  s.appShell = { areas: [{ label: 'M', groups: [{ label: 'M', subAreas: [{ title: 'Overview', page: 'ov' }] }] }] };
+  assert.strictEqual(runCli(s).code, 0, 'passes the default plan gate');
+  const deploy = runCli(s, ['--profile', 'deploy']);
+  assert.strictEqual(deploy.code, 1);
+  assert.match(deploy.stdout, /FAIL \[profile: deploy\]/);
+});
+
+// Review finding. The JSON payload's `ok` must describe the COMMAND's outcome. A warnings-only
+// --strict run exits 1, so emitting ok:true there would let a machine consumer read a failure as
+// a success.
+test('CLI --strict --json reports ok:false and exits 1 on warnings alone', () => {
+  const s = good();
+  s.views = [{ entity: 'c_order', name: 'Active Orders', columns: ['c_name'], activeOnly: true }];
+  const out = runCli(s, ['--strict', '--json']);
+  assert.strictEqual(out.code, 1);
+  const payload = JSON.parse(out.stdout);
+  assert.strictEqual(payload.ok, false, 'JSON status must match the exit code');
+  assert.deepStrictEqual(payload.errors, []);
+  assert.ok(payload.warnings.length > 0);
+  assert.match(out.stderr, /--strict was set/);
+  // The misleading "completed with 0 error(s)" summary must not appear for a warnings-only failure.
+  assert.doesNotMatch(out.stderr, /completed with 0 error\(s\)/);
+});
+
+test('CLI --json on a clean spec reports ok:true and exits 0', () => {
+  const out = runCli(good(), ['--json']);
+  assert.strictEqual(out.code, 0);
+  const payload = JSON.parse(out.stdout);
+  assert.strictEqual(payload.ok, true);
+  assert.strictEqual(payload.profile, 'plan');
+});
+
+test('CLI --strict turns warnings into a failure', () => {
+  const s = good();
+  s.views = [{ entity: 'c_order', name: 'Active Orders', columns: ['c_name'], activeOnly: true }];
+  assert.strictEqual(runCli(s).code, 0, 'warnings alone pass without --strict');
+  const strict = runCli(s, ['--strict']);
+  assert.strictEqual(strict.code, 1);
+  assert.match(strict.stdout, /failed by --strict/);
+});
+
+test('CLI reports an unreadable spec by name rather than a generic gate error', () => {
+  let out;
+  try {
+    execFileSync(process.execPath, [CLI, '--spec', '@does-not-exist.json'], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+    out = { code: 0 };
+  } catch (err) {
+    out = { code: err.status, stderr: String(err.stderr || '') };
+  }
+  assert.strictEqual(out.code, 1);
+  assert.match(out.stderr, /could not read spec @does-not-exist\.json/);
+});
+
+test('CLI with no --spec prints usage', () => {
+  let out;
+  try {
+    execFileSync(process.execPath, [CLI], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+    out = { code: 0 };
+  } catch (err) {
+    out = { code: err.status, stderr: String(err.stderr || '') };
+  }
+  assert.strictEqual(out.code, 1);
+  assert.match(out.stderr, /Usage: node lint-app-spec\.js/);
+});

--- a/plugins/model-apps/scripts/tests/source-literals.test.js
+++ b/plugins/model-apps/scripts/tests/source-literals.test.js
@@ -122,6 +122,11 @@ test('JSX text is text, not code — the false-positive cases that block real us
     'in-tag block comment with an apostrophe': 'export default function P(){ return <button\n  type="button"\n  /* Griffel\'s atomic output wins */\n  className={x}\n>hi</button>; }\n',
     'in-tag comment containing a quote and a bracket': 'export default function P(){ return <button\n  // don\'t count this ( or this "\n  className={x}\n>hi</button>; }\n',
     'in-tag comment before a self-closing tag': 'export default function P(){ return <div><Icon\n  // Griffel\'s output\n  aria-hidden\n/></div>; }\n',
+    // The other position a `//` can appear inside a tag WITHOUT being a comment: a template-literal
+    // TYPE argument. Its content is data, so it must be consumed whole — otherwise the comment
+    // branch above blanks to end of line and rejects a valid module.
+    'template-literal type argument containing `//`': 'export default function P(){ return <C<`https://${string}`> />; }\n',
+    'template-literal type argument containing `/*`': 'export default function P(){ return <C<`a/*b`> />; }\n',
   };
   for (const [name, code] of Object.entries(cases)) {
     assert.equal(hasDefaultExport(code), true, `default export missed: ${name}`);
@@ -145,6 +150,11 @@ test('hasUnbalancedBrackets flags a truncated write but tolerates JSX and generi
   assert.equal(hasUnbalancedBrackets('const x: Array<Record<string, number>> = [];\nexport default () => <div a={1} />;\n'), false);
   // Brackets inside strings/comments must not count.
   assert.equal(hasUnbalancedBrackets('const s = "{{{"; // )))\nexport default () => null;\n'), false);
+  // ...but blanking a comment must not become a way to HIDE a real defect. A template-literal type
+  // argument in a tag is consumed as data, so a malformed expression after it on the same line is
+  // still visible. (When the `//` inside the template was mistaken for a comment, the rest of the
+  // line — including this `{(}` — was blanked and the file read as balanced.)
+  assert.equal(hasUnbalancedBrackets('export default function P() {\n  return <C<`https://${string}`> value={(} />;\n}\n'), true);
 });
 
 test('every committed .tsx the repo ships is accepted (false-positive corpus)', () => {

--- a/plugins/model-apps/scripts/tests/source-literals.test.js
+++ b/plugins/model-apps/scripts/tests/source-literals.test.js
@@ -110,6 +110,18 @@ test('JSX text is text, not code — the false-positive cases that block real us
     'JSX with an explicit type argument': 'export default function P(){ return <Table<Row> rows={r} />; }\n',
     'fragment': 'export default function P(){ return <><span>a</span><span>b</span></>; }\n',
     'comparison operators': 'const b = a < c && c > a;\nexport default function P(){ return <div/>; }\n',
+    // #542. A `//` or `/* */` comment BETWEEN ATTRIBUTES in a JSX opening tag is valid TSX and a
+    // natural thing for a generator to emit when explaining an attribute. `jsxTag` mode had no
+    // comment handling at all, so an apostrophe inside one was read as an attribute-value quote,
+    // which then ran to EOF (the attribute scanner does not stop at a newline, because a JSX
+    // attribute value legitimately may span lines). That blanked the real `export default` and
+    // miscounted every bracket after it, so promotion rejected a complete page as "truncated" —
+    // and because promotion is transactional, one such page blocked the whole batch.
+    'in-tag line comment': 'export default function P(){ return <button\n  type="button"\n  // wins over the base border shorthand\n  className={x}\n>hi</button>; }\n',
+    'in-tag line comment with an apostrophe': 'export default function P(){ return <button\n  type="button"\n  // wins over Griffel\'s atomic output\n  className={x}\n>hi</button>; }\n',
+    'in-tag block comment with an apostrophe': 'export default function P(){ return <button\n  type="button"\n  /* Griffel\'s atomic output wins */\n  className={x}\n>hi</button>; }\n',
+    'in-tag comment containing a quote and a bracket': 'export default function P(){ return <button\n  // don\'t count this ( or this "\n  className={x}\n>hi</button>; }\n',
+    'in-tag comment before a self-closing tag': 'export default function P(){ return <div><Icon\n  // Griffel\'s output\n  aria-hidden\n/></div>; }\n',
   };
   for (const [name, code] of Object.entries(cases)) {
     assert.equal(hasDefaultExport(code), true, `default export missed: ${name}`);

--- a/plugins/model-apps/scripts/tests/spec-lint.test.js
+++ b/plugins/model-apps/scripts/tests/spec-lint.test.js
@@ -35,6 +35,30 @@ test('malformed top-level collections return lint errors instead of throwing', (
   }
 });
 
+// #546. `eq-businessid` / `ne-businessid` are value-less FetchXML condition operators — the
+// business-unit equivalents of `eq-userid` / `ne-userid` — and are the natural way to express
+// "rows owned by my business unit". They were missing from NO_VALUE_OPS, so the lint demanded a
+// `value` the operator must not carry and rejected a correct spec.
+// https://learn.microsoft.com/en-us/power-apps/developer/data-platform/webapi/reference/condition-operator
+test('#546 view filters: value-less operators are accepted without a value', () => {
+  for (const op of ['eq-businessid', 'ne-businessid', 'eq-userid', 'ne-userid', 'null', 'this-week']) {
+    const s = base();
+    s.views = [{ entity: 'new_ticket', name: 'Mine', columns: ['new_name'], filters: [{ attr: 'owningbusinessunit', op }] }];
+    const r = lintAppSpec(s);
+    assert.strictEqual(r.ok, true, `${op} must not require a value: ${JSON.stringify(r.errors)}`);
+  }
+});
+
+// The complement: an operator that DOES take a value must still be caught when the value is
+// omitted, or widening the set above would have turned the check into a rubber stamp.
+test('#546 view filters: a value-taking operator with no value is still an error', () => {
+  const s = base();
+  s.views = [{ entity: 'new_ticket', name: 'Mine', columns: ['new_name'], filters: [{ attr: 'new_priority', op: 'eq' }] }];
+  const r = lintAppSpec(s);
+  assert.strictEqual(r.ok, false);
+  assert.ok(r.errors.some((e) => /needs a value/.test(e)), JSON.stringify(r.errors));
+});
+
 test('a view named like the stock default ("Active <Plural>") WARNS about the merge-onto-default collision', () => {
   const s = base();
   s.views = [{ entity: 'new_ticket', name: 'Active Tickets', columns: ['new_name', 'new_priority'], activeOnly: true }];

--- a/plugins/model-apps/skills/app-builder/SKILL.md
+++ b/plugins/model-apps/skills/app-builder/SKILL.md
@@ -202,10 +202,11 @@ every prompt yourself via `AskUserQuestion`. In short:
      right" (see the CRITICAL note above).** The user must be able to SEE each form, the sitemap, and
      the page intents they are approving. For a single form only: `node "${PLUGIN_ROOT}/scripts/preview-form.js" --spec @<working-dir>/app-spec.json`.
    - **Don't pre-create tables/columns** — the build does it idempotently.
-5. **Guardrail lint (hard gate)** — run the **full** `spec-lint.js` on the complete spec; **errors block**, warnings teach. If it blocks (or warns), **paste the findings into your chat reply** — tool output is collapsed and invisible to the user (see the CRITICAL note above), so the user can't fix what they can't see:
+5. **Guardrail lint (hard gate)** — run the **full** lint on the complete spec; **errors block**, warnings teach. If it blocks (or warns), **paste the findings into your chat reply** — tool output is collapsed and invisible to the user (see the CRITICAL note above), so the user can't fix what they can't see:
    ```bash
-   node -e "const{lintAppSpec}=require('${PLUGIN_ROOT}/scripts/lib/spec-lint.js');const s=require('<working-dir>/app-spec.json');const r=lintAppSpec(s);console.log(JSON.stringify(r,null,2));process.exit(r.ok?0:1)"
+   node "${PLUGIN_ROOT}/scripts/lint-app-spec.js" --spec @<working-dir>/app-spec.json --json
    ```
+   This runs the same three steps every deploying CLI runs on load — migrate → `validateAppSpec` → `lintAppSpec` — so a clean result means the same thing the build's dry run means by it. It exits non-zero on errors. It validates under the `plan` profile (which allows not-yet-generated intent pages), matching Step 6's dry run.
 6. **Plan-mode approval (the single build approval)** — present the plan **including the build
    dry-run's phase-grouped plan** (run `build-model-app.js` without `--apply`, using the `plan`
    profile that allows intent pages) inside `EnterPlanMode`, then `ExitPlanMode` to get the user's

--- a/plugins/model-apps/skills/app-builder/SKILL.md
+++ b/plugins/model-apps/skills/app-builder/SKILL.md
@@ -206,7 +206,7 @@ every prompt yourself via `AskUserQuestion`. In short:
    ```bash
    node "${PLUGIN_ROOT}/scripts/lint-app-spec.js" --spec @<working-dir>/app-spec.json --json
    ```
-   This runs the same three steps every deploying CLI runs on load — migrate → `validateAppSpec` → `lintAppSpec` — so a clean result means the same thing the build's dry run means by it. It exits non-zero on errors. It validates under the `plan` profile (which allows not-yet-generated intent pages), matching Step 6's dry run.
+   This runs migration and `validateAppSpec` — the gates the build itself runs on load — plus the `lintAppSpec` authoring guardrails, which the builder does **not** run. It exits non-zero on errors. It validates under the `plan` profile (which allows not-yet-generated intent pages), matching Step 6's dry run.
 6. **Plan-mode approval (the single build approval)** — present the plan **including the build
    dry-run's phase-grouped plan** (run `build-model-app.js` without `--apply`, using the `plan`
    profile that allows intent pages) inside `EnterPlanMode`, then `ExitPlanMode` to get the user's

--- a/scripts/tests/validate-hooks-manifests.test.js
+++ b/scripts/tests/validate-hooks-manifests.test.js
@@ -1,0 +1,67 @@
+// Guards the guard. validate-hooks-manifests.js exists to stop a plugin shipping a hooks.json
+// key the host does not recognise, because the only symptom is a warning line in somebody
+// else's terminal at every session start — invisible in review, and caught by no other test.
+// The cases that matter most are therefore the ones asserting it does NOT stay silent.
+
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { checkManifest, findHookManifests, ALLOWED_TOP_LEVEL_KEYS } = require('../validate-hooks-manifests.js');
+
+test('a manifest with only "hooks" passes', () => {
+  assert.deepEqual(checkManifest({ hooks: {} }, 'x/hooks.json'), []);
+});
+
+test('a manifest with "hooks" and the recognised "description" passes', () => {
+  assert.deepEqual(checkManifest({ description: 'what these do', hooks: {} }, 'x/hooks.json'), []);
+});
+
+test('the "_comment" key that caused #555/#558 is rejected, and the message says where prose goes', () => {
+  const problems = checkManifest({ _comment: 'prose', hooks: {} }, 'plugins/p/hooks/hooks.json');
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /unknown top-level key "_comment"/);
+  assert.match(problems[0], /hooks\/README\.md/);
+  // The message must quote the host's own wording so a reader can connect it to the
+  // warning they actually saw in their terminal.
+  assert.match(problems[0], /unknown key "_comment" ignored/);
+});
+
+test('any other unrecognised key is rejected too (the rule is an allow-list, not a _comment blocklist)', () => {
+  for (const key of ['comment', '//', 'notes', 'x-docs', 'readme']) {
+    const problems = checkManifest({ [key]: 'prose', hooks: {} }, 'x/hooks.json');
+    assert.equal(problems.length, 1, `${key} should be rejected`);
+    assert.match(problems[0], new RegExp(`unknown top-level key "${key.replace(/[.*+?^${}()|[\]\\/]/g, '\\$&')}"`));
+  }
+});
+
+test('a manifest missing "hooks" is rejected', () => {
+  const problems = checkManifest({ description: 'only prose' }, 'x/hooks.json');
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /missing the required "hooks" key/);
+});
+
+test('a non-object manifest is rejected without throwing', () => {
+  for (const value of [null, [], 'string', 42]) {
+    const problems = checkManifest(value, 'x/hooks.json');
+    assert.equal(problems.length, 1, JSON.stringify(value));
+    assert.match(problems[0], /expected a JSON object/);
+  }
+});
+
+// The real repository must satisfy the rule. This is what actually fails a PR that
+// reintroduces the key, so it is asserted against the committed files rather than fixtures.
+test('every committed plugin hooks.json passes', () => {
+  const files = findHookManifests();
+  assert.ok(files.length >= 3, `expected to find plugin hooks manifests, found ${files.length}`);
+  for (const filePath of files) {
+    const manifest = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    const rel = path.relative(path.resolve(__dirname, '..', '..'), filePath);
+    assert.deepEqual(checkManifest(manifest, rel), [], rel);
+  }
+});
+
+test('the allow-list stays tight — widening it silently re-creates the bug', () => {
+  assert.deepEqual([...ALLOWED_TOP_LEVEL_KEYS].sort(), ['description', 'hooks']);
+});

--- a/scripts/validate-hooks-manifests.js
+++ b/scripts/validate-hooks-manifests.js
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+
+/**
+ * Validates that every plugin's `hooks/hooks.json` carries only keys the host's
+ * hook loader recognises.
+ *
+ * WHY: Claude Code validates `hooks.json` against a CLOSED schema and prints a
+ * warning for any key it does not know:
+ *
+ *     model-apps: hooks.json: unknown key "_comment" ignored
+ *
+ * That line appears at EVERY session start, for every user of the plugin, and
+ * reads as a plugin misconfiguration. The hooks themselves still work — the key
+ * really is ignored — so nothing fails, no test catches it, and the noise
+ * survives indefinitely. Two of the eight plugins shipped a `_comment` key
+ * holding documentation prose (model-apps, mobile-apps); see issues #555 / #558.
+ *
+ * The prose is worth keeping, so it moved to `plugins/<plugin>/hooks/README.md`,
+ * which has no schema at all. This check exists because a JSON file is exactly
+ * where the next contributor will reach for a comment: JSON has no comment
+ * syntax, `_comment` is the usual workaround, and the cost of getting it wrong
+ * is invisible in review and only shows up in somebody else's terminal.
+ *
+ * Allowed top-level keys:
+ *   - `hooks`       (required)   the event -> matcher -> command tree the loader reads.
+ *   - `description` (optional)   a recognised, ignored-by-design documentation field.
+ * Anything else fails, naming the file, the key, and where the prose should go.
+ *
+ * Scope: repo-wide over `plugins/<plugin>/hooks/hooks.json`. Unlike the
+ * model-apps-scoped environment scan, there is no pre-existing violation
+ * elsewhere to grandfather — canvas-apps already uses `description` and
+ * power-pages ships `hooks` alone — so every plugin can be held to this today.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+const PLUGINS_DIR = path.join(ROOT, 'plugins');
+
+// `hooks` is what the loader actually executes; `description` is a documented,
+// deliberately-ignored field several plugin ecosystems accept. Keep this list
+// tight: the whole point is that an unrecognised key is a user-visible warning,
+// so widening it without checking the host's schema re-creates the bug.
+const ALLOWED_TOP_LEVEL_KEYS = new Set(['hooks', 'description']);
+
+function toPosix(relativePath) {
+  return relativePath.replace(/\\/g, '/');
+}
+
+// Returns the list of problems with ONE parsed manifest. Pure and exported so the
+// test can exercise the rule without writing files to disk.
+function checkManifest(manifest, relPath) {
+  const problems = [];
+
+  if (!manifest || typeof manifest !== 'object' || Array.isArray(manifest)) {
+    problems.push(`${relPath}: expected a JSON object at the top level`);
+    return problems;
+  }
+
+  for (const key of Object.keys(manifest)) {
+    if (ALLOWED_TOP_LEVEL_KEYS.has(key)) continue;
+    problems.push(
+      `${relPath}: unknown top-level key "${key}". The host prints ` +
+        `'hooks.json: unknown key "${key}" ignored' at every session start. ` +
+        `Move prose to plugins/<plugin>/hooks/README.md.`
+    );
+  }
+
+  if (!Object.prototype.hasOwnProperty.call(manifest, 'hooks')) {
+    problems.push(`${relPath}: missing the required "hooks" key`);
+  }
+
+  return problems;
+}
+
+// Probe the canonical path per plugin rather than walking the tree: a hooks
+// manifest is only loaded from plugins/<plugin>/hooks/hooks.json, so a file of
+// that name anywhere else is not a manifest and must not be held to this schema.
+function findHookManifests() {
+  if (!fs.existsSync(PLUGINS_DIR)) return [];
+  return fs
+    .readdirSync(PLUGINS_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => path.join(PLUGINS_DIR, entry.name, 'hooks', 'hooks.json'))
+    .filter((filePath) => fs.existsSync(filePath));
+}
+
+function main() {
+  const errors = [];
+  const files = findHookManifests();
+
+  for (const filePath of files) {
+    const relPath = toPosix(path.relative(ROOT, filePath));
+    let manifest;
+    try {
+      manifest = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    } catch (err) {
+      // A manifest that does not parse cannot load any hook at all, so this is a
+      // shippable defect in its own right — fail rather than skip.
+      errors.push(`${relPath}: could not parse JSON (${err.message})`);
+      continue;
+    }
+    errors.push(...checkManifest(manifest, relPath));
+  }
+
+  if (errors.length > 0) {
+    console.log('Plugin hooks.json validation failed:');
+    for (const error of errors) console.log(`- ${error}`);
+    console.log(
+      `\nAllowed top-level keys: ${[...ALLOWED_TOP_LEVEL_KEYS].join(', ')}. ` +
+        'JSON has no comment syntax — document the hooks in hooks/README.md instead.'
+    );
+    process.exit(1);
+  }
+
+  console.log(`All ${files.length} plugin hooks.json manifest(s) use only recognised top-level keys.`);
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { checkManifest, findHookManifests, ALLOWED_TOP_LEVEL_KEYS };


### PR DESCRIPTION
Closes four open issues an author hits **before ever reaching an environment**, plus the startup warning every user of two plugins sees.

Fixes #542 · Fixes #545 · Fixes #546 · Fixes #555 · Fixes #558 · Fixes #560

## What was wrong

### #545 — hand-authored page keys were silently overwritten
`migrateAppSpec` mints a stable `key` per page by slugifying the page `name`, and it ran whenever the **top-level** `schemaVersion` was < 2. A real spec declared `schemaVersion: 2` on each **page**, carried hand-authored keys, and referenced pages **by key** (`navigatesTo[].targetKey`, `appShell` subareas) — but omitted the top-level field. Migration therefore ran and overwrote every authored key with a name-slug. Pass 2 only rewrites refs that match a page *name*, so every key-based ref was left dangling and validation emitted one `not a known page key` / `unknown page` error per page — **none of which named the cause**. Adding the top-level field "fixed" it only by making migration a no-op.

Reproduced before fixing; the authored keys `orders` / `order-card` came back as `all-open-orders` / `order-details-view` while the refs stayed put.

**Fix:** a new pass 0 reserves every authored key, and pass 1 mints only for keyless pages (so a minted slug cannot steal a key a later page authored). A malformed authored key is preserved deliberately, so `validateAppSpec` names it instead of this pass silently replacing it.

### #546 — `eq-businessid` / `ne-businessid` rejected
Both are value-less FetchXML operators — the business-unit equivalents of `eq-userid` / `ne-userid` — so the lint demanded a `value` they must not carry. `NO_VALUE_OPS` is now the documented value-less set (also adding `eq-userlanguage`, the user-hierarchy operators, and the relative fiscal-period ones), checked against the Learn operator reference.

### #555 / #558 — `unknown key "_comment" ignored` at every session start
`model-apps` and `mobile-apps` each shipped a `_comment` documentation key in `hooks/hooks.json`. The host validates that file against a **closed** schema, so it printed a warning on **every launch** — harmless, but it reads as a plugin misconfiguration. The prose moved to `hooks/README.md`, and a new repo-wide `scripts/validate-hooks-manifests.js` fails any manifest with an unrecognised top-level key (allow-list: `hooks`, `description`).

This guard matters more than the one-line deletion: the symptom fails no test and no build, so nothing else in CI or review can catch it. JSON has no comment syntax, and `_comment` is exactly what the next contributor will reach for.


### #542 — a comment inside a JSX opening tag made a valid page look truncated
`source-literals.js` tracks JSX properly rather than running regexes over the raw file, but `jsxTag` mode had **no comment handling at all**. A `//` or `/* */` comment between attributes is valid TSX and a natural thing for a generator to emit when explaining an attribute; an apostrophe in the prose (`// wins over Griffel's atomic output`) was therefore read as an attribute-value quote. That scanner deliberately does not stop at a newline — a JSX attribute value may legitimately span lines — so it ran to **end of file**, blanking the real `export default` and miscounting every bracket after it. `promote-intent-pages` then rejected a complete page as truncated, and because promotion is **transactional**, one such page blocked the whole batch.

This is the false-positive direction the file's own header calls the worse of the two.

Reproduced first. The fix also covers **block** comments, which fail identically and which the report did not mention. I probed the opposite direction too — a URL inside an attribute value is still consumed as a string (the comment branches never see it), JSX text is untouched, a multi-line attribute value is not truncated, and a degenerate unterminated block comment does not crash.
### #560 — no CLI for the two gates
`validateAppSpec` and `lintAppSpec` were library exports with no entry point, so a headless author or CI job had to call them through `node -e` — which is what the docs recommended, and which linted the file **as written** rather than the migrated shape (the very trap in #545). New `scripts/lint-app-spec.js` runs migrate → validate → lint, tags findings `schema:` / `lint:`, and exits non-zero on errors. `--strict` also fails on warnings; `--json` emits the report.

## Review changed this PR

An adversarial review caught a **High-severity defect I introduced**: `lint-app-spec.js` hardcoded the **deploy** validation profile, but the documented gates run it while pages are still `intent` and jobs still lack privileges. Measured — a normal work-in-progress spec failed with `page 'ov': must be implemented ... for a deploy build`, exit 1. My doc change would have broken the authoring flow at both gates. `--profile` now defaults to `plan` (what the builder's own dry run uses); `--profile deploy` gates a final spec.

Three further findings, all verified and fixed:
- Once authored keys survive, a key that equals a **different page's name** was silently retargeted by the pass-2 rewrite — and still validated, because the substitute is itself a valid key. An exact key match now wins.
- `validateAppSpec`'s own warnings were dropped, making the CLI quieter than the build it stands in for.
- `--strict --json` emitted `ok: true` next to exit 1.

One reported category was checked and confirmed clean (no added operator takes a value).

## Verification

| | |
|---|---|
| model-apps suite | **2277 / 2277** |
| mobile-apps suite | **246 pass, 1 pre-existing skip, 0 fail** |
| model-apps evals | **159 / 159** |
| repo validator tests | **71 / 71** |
| repo validators (8) | **all exit 0** |

Both new guards were **mutation-tested**, not just asserted:
- disabling the key-reservation pass fails exactly the one test that covers it; restoring it passes
- disabling the key-precedence rewrite fails exactly its test
- re-adding `_comment` makes the new validator exit 1 with a precise message; removing it exits 0

Not live-tested against a Dataverse environment — every change is in pure spec-processing, linting, docs, or a CI guard, and none of it issues a platform call.

`model-apps` 2.7.1 · `mobile-apps` 0.3.2.

